### PR TITLE
Bump to 1.0.9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.9
+
+* Updated tests. No user-facing changes.
+
 # 1.0.8
 
 * Support v1 of `pkg/args`.

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -14,7 +14,7 @@ import 'package:dart_style/src/io.dart';
 import 'package:dart_style/src/source_code.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const version = "1.0.8";
+const version = "1.0.9";
 
 void main(List<String> args) {
   var parser = new ArgParser(allowTrailingOptions: true);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2,340 +2,382 @@
 # See http://pub.dartlang.org/doc/glossary.html#lockfile
 packages:
   analyzer:
+    dependency: "direct main"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.30.0+2"
-  ansicolor:
-    description:
-      name: ansicolor
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.9"
+    version: "0.30.0+4"
   args:
+    dependency: "direct main"
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "1.2.0"
   async:
+    dependency: "direct dev"
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.13.3"
+    version: "2.0.0"
   barback:
+    dependency: transitive
     description:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+11"
+    version: "0.15.2+13"
   boolean_selector:
+    dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
   browser:
+    dependency: "direct dev"
     description:
       name: browser
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.0+2"
   charcode:
+    dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   cli_util:
+    dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.2+1"
   collection:
+    dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.1"
+    version: "1.14.5"
   convert:
+    dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   crypto:
+    dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2+1"
   csslib:
+    dependency: transitive
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "0.14.1"
   front_end:
+    dependency: transitive
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.4"
+    version: "0.1.0-alpha.4.1"
   glob:
+    dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.5"
   grinder:
+    dependency: "direct dev"
     description:
       name: grinder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.0+3"
+    version: "0.8.1"
   html:
+    dependency: transitive
     description:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.2"
+    version: "0.13.2+1"
   http:
+    dependency: transitive
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+13"
+    version: "0.11.3+16"
   http_multi_server:
+    dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   http_parser:
+    dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
+  io:
+    dependency: transitive
+    description:
+      name: io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.1"
   isolate:
+    dependency: transitive
     description:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   js:
+    dependency: "direct dev"
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.1"
   kernel:
+    dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.1"
+    version: "0.3.0-alpha.1.1"
   logging:
+    dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.3+1"
   matcher:
+    dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+1"
+    version: "0.12.1+4"
   meta:
+    dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.2"
   mime:
+    dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.3"
-  mockable_filesystem:
+    version: "0.9.5"
+  multi_server_socket:
+    dependency: transitive
     description:
-      name: mockable_filesystem
+      name: multi_server_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.3"
+    version: "1.0.1"
   node_preamble:
+    dependency: "direct dev"
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   package_config:
+    dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.3"
   package_resolver:
+    dependency: transitive
     description:
       name: package_resolver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
   path:
+    dependency: "direct main"
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.2"
+    version: "1.5.1"
   plugin:
+    dependency: transitive
     description:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.0+2"
   pool:
+    dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.4"
   pub_semver:
+    dependency: "direct dev"
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.2"
   shelf:
+    dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.7+2"
+    version: "0.7.1"
   shelf_packages_handler:
+    dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   shelf_static:
+    dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.4"
+    version: "0.2.6"
   shelf_web_socket:
+    dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   source_map_stack_trace:
+    dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.4"
   source_maps:
+    dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.4"
   source_span:
+    dependency: "direct main"
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
   stack_trace:
+    dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.3"
+    version: "1.9.1"
   stream_channel:
+    dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.3"
   string_scanner:
+    dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
-  supports_color:
-    description:
-      name: supports_color
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.1"
   term_glyph:
+    dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
   test:
+    dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.20+13"
+    version: "0.12.30"
   test_descriptor:
+    dependency: "direct dev"
     description:
       name: test_descriptor
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   test_process:
+    dependency: "direct dev"
     description:
       name: test_process
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
   typed_data:
+    dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
-  unscripted:
-    description:
-      name: unscripted
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.2"
+    version: "1.1.5"
   utf:
+    dependency: transitive
     description:
       name: utf
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.0+3"
   watcher:
+    dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+3"
+    version: "0.9.7+4"
   web_socket_channel:
+    dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.6"
   yaml:
+    dependency: "direct dev"
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.13"
 sdks:
-  dart: ">=1.23.0-dev.0.0 <=2.0.0-dev.2.0"
+  dart: ">=1.23.0 <=2.0.0-edge.d5105da9cabff92c398d90d7c80fc23b5e38e012"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.0.9-dev
+version: 1.0.9
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style


### PR DESCRIPTION
Getting ready to release 1.0.9.

The only change in it is your removal of scheduled_test (which is an excellent change :) ).