### PR TITLE
Replace use of deprecated API

### DIFF
--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -603,7 +603,7 @@ class SourceVisitor implements AstVisitor {
 
     token(node.rightParenthesis);
     space();
-    visit(node.libraryUri);
+    visit(node.uri);
   }
 
   visitConstructorDeclaration(ConstructorDeclaration node) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/dart-lang/dart_style
 environment:
   sdk: ">=1.8.0 <2.0.0"
 dependencies:
-  analyzer: '>=0.27.4 <0.30.0'
+  analyzer: '^0.29.0'
   args: '>=0.12.1 <0.14.0'
   path: '>=1.0.0 <2.0.0'
   source_span: '>=1.1.1 <2.0.0'


### PR DESCRIPTION
We plan on removing deprecated APIs as part of the next breaking change of analyzer, and dart_style is using one of those APIs. This PR proactively replaces the use of the API. (In other words, this isn't urgent.) Unfortunately, this requires narrowing the version constraints on analyzer.

I'm not sure how to handle the pubspec.lock file in a situation like this. Guidance welcome.

Also, there is a strong-mode error being reported. I'd be happy to fix it, either as part of this PR or separately. Let me know if you'd like me to do that.