### PR TITLE
Don't drop type argument on method calls with closure arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.16
+
+* Don't discard type arguments on method calls with closure arguments (#582).
+
 # 0.2.15
 
 * Support `covariant` modifier on methods.

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -14,7 +14,7 @@ import 'package:dart_style/src/io.dart';
 import 'package:dart_style/src/source_code.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const version = "0.2.15";
+const version = "0.2.16";
 
 void main(List<String> args) {
   var parser = new ArgParser(allowTrailingOptions: true);

--- a/example/format.dart
+++ b/example/format.dart
@@ -20,9 +20,15 @@ void main(List<String> args) {
   debug.traceSplitter = true;
   debug.useAnsiColors = true;
 
-  runTest("regression/0000/0068.stmt", 14);
-
-  formatStmt("hello(world);");
+  formatUnit("""
+void fn() {
+  List<String> a;
+  // NOTICE THE TYPE PARAMETER
+  a.fold<int>(0, (memo, s) {
+    return max(memo, s.length);
+  });
+}
+""");
 }
 
 void formatStmt(String source, [int pageWidth = 80]) {

--- a/example/format.dart
+++ b/example/format.dart
@@ -20,15 +20,9 @@ void main(List<String> args) {
   debug.traceSplitter = true;
   debug.useAnsiColors = true;
 
-  formatUnit("""
-void fn() {
-  List<String> a;
-  // NOTICE THE TYPE PARAMETER
-  a.fold<int>(0, (memo, s) {
-    return max(memo, s.length);
-  });
-}
-""");
+  runTest("regression/0000/0068.stmt", 14);
+
+  formatStmt("hello(world);");
 }
 
 void formatStmt(String source, [int pageWidth = 80]) {

--- a/lib/src/call_chain_visitor.dart
+++ b/lib/src/call_chain_visitor.dart
@@ -410,6 +410,7 @@ class CallChainVisitor {
   void _writeBlockCall(MethodInvocation invocation) {
     _visitor.token(invocation.operator);
     _visitor.token(invocation.methodName.token);
+    _visitor.visit(invocation.typeArguments);
     _visitor.visit(invocation.argumentList);
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,7 +6,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.29.5"
+    version: "0.29.6"
   ansicolor:
     description:
       name: ansicolor
@@ -24,7 +24,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.3"
+    version: "1.12.0"
   barback:
     description:
       name: barback
@@ -49,6 +49,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
+  cli_util:
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+2"
   collection:
     description:
       name: collection
@@ -72,7 +78,7 @@ packages:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.2+2"
+    version: "0.13.3+1"
   glob:
     description:
       name: glob
@@ -252,7 +258,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.6.1"
   string_scanner:
     description:
       name: string_scanner
@@ -301,6 +307,18 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  when:
+    description:
+      name: when
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
+  which:
+    description:
+      name: which
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   yaml:
     description:
       name: yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 0.2.15
+version: 0.2.16
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style

--- a/test/regression/0500/0582.unit
+++ b/test/regression/0500/0582.unit
@@ -1,0 +1,16 @@
+>>>
+void fn() {
+  List<String> a;
+  // NOTICE THE TYPE PARAMETER
+  a.fold<int>(0, (memo, s) {
+    return max(memo, s.length);
+  });
+}
+<<<
+void fn() {
+  List<String> a;
+  // NOTICE THE TYPE PARAMETER
+  a.fold<int>(0, (memo, s) {
+    return max(memo, s.length);
+  });
+}


### PR DESCRIPTION
Fix #582.