### PR TITLE
Bump use of pkg/args to <2.0.0.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=1.8.0 <2.0.0"
 dependencies:
   analyzer: '^0.30.0'
-  args: '>=0.12.1 <0.14.0'
+  args: '>=0.12.1 <2.0.0'
   path: '>=1.0.0 <2.0.0'
   source_span: '>=1.1.1 <2.0.0'
 dev_dependencies:


### PR DESCRIPTION
Partial towards https://github.com/dart-lang/dart_style/issues/638.

This is important because `dart_style` is used as a `dependency` in a few packages (think code-generation), and limiting `args` makes developing them (and using newer features) much harder.