### PR TITLE
Support optional new/const.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.10
+
+* Support optional `new`/`const` (#652).
+
 # 1.0.9
 
 * Updated tests. No user-facing changes.

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -14,7 +14,7 @@ import 'package:dart_style/src/io.dart';
 import 'package:dart_style/src/source_code.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const version = "1.0.9";
+const version = "1.0.10";
 
 void main(List<String> args) {
   var parser = new ArgParser(allowTrailingOptions: true);

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -103,7 +103,7 @@ class DartFormatter {
 
     // Parse it.
     var parser = new Parser(stringSource, errorListener);
-    parser.enableAssertInitializer = true;
+    parser.enableOptionalNewAndConst = true;
 
     AstNode node;
     if (source.isCompilationUnit) {

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1341,8 +1341,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   visitInstanceCreationExpression(InstanceCreationExpression node) {
     builder.startSpan();
-    token(node.keyword);
-    space();
+    token(node.keyword, after: space);
     builder.startSpan(Cost.constructorName);
 
     // Start the expression nesting for the argument list here, in case this

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.31.0"
+    version: "0.31.2-alpha.0"
   args:
     dependency: "direct main"
     description:
@@ -21,7 +21,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   barback:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.8"
+    version: "0.1.0-alpha.10"
   glob:
     dependency: transitive
     description:
@@ -161,7 +161,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.5"
+    version: "0.3.0-alpha.10"
   logging:
     dependency: transitive
     description:
@@ -301,7 +301,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.2"
   stream_channel:
     dependency: transitive
     description:
@@ -329,7 +329,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.30+1"
+    version: "0.12.30+3"
   test_descriptor:
     dependency: "direct dev"
     description:
@@ -371,7 +371,7 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.7"
   yaml:
     dependency: "direct dev"
     description:
@@ -380,4 +380,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: "2.0.0-dev.20.0"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-edge.d5105da9cabff92c398d90d7c80fc23b5e38e012"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,27 +1,27 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.0.9+1
+version: 1.0.10
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style
 environment:
-  sdk: ">=1.8.0 <2.0.0"
+  sdk: '>=1.8.0 <2.0.0'
 dependencies:
-  analyzer: '>=0.30.0 <0.32.0'
+  analyzer: ^0.31.2-alpha.0
   args: '>=0.12.1 <2.0.0'
-  path: '>=1.0.0 <2.0.0'
-  source_span: '>=1.4.0 <2.0.0'
+  path: ^1.0.0
+  source_span: ^1.4.0
 dev_dependencies:
   async: '>=1.0.0 <=3.0.0'
-  browser: '>=0.10.0 <0.11.0'
-  grinder: '^0.8.0'
+  browser: ^0.10.0
+  grinder: ^0.8.0
   js: ^0.6.0
   node_preamble: ^1.0.0
-  pub_semver: '^1.2.3'
-  test: '>=0.12.0 <0.13.0'
-  test_descriptor: "^1.0.0"
-  test_process: "^1.0.0"
-  yaml: '^2.0.0'
+  pub_semver: ^1.2.3
+  test: ^0.12.0
+  test_descriptor: ^1.0.0
+  test_process: ^1.0.0
+  yaml: ^2.0.0
 executables:
   dartfmt: format
   dartformat: format # Allow the old name for compatibility.

--- a/test/whitespace/type_arguments.stmt
+++ b/test/whitespace/type_arguments.stmt
@@ -7,3 +7,7 @@ new Foo<T>();
 new Foo<  A,B,   C,D>();
 <<<
 new Foo<A, B, C, D>();
+>>> named constructor with implicit "new"
+C <  int  ,float>  .named(42);
+<<<
+C<int, float>.named(42);


### PR DESCRIPTION
In almost all cases, an elided "new"/"const" is parsed as a normal
method call by analyzer, so the existing formatting behavior for those
does the right thing. The only edge case is a named constructor on a
generic class. That syntax can *only* be a constructor call, so it's
parsed as an instance creation expression.

When we get to that code path, we need to not add an extra space before
the class name if there is no preceding "new" or "const" keyword.

Fix #652.