### PR TITLE
replace .toString() with .lexeme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.7-dev
+
+* Fix call to analyzer API
+
 # 1.0.6
 
 * Support URIs in part-of directives (#615).

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2652,7 +2652,7 @@ class SourceVisitor extends ThrowingAstVisitor {
         previousLine = commentLine;
       }
 
-      var text = comment.toString().trim();
+      var text = comment.lexeme.trim();
       var linesBefore = commentLine - previousLine;
       var flushLeft = _startColumn(comment) == 1;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.0.6
+version: 1.0.7-dev
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style


### PR DESCRIPTION
Minor fix. Something I bumped into while integrating the fasta scanner into analyzer.