### PR TITLE
Force a split if the cascade target has non-obvious precedence.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   like other function literals (#566).
 * Fix splitting in generic methods with `=>` bodies (#584).
 * Don't split after `<` when a collection is in statement position (#589).
+* Force a split if the cascade target has non-obvious precedence (#590).
 
 # 0.2.16
 

--- a/test/whitespace/cascades.stmt
+++ b/test/whitespace/cascades.stmt
@@ -34,3 +34,63 @@ foo
   ..toString(() {
     body;
   });
+>>> force split if receiver an expression where the precedence isn't obvious
+main() async {
+  // These are OK.
+  a = b..c();
+  a += b..c();
+  a.b..c();
+
+  // These are unclear.
+  a ? b : c..d();
+  a ?? b..c();
+  a && b..c();
+  a || b..c();
+  a == b..c();
+  a <= b..c();
+  a + b..c();
+  a / b..c();
+  a ^ b..c();
+  a << b..c();
+  -a..b();
+  !a..b();
+  --a..b();
+  await a..b();
+}
+<<<
+main() async {
+  // These are OK.
+  a = b..c();
+  a += b..c();
+  a.b..c();
+
+  // These are unclear.
+  a ? b : c
+    ..d();
+  a ?? b
+    ..c();
+  a && b
+    ..c();
+  a || b
+    ..c();
+  a == b
+    ..c();
+  a <= b
+    ..c();
+  a + b
+    ..c();
+  a / b
+    ..c();
+  a ^ b
+    ..c();
+  a << b
+    ..c();
+  -a
+    ..b();
+  !a
+    ..b();
+  --a
+    ..b();
+  await a
+    ..b();
+}


### PR DESCRIPTION
Fix #590.