### PR TITLE
Print errors to stderr, don't crash the app

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -47,5 +47,10 @@ void processFile(File file, {String label, bool overwrite, int pageWidth}) {
     }
   } on FormatterException catch (err, stack) {
     stderr.writeln("Failed $label:\n$err");
+  } catch (err, stack) {
+    stderr.writeln('''Hit a bug in the formatter when formatting $label
+  Please report at: github.com/dart-lang/dart_style/issues
+$err
+$stack''');
   }
 }


### PR DESCRIPTION
- print out the guilty file, which is useful
- continue to format other files if possible
- suggest where to report the issue
