### PR TITLE
Add tests for new language features:

### DIFF
--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -102,6 +102,12 @@ class DartFormatter {
 
     // Parse it.
     var parser = new Parser(stringSource, errorListener);
+    try {
+      parser.enableAssertInitializer = true;
+    } on NoSuchMethodError {
+      // If using a version of analyzer that doesn't have the flag, just ignore
+      // it.
+    }
 
     AstNode node;
     if (source.isCompilationUnit) {

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -167,20 +167,15 @@ class SourceVisitor implements AstVisitor {
     builder.endSpan();
   }
 
-  // TODO(rnystrom): Type annotate once analyzer publishes a version with the
-  // new AST type.
-  // TODO(rnystrom): Test.
-  visitAssertInitializer(node) {
-    _simpleStatement(node, () {
-      token(node.assertKeyword);
+  visitAssertInitializer(AssertInitializer node) {
+    token(node.assertKeyword);
 
-      var arguments = <Expression>[node.condition];
-      if (node.message != null) arguments.add(node.message);
+    var arguments = <Expression>[node.condition];
+    if (node.message != null) arguments.add(node.message);
 
-      var visitor = new ArgumentListVisitor.forArguments(
-          this, node.leftParenthesis, node.rightParenthesis, arguments);
-      visitor.visit();
-    });
+    var visitor = new ArgumentListVisitor.forArguments(
+        this, node.leftParenthesis, node.rightParenthesis, arguments);
+    visitor.visit();
   }
 
   visitAssertStatement(AssertStatement node) {

--- a/test/splitting/constructors.unit
+++ b/test/splitting/constructors.unit
@@ -82,3 +82,14 @@ class Foo {
       : initializer =
             function(argument, arg);
 }
+>>> long assert parameter list
+class Foo {
+  Foo():assert(someLongIdentifier > anotherLongIdentifier), a = b;
+}
+<<<
+class Foo {
+  Foo()
+      : assert(someLongIdentifier >
+            anotherLongIdentifier),
+        a = b;
+}

--- a/test/whitespace/constructors.unit
+++ b/test/whitespace/constructors.unit
@@ -69,3 +69,22 @@ class Foo {
 class Foo {
   Foo(this.bar(), baz);
 }
+>>> single short assert
+class Foo {
+  Foo():assert (  1,2);
+}
+<<<
+class Foo {
+  Foo() : assert(1, 2);
+}
+>>> multiple asserts
+class Foo {
+  Foo():assert (  1,2),assert(    true
+  )  ;
+}
+<<<
+class Foo {
+  Foo()
+      : assert(1, 2),
+        assert(true);
+}

--- a/test/whitespace/functions.unit
+++ b/test/whitespace/functions.unit
@@ -21,6 +21,10 @@ int a(var x, {optional: null}) => null;
 int a(var x, [optional = null]) => null;
 <<<
 int a(var x, [optional = null]) => null;
+>>> named parameters with "="
+int a({b=null, c   =   null}) => null;
+<<<
+int a({b = null, c = null}) => null;
 >>> async
 main()
     async  {


### PR DESCRIPTION
- "=" as separate for named optional parameters. This was conveniently
  already doing the right thing.
- Asserts in constructor initializers. This was broken. :( Fixed it.

This patch works, but the tests don't pass unless you use an unreleased
version of analyzer. So, for now this won't be merged in until after
that's released and I upgrade the pubspec in this branch.