### PR TITLE
Don't drop type arguments on generic function typed parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.3
+
+* Preserve type arguments in generic function-typed parameters (#613).
+
 # 1.0.2
 
 * Support new generic function typedef syntax (#563).

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -14,7 +14,7 @@ import 'package:dart_style/src/io.dart';
 import 'package:dart_style/src/source_code.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const version = "1.0.2";
+const version = "1.0.3";
 
 void main(List<String> args) {
   var parser = new ArgParser(allowTrailingOptions: true);

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1176,7 +1176,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       // Try to keep the function's parameters with its name.
       builder.startSpan();
       visit(node.identifier);
-      visit(node.parameters);
+      _visitParameterSignature(node.typeParameters, node.parameters);
       builder.endSpan();
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.0.2
+version: 1.0.3
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style

--- a/test/regression/0600/0613.unit
+++ b/test/regression/0600/0613.unit
@@ -1,0 +1,4 @@
+>>>
+void takeIdentityFunction(T id<T>(T x)) {}
+<<<
+void takeIdentityFunction(T id<T>(T x)) {}

--- a/test/splitting/generic_method_parameters.unit
+++ b/test/splitting/generic_method_parameters.unit
@@ -63,3 +63,15 @@ longFunctionName<LongTypeParameterT,
         longParameter1,
         longParameter2) =>
     body;
+>>> generic function typed parameter
+longFunctionName(String longParameterName<LongTypeParameter,
+AnotherTypeParam>(LongTypeParameter parameter, AnotherTypeParam another)) {;}
+<<<
+longFunctionName(
+    String longParameterName<
+            LongTypeParameter,
+            AnotherTypeParam>(
+        LongTypeParameter parameter,
+        AnotherTypeParam another)) {
+  ;
+}

--- a/test/whitespace/functions.unit
+++ b/test/whitespace/functions.unit
@@ -162,3 +162,7 @@ main() {
     ;
   });
 }
+>>> generic function typed parameter
+function(int   foo  <  T  ,S >(T t, S s)) {}
+<<<
+function(int foo<T, S>(T t, S s)) {}


### PR DESCRIPTION
Fix #613.