### PR TITLE
Tweak how initialization lists are handled after trailing commas.

### DIFF
--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -716,37 +716,50 @@ class SourceVisitor extends ThrowingAstVisitor {
       //       parameter,
       //     ) : super();
       space();
+
+      var isOptional = node.parameters.parameters.last.kind != ParameterKind.REQUIRED;
+      if (node.initializers.length > 1) {
+        _writeText(isOptional ? " " : "  ", node.separator.offset);
+      }
+
+      // ":".
+      token(node.separator);
+
+      space();
+
+      builder.indent(6);
     } else {
       // Shift the itself ":" forward.
       builder.indent(Indent.constructorInitializer);
 
       // If the parameters or initializers split, put the ":" on its own line.
       split();
+
+      // ":".
+      token(node.separator);
+      space();
+
+
+      // Try to line up the initializers with the first one that follows the ":":
+      //
+      //     Foo(notTrailing)
+      //         : initializer = value,
+      //           super(); // +2 from previous line.
+      //
+      //     Foo(
+      //       trailing,
+      //     ) : initializer = value,
+      //         super(); // +4 from previous line.
+      //
+      // This doesn't work if there is a trailing comma in an optional parameter,
+      // but we don't want to do a weird +5 alignment:
+      //
+      //     Foo({
+      //       trailing,
+      //     }) : initializer = value,
+      //         super(); // Doesn't quite line up. :(
+      builder.indent(2);
     }
-
-    // ":".
-    token(node.separator);
-    space();
-
-    // Try to line up the initializers with the first one that follows the ":":
-    //
-    //     Foo(notTrailing)
-    //         : initializer = value,
-    //           super(); // +2 from previous line.
-    //
-    //     Foo(
-    //       trailing,
-    //     ) : initializer = value,
-    //         super(); // +4 from previous line.
-    //
-    // This doesn't work if there is a trailing comma in an optional parameter,
-    // but we don't want to do a weird +5 alignment:
-    //
-    //     Foo({
-    //       trailing,
-    //     }) : initializer = value,
-    //         super(); // Doesn't quite line up. :(
-    builder.indent(hasTrailingComma ? 4 : 2);
 
     for (var i = 0; i < node.initializers.length; i++) {
       if (i > 0) {

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -717,7 +717,8 @@ class SourceVisitor extends ThrowingAstVisitor {
       //     ) : super();
       space();
 
-      var isOptional = node.parameters.parameters.last.kind != ParameterKind.REQUIRED;
+      var isOptional =
+          node.parameters.parameters.last.kind != ParameterKind.REQUIRED;
       if (node.initializers.length > 1) {
         _writeText(isOptional ? " " : "  ", node.separator.offset);
       }
@@ -738,7 +739,6 @@ class SourceVisitor extends ThrowingAstVisitor {
       // ":".
       token(node.separator);
       space();
-
 
       // Try to line up the initializers with the first one that follows the ":":
       //

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -709,14 +709,16 @@ class SourceVisitor extends ThrowingAstVisitor {
         node.parameters.parameters.last.endToken.next.type == TokenType.COMMA;
 
     if (hasTrailingComma) {
-      // If there is a trailing comma in the argument list, the ")" will be on
-      // its own line, so keep the ":" with it:
+      // Since the ")", "])", or "})" on the preceding line doesn't take up
+      // much space, it looks weird to move the ":" onto it's own line. Instead,
+      // keep it and the first initializer on the current line but add enough
+      // space before it to line it up with any subsequent initializers.
       //
       //     Foo(
       //       parameter,
-      //     ) : super();
+      //     )   : field = value,
+      //           super();
       space();
-
       var isOptional =
           node.parameters.parameters.last.kind != ParameterKind.REQUIRED;
       if (node.initializers.length > 1) {
@@ -725,7 +727,6 @@ class SourceVisitor extends ThrowingAstVisitor {
 
       // ":".
       token(node.separator);
-
       space();
 
       builder.indent(6);

--- a/test/regression/0600/0658.unit
+++ b/test/regression/0600/0658.unit
@@ -25,6 +25,6 @@ class Foo {
   Foo({
     Bar bar,
     Baz baz,
-  }) : assert(bar != null),
-      super(baz);
+  })  : assert(bar != null),
+        super(baz);
 }

--- a/test/splitting/constructors.unit
+++ b/test/splitting/constructors.unit
@@ -135,10 +135,10 @@ class A {
 class A {
   A(
     a,
-  ) : b = 1,
-      super();
+  )   : b = 1,
+        super();
 }
->>>
+>>> extra space after ":" to line up with later initializers
 class A {
   A({a,}):b=1,super(){;}
 }
@@ -146,8 +146,19 @@ class A {
 class A {
   A({
     a,
-  }) : b = 1,
-      super() {
+  })  : b = 1,
+        super() {
     ;
   }
+}
+>>> no extra space on a single initializer, even if it splits
+class A {
+  A(a,):parameter = "some very very long param";
+}
+<<<
+class A {
+  A(
+    a,
+  ) : parameter =
+            "some very very long param";
 }


### PR DESCRIPTION
This gets avoids the pointless newlines of the old formatting rules,
but keeps it otherwise closer to the original behavior than
43832d24e7b86a165ec6a1765cbbb3644cae5f38 does.

In particular, initialization lists are always indented +6. This ensures
that initialization lists line up for constructors with trailing commas,
without, with optional parameters, mandatory, or none at all.