### PR TITLE
Don't split after '<' when a collection is in statement position.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.17
+
+* Fix splitting in generic methods with `=>` bodies (#584).
+* Don't split after `<` when a collection is in statement position (#589).
+
 # 0.2.16
 
 * Don't discard type arguments on method calls with closure arguments (#582).

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1834,7 +1834,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   void _visitGenericList(
       Token leftBracket, Token rightBracket, List<AstNode> nodes) {
     var rule = new TypeArgumentRule();
-    builder.startRule(rule);
+    builder.startLazyRule(rule);
     builder.startSpan();
     builder.nestExpression();
 

--- a/test/regression/0500/0543.unit
+++ b/test/regression/0500/0543.unit
@@ -1,0 +1,19 @@
+>>> (indent 6)
+      main() {
+        HInstruction result = new HInvokeDynamicMethod(
+            selector,
+            input.instructionType, // receiver mask.
+            <
+                HInstruction>[input, input], // [interceptor, receiver].
+            toStringType)..sourceInformation = node.sourceInformation;
+        return result;
+      }
+<<<
+      main() {
+        HInstruction result = new HInvokeDynamicMethod(
+            selector,
+            input.instructionType, // receiver mask.
+            <HInstruction>[input, input], // [interceptor, receiver].
+            toStringType)..sourceInformation = node.sourceInformation;
+        return result;
+      }

--- a/test/regression/0500/0589.unit
+++ b/test/regression/0500/0589.unit
@@ -1,0 +1,29 @@
+>>>
+List<dynamic> _generateUsedComponentReferences(
+    Globals globals, FormComponent component) {
+  return component.children == null
+      ? <dynamic>[]
+      : component.children.map<List<dynamic>>((c) {
+          final globalComponent = globals.components.firstWhere(
+              (c) => c.id == component.component.componentId,
+              orElse: () => null);
+          <
+              dynamic>[
+            reference(globalComponent.className, globalComponent.importPath)
+          ]..addAll(_generateUsedComponentReferences(globals, c));
+        }).toList();
+}
+<<<
+List<dynamic> _generateUsedComponentReferences(
+    Globals globals, FormComponent component) {
+  return component.children == null
+      ? <dynamic>[]
+      : component.children.map<List<dynamic>>((c) {
+          final globalComponent = globals.components.firstWhere(
+              (c) => c.id == component.component.componentId,
+              orElse: () => null);
+          <dynamic>[
+            reference(globalComponent.className, globalComponent.importPath)
+          ]..addAll(_generateUsedComponentReferences(globals, c));
+        }).toList();
+}

--- a/test/splitting/type_arguments.stmt
+++ b/test/splitting/type_arguments.stmt
@@ -56,3 +56,13 @@ new SomeClass<
     sixth,
     seventh,
     eighth);
+>>> newline before typed collection should not force <> to split
+{
+  <int>[];
+  <int>[];
+}
+<<<
+{
+  <int>[];
+  <int>[];
+}


### PR DESCRIPTION
Fix #589.