### PR TITLE
Preserve a blank line between an annotation and the first directive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Handle mixed block and arrow bodied function arguments uniformly (#500).
 * Handle parenthesized and immediately invoked functions in argument lists
   like other function literals (#566).
+* Preserve a blank line between an annotation and the first directive (#571).
 * Fix splitting in generic methods with `=>` bodies (#584).
 * Don't split after `<` when a collection is in statement position (#589).
 

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -792,8 +792,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   visitExportDirective(ExportDirective node) {
-    visitMetadata(node.metadata);
-
+    _visitDirectiveMetadata(node);
     _simpleStatement(node, () {
       token(node.keyword);
       space();
@@ -1178,8 +1177,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   visitImportDirective(ImportDirective node) {
-    visitMetadata(node.metadata);
-
+    _visitDirectiveMetadata(node);
     _simpleStatement(node, () {
       token(node.keyword);
       space();
@@ -1293,8 +1291,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   visitLibraryDirective(LibraryDirective node) {
-    visitMetadata(node.metadata);
-
+    _visitDirectiveMetadata(node);
     _simpleStatement(node, () {
       token(node.keyword);
       space();
@@ -1402,8 +1399,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   visitPartDirective(PartDirective node) {
-    visitMetadata(node.metadata);
-
+    _visitDirectiveMetadata(node);
     _simpleStatement(node, () {
       token(node.keyword);
       space();
@@ -1412,8 +1408,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   visitPartOfDirective(PartOfDirective node) {
-    visitMetadata(node.metadata);
-
+    _visitDirectiveMetadata(node);
     _simpleStatement(node, () {
       token(node.keyword);
       space();
@@ -1740,11 +1735,24 @@ class SourceVisitor extends ThrowingAstVisitor {
     if (after != null) after();
   }
 
-  /// Visit metadata annotations on directives, declarations, and members.
+  /// Visit metadata annotations on declarations, and members.
   ///
   /// These always force the annotations to be on the previous line.
   void visitMetadata(NodeList<Annotation> metadata) {
     visitNodes(metadata, between: newline, after: newline);
+  }
+
+
+  /// Visit metadata annotations for a directive.
+  ///
+  /// Always force the annotations to be on a previous line.
+  void _visitDirectiveMetadata(Directive directive) {
+    // Preserve a blank line before the first directive since users (in
+    // particular the test package) sometimes use that for metadata that
+    // applies to the entire library and not the following directive itself.
+    var isFirst = directive == (directive.parent as CompilationUnit).directives.first;
+
+    visitNodes(directive.metadata, between: newline, after: isFirst ? oneOrTwoNewlines : newline);
   }
 
   /// Visits metadata annotations on parameters and type parameters.

--- a/test/regression/0500/0571.unit
+++ b/test/regression/0500/0571.unit
@@ -1,0 +1,8 @@
+>>>
+@Timeout(const Duration(minutes: 1))
+
+import "package:test/test.dart";
+<<<
+@Timeout(const Duration(minutes: 1))
+
+import "package:test/test.dart";

--- a/test/whitespace/metadata.unit
+++ b/test/whitespace/metadata.unit
@@ -24,6 +24,21 @@ part "part.dart";
 <<<
 @foo
 part of bar;
+>>> preserve a blank line before the first directive
+@foo
+
+import 'foo.dart';
+
+@bar
+
+import 'bar.dart';
+<<<
+@foo
+
+import 'foo.dart';
+
+@bar
+import 'bar.dart';
 >>> force newline before types
 @meta class X {}
 


### PR DESCRIPTION
Fix #571.