### PR TITLE
Split the cascade (usually) if the cascade target contains a split.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Allow splitting between a parameter name and type (#585).
 * Don't split after `<` when a collection is in statement position (#589).
 * Force a split if the cascade target has non-obvious precedence (#590).
+* Split more often if a cascade target contains a split (#591).
 
 # 0.2.16
 

--- a/test/regression/0500/0543.unit
+++ b/test/regression/0500/0543.unit
@@ -14,6 +14,7 @@
             selector,
             input.instructionType, // receiver mask.
             <HInstruction>[input, input], // [interceptor, receiver].
-            toStringType)..sourceInformation = node.sourceInformation;
+            toStringType)
+          ..sourceInformation = node.sourceInformation;
         return result;
       }

--- a/test/regression/0500/0591.unit
+++ b/test/regression/0500/0591.unit
@@ -1,0 +1,111 @@
+>>>
+void fn81() {
+  // The number of characters in the `four` line is ...........................81
+  var list = (one.two().three()
+    ..four('_15___20___25___30___35___40___45___50___55___60___65___70___75___'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}
+<<<
+void fn81() {
+  // The number of characters in the `four` line is ...........................81
+  var list = (one.two().three()
+    ..four(
+        '_15___20___25___30___35___40___45___50___55___60___65___70___75___'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}
+>>>
+void fn80() {
+  // The number of characters in the `four` line is ..........................80
+  var list = (one.two().three()
+    ..four('_15___20___25___30___35___40___45___50___55___60___65___70___75__'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}
+<<<
+void fn80() {
+  // The number of characters in the `four` line is ..........................80
+  var list = (one
+      .two()
+      .three()
+        ..four(
+            '_15___20___25___30___35___40___45___50___55___60___65___70___75__'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}
+>>>
+void fn79() {
+  // The number of characters in the `four` line is .........................79
+  var list = (one.two().three()
+    ..four('_15___20___25___30___35___40___45___50___55___60___65___70___75_'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}
+<<<
+void fn79() {
+  // The number of characters in the `four` line is .........................79
+  var list = (one
+      .two()
+      .three()
+        ..four(
+            '_15___20___25___30___35___40___45___50___55___60___65___70___75_'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}
+>>>
+void fn78() {
+  // The number of characters in the `four` line is ........................78
+  var list = (one.two().three()
+    ..four('_15___20___25___30___35___40___45___50___55___60___65___70___75'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}
+<<<
+void fn78() {
+  // The number of characters in the `four` line is ........................78
+  var list = (one
+      .two()
+      .three()
+        ..four(
+            '_15___20___25___30___35___40___45___50___55___60___65___70___75'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}
+>>>
+void fn77() {
+  // The number of characters in the `four` line is .......................77
+  var list = (one.two().three()
+    ..four('_15___20___25___30___35___40___45___50___55___60___65___70___7'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}
+<<<
+void fn77() {
+  // The number of characters in the `four` line is .......................77
+  var list = (one
+      .two()
+      .three()
+        ..four(
+            '_15___20___25___30___35___40___45___50___55___60___65___70___7'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}
+>>>
+void fn76() {
+  // The number of characters in the `four` line is ......................76
+  var list = (one.two().three()
+    ..four('_15___20___25___30___35___40___45___50___55___60___65___70___'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}
+<<<
+void fn76() {
+  // The number of characters in the `four` line is ......................76
+  var list = (one
+      .two()
+      .three()
+        ..four('_15___20___25___30___35___40___45___50___55___60___65___70___'))
+    ..six('zzzzzzzzzzzzzzzzzzzzzzzzzzzz');
+  ;
+}

--- a/test/splitting/invocations.stmt
+++ b/test/splitting/invocations.stmt
@@ -138,14 +138,6 @@ object.method().method()..cascade()..cascade();
 object.method().method()
   ..cascade()
   ..cascade();
->>> unsplit cascade split method
-object.method().method().method().method()..cascade()..cascade();
-<<<
-object
-    .method()
-    .method()
-    .method()
-    .method()..cascade()..cascade();
 >>> split cascade split method
 object.method().method().method().method()..cascade()..cascade()..cascade();
 <<<

--- a/test/whitespace/cascades.stmt
+++ b/test/whitespace/cascades.stmt
@@ -94,3 +94,33 @@ main() async {
   await a
     ..b();
 }
+>>> omit split if single section on list literal
+[1,]..addAll(more);
+<<<
+[
+  1,
+]..addAll(more);
+>>> omit split if single section on map literal
+var map = {1:2,}..addAll(more);
+<<<
+var map = {
+  1: 2,
+}..addAll(more);
+>>> omit split if single section on trailing comma call
+foo(1,)..addAll(more);
+<<<
+foo(
+  1,
+)..addAll(more);
+>>> omit split if single section on trailing comma constructor
+new Foo(1,)..addAll(more);
+<<<
+new Foo(
+  1,
+)..addAll(more);
+>>> omit split if single section on trailing comma expression call
+(foo)(1,)..addAll(more);
+<<<
+(foo)(
+  1,
+)..addAll(more);


### PR DESCRIPTION
This makes cascades more similar to method calls and other syntax where
a split in a subexpression forces the outer expression to split. So,
instead of:

    method(argument,
        another)..cascade();

This produces:

    method(argument,
        another)
          ..cascade();

Fix #591.