### PR TITLE
Fix splitting in generic methods with "=>" body.

### DIFF
--- a/lib/src/chunk_builder.dart
+++ b/lib/src/chunk_builder.dart
@@ -137,7 +137,7 @@ class ChunkBuilder {
     _emitPendingWhitespace();
     _writeText(string);
 
-    _lazyRules.forEach(startRule);
+    _lazyRules.forEach(_activateRule);
     _lazyRules.clear();
 
     _nesting.commitNesting();
@@ -360,6 +360,15 @@ class ChunkBuilder {
   void startRule([Rule rule]) {
     if (rule == null) rule = new Rule();
 
+    // If there are any pending lazy rules, start them now so that the proper
+    // stack ordering of rules is maintained.
+    _lazyRules.forEach(_activateRule);
+    _lazyRules.clear();
+
+    _activateRule(rule);
+  }
+
+  void _activateRule(Rule rule) {
     // See if any of the rules that contain this one care if it splits.
     _rules.forEach((outer) {
       if (!outer.splitsOnInnerRules) return;

--- a/lib/src/rule/type_argument.dart
+++ b/lib/src/rule/type_argument.dart
@@ -14,13 +14,6 @@ import 'rule.dart';
 ///
 /// The values for a rule for `n` arguments are:
 ///
-/// 3 args
-/// 0 : no
-/// 1 : before arg 2
-/// 2: before arg 1
-/// 3: before arg 0
-/// 4: all
-///
 /// * `0`: No splits at all.
 /// * `1 ... n`: Split before one argument, starting from the last.
 /// * `n + 1`: Split before all arguments.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,7 +6,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.29.6"
+    version: "0.29.8"
   ansicolor:
     description:
       name: ansicolor
@@ -24,7 +24,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.12.0"
+    version: "1.13.2"
   barback:
     description:
       name: barback
@@ -78,7 +78,7 @@ packages:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3+1"
+    version: "0.13.4"
   glob:
     description:
       name: glob
@@ -102,7 +102,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+9"
+    version: "0.11.3+12"
   http_multi_server:
     description:
       name: http_multi_server
@@ -120,7 +120,7 @@ packages:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.0"
   js:
     description:
       name: js
@@ -162,7 +162,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   package_config:
     description:
       name: package_config
@@ -192,7 +192,7 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.4"
+    version: "1.3.0"
   pub_semver:
     description:
       name: pub_semver
@@ -204,7 +204,7 @@ packages:
       name: scheduled_test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.9"
+    version: "0.12.11"
   shelf:
     description:
       name: shelf
@@ -240,7 +240,7 @@ packages:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.2"
+    version: "0.10.3"
   source_span:
     description:
       name: source_span
@@ -252,7 +252,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.7.3"
   stream_channel:
     description:
       name: stream_channel
@@ -271,12 +271,18 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.1"
+  term_glyph:
+    description:
+      name: term_glyph
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   test:
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.18+1"
+    version: "0.12.20+3"
   typed_data:
     description:
       name: typed_data
@@ -326,4 +332,4 @@ packages:
     source: hosted
     version: "2.1.12"
 sdks:
-  dart: ">=1.21.0-dev.2.0 <2.0.0"
+  dart: ">=1.23.0-dev.0.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 0.2.16
+version: 0.2.17-dev
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style

--- a/test/regression/0500/0584.unit
+++ b/test/regression/0500/0584.unit
@@ -1,0 +1,6 @@
+>>>
+bool
+    listEquals<T>(List<T> a, List<T> b) => const ListEquality<T>().equals(a, b);
+<<<
+bool listEquals<T>(List<T> a, List<T> b) =>
+    const ListEquality<T>().equals(a, b);

--- a/test/splitting/generic_method_parameters.unit
+++ b/test/splitting/generic_method_parameters.unit
@@ -52,15 +52,13 @@ lengthyMethodName<
 >>> type parameters and => body
 longFunctionName<LongTypeParameterT, LongTypeParameterS>() => body;
 <<<
-longFunctionName<
-        LongTypeParameterT,
+longFunctionName<LongTypeParameterT,
         LongTypeParameterS>() =>
     body;
 >>> type parameters, value parameters, and => body
 longFunctionName<LongTypeParameterT, LongTypeParameterS>(longParameter1, longParameter2) => body;
 <<<
-longFunctionName<
-            LongTypeParameterT,
+longFunctionName<LongTypeParameterT,
             LongTypeParameterS>(
         longParameter1,
         longParameter2) =>


### PR DESCRIPTION
Fix #584.