### PR TITLE
Don't split before "." when the target has a trailing comma.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 1.0.10
 
 * Support optional `new`/`const` (#652).
+* Don't split before `.` if the target expression is an argument list with a
+  trailing comma (#548, #665).
 
 # 1.0.9
 

--- a/lib/src/call_chain_visitor.dart
+++ b/lib/src/call_chain_visitor.dart
@@ -5,6 +5,7 @@
 library dart_style.src.call_chain_visitor;
 
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/token.dart';
 
 import 'argument_list_visitor.dart';
 import 'rule/argument.dart';
@@ -331,6 +332,10 @@ class CallChainVisitor {
     if (argumentList.arguments.isEmpty) return true;
 
     var argument = argumentList.arguments.last;
+
+    // If the argument list has a trailing comma, treat it like a collection.
+    if (argument.endToken.next.type == TokenType.COMMA) return false;
+
     if (argument is NamedExpression) {
       argument = (argument as NamedExpression).expression;
     }

--- a/test/regression/0500/0548.stmt
+++ b/test/regression/0500/0548.stmt
@@ -1,0 +1,44 @@
+>>> (indent 2)
+  StatementBuilder assignConst(String variable, [TypeBuilder type]) {
+    return new _AsAssign(
+      this,
+      variable,
+      keyword: _AsAssignType.asConst,
+      type: type,
+    )
+        .asStatement();
+  }
+<<<
+  StatementBuilder assignConst(String variable, [TypeBuilder type]) {
+    return new _AsAssign(
+      this,
+      variable,
+      keyword: _AsAssignType.asConst,
+      type: type,
+    ).asStatement();
+  }
+>>> (indent 4)
+return new _AsAssign(this, variable,
+            keyword: _AsAssignType.asConst, type: type)
+        .asStatement();
+<<<
+    return new _AsAssign(this, variable,
+            keyword: _AsAssignType.asConst, type: type)
+        .asStatement();
+>>> (indent 2)
+StatementBuilder assignConst(String variable, [TypeBuilder type]) =>
+      new _AsAssign(
+        this,
+        variable,
+        keyword: _AsAssignType.asConst,
+        type: type,
+      )
+          .asStatement();
+<<<
+  StatementBuilder assignConst(String variable, [TypeBuilder type]) =>
+      new _AsAssign(
+        this,
+        variable,
+        keyword: _AsAssignType.asConst,
+        type: type,
+      ).asStatement();

--- a/test/regression/0600/0665.stmt
+++ b/test/regression/0600/0665.stmt
@@ -1,0 +1,17 @@
+>>>
+when(
+ runner.call(
+   typed(captureAny),
+   typed(captureAny),
+   workingDirectory: typed(captureAny, named: "workingDirectory"),
+ ),
+)
+   .thenReturn(new Future<MockProcessResult>.value(new MockProcessResult()));
+<<<
+when(
+  runner.call(
+    typed(captureAny),
+    typed(captureAny),
+    workingDirectory: typed(captureAny, named: "workingDirectory"),
+  ),
+).thenReturn(new Future<MockProcessResult>.value(new MockProcessResult()));

--- a/test/splitting/invocations.stmt
+++ b/test/splitting/invocations.stmt
@@ -272,3 +272,20 @@ new Foo(() {
 (function)(() {
   ;
 }).someLongMethod();
+>>> trailing comma argument list does not force trailing method chain to split
+function(argument,).method().method();
+<<<
+function(
+  argument,
+).method().method();
+>>> if method chain splits, split before first too
+function(argument,).method().method().method().method().method();
+<<<
+function(
+  argument,
+)
+    .method()
+    .method()
+    .method()
+    .method()
+    .method();

--- a/test/splitting/list_arguments.stmt
+++ b/test/splitting/list_arguments.stmt
@@ -435,3 +435,20 @@ function(argument, // comment
     [
       [element]
     ]);
+>>> don't force trailing method chain to split
+function([argument,]).method().method();
+<<<
+function([
+  argument,
+]).method().method();
+>>> if method chain splits, split before first too
+function([argument,]).method().method().method().method().method();
+<<<
+function([
+  argument,
+])
+    .method()
+    .method()
+    .method()
+    .method()
+    .method();

--- a/test/splitting/map_arguments.stmt
+++ b/test/splitting/map_arguments.stmt
@@ -222,3 +222,20 @@ obj.outer(
       key: value,
       otherKey: otherLongValue
     }));
+>>> don't force trailing method chain to split
+function({key: value,}).method().method();
+<<<
+function({
+  key: value,
+}).method().method();
+>>> if method chain splits, split before first too
+function({key: value,}).method().method().method().method().method();
+<<<
+function({
+  key: value,
+})
+    .method()
+    .method()
+    .method()
+    .method()
+    .method();


### PR DESCRIPTION
Fix #548. Fix #665.