### PR TITLE
Clean up some analyzer imports

### DIFF
--- a/lib/src/argument_list_visitor.dart
+++ b/lib/src/argument_list_visitor.dart
@@ -6,7 +6,7 @@ library dart_style.src.argument_list_visitor;
 
 import 'dart:math' as math;
 
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 
 import 'chunk.dart';

--- a/lib/src/call_chain_visitor.dart
+++ b/lib/src/call_chain_visitor.dart
@@ -4,7 +4,7 @@
 
 library dart_style.src.call_chain_visitor;
 
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 
 import 'argument_list_visitor.dart';

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -6,8 +6,9 @@ library dart_style.src.dart_formatter;
 
 import 'dart:math' as math;
 
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:analyzer/src/dart/scanner/reader.dart';
 import 'package:analyzer/src/dart/scanner/scanner.dart';
 import 'package:analyzer/src/generated/parser.dart';

--- a/lib/src/error_listener.dart
+++ b/lib/src/error_listener.dart
@@ -4,7 +4,8 @@
 
 library dart_style.src.error_listener;
 
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/listener.dart';
 
 import 'exceptions.dart';
 

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -4,7 +4,7 @@
 
 library dart_style.src.formatter_exception;
 
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:source_span/source_span.dart';
 
 /// Thrown when one or more errors occurs while parsing the code to be

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -4,8 +4,10 @@
 
 library dart_style.src.source_visitor;
 
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/analyzer.dart' show ParameterKind;
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/src/generated/source.dart';
 
 import 'argument_list_visitor.dart';


### PR DESCRIPTION
I am in the process of looking at clients of analyzer to determine what needs to be added to the public API in order to remove imports of internal code. In the process, I am sometimes cleaning up existing imports in order to make that task easier.

This replaces an import that exposes a very large API with more specific imports that expose a much smaller portion of the API.

I won't be offended if you'd prefer not to accept it.