### PR TITLE
Improve the handling of adjacent strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 1.0.7-dev
 
+* Only add newlines between adjacent strings if necessary. This makes it easier
+  to tell where adjacent strings can be combined into single strings.
+* If adjacent strings do split, ensure that they're vertically aligned (#133).
+* Always add a newline after adjacent strings that end in newlines; otherwise
+  indent the next string. This makes it easier to visually distinguish separate
+  lines from continued lines (#134).
 * Fix call to analyzer API
 
 # 1.0.6

--- a/lib/src/chunk_builder.dart
+++ b/lib/src/chunk_builder.dart
@@ -740,6 +740,14 @@ class ChunkBuilder {
       return null;
     }
 
+    // If a zero-width split follows a space, make it a space split instead.
+    // This ensures that we don't leave whitespace dangling where it isn't
+    // needed.
+    if (space != true && _pendingWhitespace == Whitespace.space) {
+      _pendingWhitespace = Whitespace.none;
+      space = true;
+    }
+
     _chunks.last.applySplit(rule, _nesting.indentation,
         nest ? _nesting.nesting : new NestingLevel(),
         flushLeft: flushLeft, isDouble: isDouble, space: space);

--- a/lib/src/formatter_options.dart
+++ b/lib/src/formatter_options.dart
@@ -120,8 +120,9 @@ class _OverwriteReporter extends _PrintReporter {
         file.writeAsStringSync(output.text);
         print("Formatted $label");
       } on FileSystemException catch (err) {
-        stderr.writeln("Could not overwrite $label: "
-            "${err.osError.message} (error code ${err.osError.errorCode})");
+        stderr.writeln(
+            "Could not overwrite $label: "
+                "${err.osError.message} (error code ${err.osError.errorCode})");
       }
     } else {
       print("Unchanged $label");

--- a/lib/src/nesting_builder.dart
+++ b/lib/src/nesting_builder.dart
@@ -80,11 +80,20 @@ class NestingBuilder {
   /// If omitted, [spaces] defaults to [Indent.block].
   void indent([int spaces]) {
     if (spaces == null) spaces = Indent.block;
+
+    // Indentation should only change outside of nesting.
+    assert(_pendingNesting == null);
+    assert(_nesting.indent == 0);
+
     _stack.add(_stack.last + spaces);
   }
 
   /// Discards the most recent indentation level.
   void unindent() {
+    // Indentation should only change outside of nesting.
+    assert(_pendingNesting == null);
+    assert(_nesting.indent == 0);
+
     // If this fails, an unindent() call did not have a preceding indent() call.
     assert(_stack.isNotEmpty);
 

--- a/lib/src/nesting_builder.dart
+++ b/lib/src/nesting_builder.dart
@@ -80,20 +80,11 @@ class NestingBuilder {
   /// If omitted, [spaces] defaults to [Indent.block].
   void indent([int spaces]) {
     if (spaces == null) spaces = Indent.block;
-
-    // Indentation should only change outside of nesting.
-    assert(_pendingNesting == null);
-    assert(_nesting.indent == 0);
-
     _stack.add(_stack.last + spaces);
   }
 
   /// Discards the most recent indentation level.
   void unindent() {
-    // Indentation should only change outside of nesting.
-    assert(_pendingNesting == null);
-    assert(_nesting.indent == 0);
-
     // If this fails, an unindent() call did not have a preceding indent() call.
     assert(_stack.isNotEmpty);
 

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -108,8 +108,13 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   visitAdjacentStrings(AdjacentStrings node) {
     builder.startSpan();
-    builder.startRule();
+    var rule = new Rule();
+    builder.startRule(rule);
+
+    var chunk = zeroSplit();
+    rule.imply(chunk.rule);
     visitNodes(node.strings, between: splitOrNewline);
+
     builder.endRule();
     builder.endSpan();
   }

--- a/test/formatter_test.dart
+++ b/test/formatter_test.dart
@@ -91,7 +91,8 @@ void main() {
     var formatter = new DartFormatter(indent: 3);
     expect(
         formatter.formatStatement('if (foo) {bar;}'),
-        equals('   if (foo) {\n'
+        equals(
+            '   if (foo) {\n'
             '     bar;\n'
             '   }'));
   });
@@ -123,10 +124,12 @@ void main() {
 
     test('handles Windows line endings in multiline strings', () {
       expect(
-          new DartFormatter(lineEnding: "\r\n").formatStatement('  """first\r\n'
+          new DartFormatter(lineEnding: "\r\n").formatStatement(
+              '  """first\r\n'
               'second\r\n'
               'third"""  ;'),
-          equals('"""first\r\n'
+          equals(
+              '"""first\r\n'
               'second\r\n'
               'third""";'));
     });
@@ -228,7 +231,8 @@ void testDirectory(String name) {
           // Fail with an explicit message because it's easier to read than
           // the matcher output.
           if (actualText != expected.text) {
-            fail("Formatting did not match expectation. Expected:\n"
+            fail(
+                "Formatting did not match expectation. Expected:\n"
                 "${expected.text}\nActual:\n$actualText");
           }
 

--- a/test/regression/0000/0021.stmt
+++ b/test/regression/0000/0021.stmt
@@ -7,9 +7,9 @@
 <<<
   verify(
       "Caractères qui doivent être échapper, par exemple barres \\ "
-        "dollars \${ (les accolades sont ok), et xml/html réservés <& et "
-        "des citations \" "
-        "avec quelques paramètres ainsi 1, 2, et 3");
+          "dollars \${ (les accolades sont ok), et xml/html réservés <& et "
+          "des citations \" "
+          "avec quelques paramètres ainsi 1, 2, et 3");
 >>> preserve newlines but not indent
 var map = {
   "nestedMessage" : "{combinedGender,select, "
@@ -32,18 +32,18 @@ var map = {
 var map = {
   "nestedMessage":
       "{combinedGender,select, "
-        "other{"
-        "{number,plural, "
-        "=0{Personne n'avait allé à la {place}}"
-        "=1{{names} était allé à la {place}}"
-        "other{{names} étaient allés à la {place}}"
-        "}"
-        "}"
-        "female{"
-        "{number,plural, "
-        "=1{{names} était allée à la {place}}"
-        "other{{names} étaient allées à la {place}}"
-        "}"
-        "}"
-        "}",
+          "other{"
+          "{number,plural, "
+          "=0{Personne n'avait allé à la {place}}"
+          "=1{{names} était allé à la {place}}"
+          "other{{names} étaient allés à la {place}}"
+          "}"
+          "}"
+          "female{"
+          "{number,plural, "
+          "=1{{names} était allée à la {place}}"
+          "other{{names} étaient allées à la {place}}"
+          "}"
+          "}"
+          "}",
 };

--- a/test/regression/0000/0021.stmt
+++ b/test/regression/0000/0021.stmt
@@ -5,7 +5,8 @@
       "des citations \" "
       "avec quelques paramètres ainsi 1, 2, et 3");
 <<<
-  verify("Caractères qui doivent être échapper, par exemple barres \\ "
+  verify(
+      "Caractères qui doivent être échapper, par exemple barres \\ "
       "dollars \${ (les accolades sont ok), et xml/html réservés <& et "
       "des citations \" "
       "avec quelques paramètres ainsi 1, 2, et 3");
@@ -29,7 +30,8 @@ var map = {
 };
 <<<
 var map = {
-  "nestedMessage": "{combinedGender,select, "
+  "nestedMessage":
+      "{combinedGender,select, "
       "other{"
       "{number,plural, "
       "=0{Personne n'avait allé à la {place}}"

--- a/test/regression/0000/0021.stmt
+++ b/test/regression/0000/0021.stmt
@@ -7,9 +7,9 @@
 <<<
   verify(
       "Caractères qui doivent être échapper, par exemple barres \\ "
-      "dollars \${ (les accolades sont ok), et xml/html réservés <& et "
-      "des citations \" "
-      "avec quelques paramètres ainsi 1, 2, et 3");
+        "dollars \${ (les accolades sont ok), et xml/html réservés <& et "
+        "des citations \" "
+        "avec quelques paramètres ainsi 1, 2, et 3");
 >>> preserve newlines but not indent
 var map = {
   "nestedMessage" : "{combinedGender,select, "
@@ -32,18 +32,18 @@ var map = {
 var map = {
   "nestedMessage":
       "{combinedGender,select, "
-      "other{"
-      "{number,plural, "
-      "=0{Personne n'avait allé à la {place}}"
-      "=1{{names} était allé à la {place}}"
-      "other{{names} étaient allés à la {place}}"
-      "}"
-      "}"
-      "female{"
-      "{number,plural, "
-      "=1{{names} était allée à la {place}}"
-      "other{{names} étaient allées à la {place}}"
-      "}"
-      "}"
-      "}",
+        "other{"
+        "{number,plural, "
+        "=0{Personne n'avait allé à la {place}}"
+        "=1{{names} était allé à la {place}}"
+        "other{{names} étaient allés à la {place}}"
+        "}"
+        "}"
+        "female{"
+        "{number,plural, "
+        "=1{{names} était allée à la {place}}"
+        "other{{names} étaient allées à la {place}}"
+        "}"
+        "}"
+        "}",
 };

--- a/test/regression/0100/0185.stmt
+++ b/test/regression/0100/0185.stmt
@@ -9,6 +9,6 @@ const NO_DART_SCRIPT_AND_EXPERIMENTAL = const MessageTemplate(
 const NO_DART_SCRIPT_AND_EXPERIMENTAL = const MessageTemplate(
     const MessageId('polymer', 6),
     'The experimental bootstrap feature doesn\'t support script tags on '
-    'the main document (for now).',
+      'the main document (for now).',
     'Script tags with experimental bootstrap',
     'This experimental feature is no longer supported.');

--- a/test/regression/0100/0185.stmt
+++ b/test/regression/0100/0185.stmt
@@ -9,6 +9,6 @@ const NO_DART_SCRIPT_AND_EXPERIMENTAL = const MessageTemplate(
 const NO_DART_SCRIPT_AND_EXPERIMENTAL = const MessageTemplate(
     const MessageId('polymer', 6),
     'The experimental bootstrap feature doesn\'t support script tags on '
-      'the main document (for now).',
+        'the main document (for now).',
     'Script tags with experimental bootstrap',
     'This experimental feature is no longer supported.');

--- a/test/regression/0100/0187.stmt
+++ b/test/regression/0100/0187.stmt
@@ -15,7 +15,7 @@
           String timeUnitDropdownPlaceholder) =>
       Intl.message(
           'Deflagrate the persimmon to $numberInputFieldPlaceholder golgafrinchans per'
-            '$timeUnitDropdownPlaceholder maximum, unless we say otherwise',
+              '$timeUnitDropdownPlaceholder maximum, unless we say otherwise',
           name: 'someComplicatedHelpMessage',
           args: [numberInputFieldPlaceholder, timeUnitDropdownPlaceholder],
           examples: {

--- a/test/regression/0100/0187.stmt
+++ b/test/regression/0100/0187.stmt
@@ -15,7 +15,7 @@
           String timeUnitDropdownPlaceholder) =>
       Intl.message(
           'Deflagrate the persimmon to $numberInputFieldPlaceholder golgafrinchans per'
-          '$timeUnitDropdownPlaceholder maximum, unless we say otherwise',
+            '$timeUnitDropdownPlaceholder maximum, unless we say otherwise',
           name: 'someComplicatedHelpMessage',
           args: [numberInputFieldPlaceholder, timeUnitDropdownPlaceholder],
           examples: {

--- a/test/regression/0100/0189.stmt
+++ b/test/regression/0100/0189.stmt
@@ -27,6 +27,6 @@
       Bidi
           .estimateDirectionOfText(
               'CAPTCHA \u05de\u05e9\u05d5\u05db\u05dc\u05dc '
-              '\u05de\u05d3\u05d9?')
+                '\u05de\u05d3\u05d9?')
           .value,
       equals(TextDirection.RTL.value));

--- a/test/regression/0100/0189.stmt
+++ b/test/regression/0100/0189.stmt
@@ -27,6 +27,6 @@
       Bidi
           .estimateDirectionOfText(
               'CAPTCHA \u05de\u05e9\u05d5\u05db\u05dc\u05dc '
-                '\u05de\u05d3\u05d9?')
+                  '\u05de\u05d3\u05d9?')
           .value,
       equals(TextDirection.RTL.value));

--- a/test/regression/0200/0201.stmt
+++ b/test/regression/0200/0201.stmt
@@ -7,6 +7,6 @@ main() {
 main() {
   var s =
       'qsmdlfkjqlsdf mlqdskf mlqkds flq fdmlqk mqlfk '
-      'mlfqks dflq sdmlfkjqmlsdkjf mlqks mfdlq smlf '
-      'mqlskdjf mlqksd jfmlqkj dmflkq mdslk jfmqds kf';
+        'mlfqks dflq sdmlfkjqmlsdkjf mlqks mfdlq smlf '
+        'mqlskdjf mlqksd jfmlqkj dmflkq mdslk jfmqds kf';
 }

--- a/test/regression/0200/0201.stmt
+++ b/test/regression/0200/0201.stmt
@@ -5,7 +5,8 @@ main() {
 }
 <<<
 main() {
-  var s = 'qsmdlfkjqlsdf mlqdskf mlqkds flq fdmlqk mqlfk '
+  var s =
+      'qsmdlfkjqlsdf mlqdskf mlqkds flq fdmlqk mqlfk '
       'mlfqks dflq sdmlfkjqmlsdkjf mlqks mfdlq smlf '
       'mqlskdjf mlqksd jfmlqkj dmflkq mdslk jfmqds kf';
 }

--- a/test/regression/0200/0201.stmt
+++ b/test/regression/0200/0201.stmt
@@ -7,6 +7,6 @@ main() {
 main() {
   var s =
       'qsmdlfkjqlsdf mlqdskf mlqkds flq fdmlqk mqlfk '
-        'mlfqks dflq sdmlfkjqmlsdkjf mlqks mfdlq smlf '
-        'mqlskdjf mlqksd jfmlqkj dmflkq mdslk jfmqds kf';
+          'mlfqks dflq sdmlfkjqmlsdkjf mlqks mfdlq smlf '
+          'mqlskdjf mlqksd jfmlqkj dmflkq mdslk jfmqds kf';
 }

--- a/test/regression/0200/0211.unit
+++ b/test/regression/0200/0211.unit
@@ -24,7 +24,7 @@ void defineProperty(var obj, String property, var value) {
   JS(
       'void',
       'Object.defineProperty(#, #, '
-        '{value: #, enumerable: false, writable: true, configurable: true})',
+          '{value: #, enumerable: false, writable: true, configurable: true})',
       obj,
       property,
       value);

--- a/test/regression/0200/0211.unit
+++ b/test/regression/0200/0211.unit
@@ -24,7 +24,7 @@ void defineProperty(var obj, String property, var value) {
   JS(
       'void',
       'Object.defineProperty(#, #, '
-      '{value: #, enumerable: false, writable: true, configurable: true})',
+        '{value: #, enumerable: false, writable: true, configurable: true})',
       obj,
       property,
       value);

--- a/test/regression/0300/0391.stmt
+++ b/test/regression/0300/0391.stmt
@@ -71,7 +71,8 @@ final ArgParser argParser = StrongModeOptions.addArguments(new ArgParser()
       help: 'Package root to resolve "package:" imports',
       defaultsTo: 'packages/')
   ..addOption('url-mapping',
-      help: '--url-mapping=libraryUri,/path/to/library.dart uses library.dart\n'
+      help:
+          '--url-mapping=libraryUri,/path/to/library.dart uses library.dart\n'
           'as the source for an import of of "libraryUri".',
       allowMultiple: true,
       splitCommas: false)
@@ -79,7 +80,8 @@ final ArgParser argParser = StrongModeOptions.addArguments(new ArgParser()
       help: 'Whether to use the multi-package resolver for "package:" imports',
       defaultsTo: false)
   ..addOption('package-paths',
-      help: 'if using the multi-package resolver, the list of directories to\n'
+      help:
+          'if using the multi-package resolver, the list of directories to\n'
           'look for packages in.',
       defaultsTo: '')
   ..addOption('resources',
@@ -98,7 +100,8 @@ final ArgParser argParser = StrongModeOptions.addArguments(new ArgParser()
       help: 'Serve embedded widget with static errors and warnings.',
       defaultsTo: true)
   ..addOption('host',
-      help: 'Host name or address to serve files from, e.g. --host=0.0.0.0\n'
+      help:
+          'Host name or address to serve files from, e.g. --host=0.0.0.0\n'
           'to listen on all interfaces (used only when --serve is on)',
       defaultsTo: 'localhost')
   ..addOption('port',

--- a/test/regression/0400/0467.unit
+++ b/test/regression/0400/0467.unit
@@ -21,6 +21,6 @@ class MyElement extends PolymerElement {
         'nodesAndEntryPoints',
         new PolymerDom(this).children.map((child) =>
             '${child.outerHtml} ------> '
-            '${(new PolymerDom(child).getDestinationInsertionPoints()[0] as Element).outerHtml}'));
+              '${(new PolymerDom(child).getDestinationInsertionPoints()[0] as Element).outerHtml}'));
   }
 }

--- a/test/regression/0400/0467.unit
+++ b/test/regression/0400/0467.unit
@@ -21,6 +21,6 @@ class MyElement extends PolymerElement {
         'nodesAndEntryPoints',
         new PolymerDom(this).children.map((child) =>
             '${child.outerHtml} ------> '
-              '${(new PolymerDom(child).getDestinationInsertionPoints()[0] as Element).outerHtml}'));
+                '${(new PolymerDom(child).getDestinationInsertionPoints()[0] as Element).outerHtml}'));
   }
 }

--- a/test/splitting/expressions.stmt
+++ b/test/splitting/expressions.stmt
@@ -9,16 +9,16 @@ var name = new Symbol("the first very long string" "the second very longstring")
 <<<
 var name = new Symbol(
     "the first very long string"
-    "the second very longstring");
+      "the second very longstring");
 >>> adjacent string lines all split together;
 var text = "first" "second" "third" "fourth" "fifth";
 <<<
 var text =
     "first"
-    "second"
-    "third"
-    "fourth"
-    "fifth";
+      "second"
+      "third"
+      "fourth"
+      "fifth";
 >>> preserve one newline between adjacent strings
 var name = "the first string"
 "the second string"
@@ -29,8 +29,8 @@ var name = "the first string"
 <<<
 var name =
     "the first string"
-    "the second string"
-    "the third string";
+      "the second string"
+      "the third string";
 >>> conditions, same operator
 if (identifier || identifier || identifier || identifier) {
 }

--- a/test/splitting/expressions.stmt
+++ b/test/splitting/expressions.stmt
@@ -13,7 +13,8 @@ var name = new Symbol(
 >>> adjacent string lines all split together;
 var text = "first" "second" "third" "fourth" "fifth";
 <<<
-var text = "first"
+var text =
+    "first"
     "second"
     "third"
     "fourth"
@@ -26,7 +27,8 @@ var name = "the first string"
 
 "the third string";
 <<<
-var name = "the first string"
+var name =
+    "the first string"
     "the second string"
     "the third string";
 >>> conditions, same operator

--- a/test/splitting/expressions.stmt
+++ b/test/splitting/expressions.stmt
@@ -9,16 +9,16 @@ var name = new Symbol("the first very long string" "the second very longstring")
 <<<
 var name = new Symbol(
     "the first very long string"
-      "the second very longstring");
+        "the second very longstring");
 >>> adjacent string lines all split together;
 var text = "first" "second" "third" "fourth" "fifth";
 <<<
 var text =
     "first"
-      "second"
-      "third"
-      "fourth"
-      "fifth";
+        "second"
+        "third"
+        "fourth"
+        "fifth";
 >>> preserve one newline between adjacent strings
 var name = "the first string"
 "the second string"
@@ -29,8 +29,8 @@ var name = "the first string"
 <<<
 var name =
     "the first string"
-      "the second string"
-      "the third string";
+        "the second string"
+        "the third string";
 >>> conditions, same operator
 if (identifier || identifier || identifier || identifier) {
 }

--- a/test/splitting/statements.stmt
+++ b/test/splitting/statements.stmt
@@ -47,11 +47,11 @@ switch (
 >>> returning long adjacent strings
 return
    "some very long string"
-     "another continued string";
+       "another continued string";
 <<<
 return
     "some very long string"
-      "another continued string";
+        "another continued string";
 >>> returning short adjacent strings
 return "foo" "bar";
 <<<

--- a/test/splitting/statements.stmt
+++ b/test/splitting/statements.stmt
@@ -47,11 +47,11 @@ switch (
 >>> returning long adjacent strings
 return
    "some very long string"
-   "another continued string";
+     "another continued string";
 <<<
 return
     "some very long string"
-    "another continued string";
+      "another continued string";
 >>> returning short adjacent strings
 return "foo" "bar";
 <<<

--- a/test/splitting/statements.stmt
+++ b/test/splitting/statements.stmt
@@ -44,3 +44,15 @@ switch (
   case 0:
     return "ok";
 }
+>>> returning long adjacent strings
+return
+   "some very long string"
+   "another continued string";
+<<<
+return
+    "some very long string"
+    "another continued string";
+>>> returning short adjacent strings
+return "foo" "bar";
+<<<
+return "foo" "bar";

--- a/test/splitting/strings.stmt
+++ b/test/splitting/strings.stmt
@@ -64,13 +64,13 @@ someMethod(
 someMethod(
     "foo\n"
     "bar"
-      "baz"
-      "bang\n"
+        "baz"
+        "bang\n"
     "qux");
 <<<
 someMethod(
     "foo\n"
     "bar"
-      "baz"
-      "bang\n"
+        "baz"
+        "bang\n"
     "qux");

--- a/test/splitting/strings.stmt
+++ b/test/splitting/strings.stmt
@@ -54,3 +54,23 @@ someMethod("""first line does not fits here
 someMethod(
     """first line does not fits here
 """);
+>>> always splits adjacent strings after newline
+someMethod("foo\n" "bar");
+<<<
+someMethod(
+    "foo\n"
+    "bar");
+>>> indents adjacent strings after non-newlines only
+someMethod(
+    "foo\n"
+    "bar"
+      "baz"
+      "bang\n"
+    "qux");
+<<<
+someMethod(
+    "foo\n"
+    "bar"
+      "baz"
+      "bang\n"
+    "qux");


### PR DESCRIPTION
This essentially makes the formatter match the style we used on pub
before it got formatted. Also, by ignoring the user's splits, it helps
call out cases where adjacent strings are unnecessary and can be
merged into single literals.