### PR TITLE
Update tests to use correct Windows file paths

### DIFF
--- a/test/formatter_test.dart
+++ b/test/formatter_test.dart
@@ -137,7 +137,7 @@ void testDirectory(String name) {
   var testDir = p.dirname(currentMirrorSystem()
       .findLibrary(#dart_style.test.formatter_test)
       .uri
-      .path);
+      .toFilePath());
 
   var entries = new Directory(p.join(testDir, name))
       .listSync(recursive: true, followLinks: false);

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -22,7 +22,7 @@ ScheduledProcess runFormatter([List<String> args]) {
   // Locate the "test" directory. Use mirrors so that this works with the test
   // package, which loads this suite into an isolate.
   var testDir = p.dirname(
-      currentMirrorSystem().findLibrary(#dart_style.test.utils).uri.path);
+      currentMirrorSystem().findLibrary(#dart_style.test.utils).uri.toFilePath());
 
   var formatterPath = p.normalize(p.join(testDir, "../bin/format.dart"));
 


### PR DESCRIPTION
Uri.toFilePath() rather than Uri.path should be used.