### PR TITLE
Force split in empty blocks in if statements with else clauses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 1.0.11-dev
+# 1.0.11
 
 * Fix cast failure when running in Dart 2.
 * Updated SDK version to 2.0.0-dev.17.0.
+* Force split in empty then block in if with an else (#680).
 
 # 1.0.10
 

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -14,7 +14,7 @@ import 'package:dart_style/src/io.dart';
 import 'package:dart_style/src/source_code.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const version = "1.0.10";
+const version = "1.0.11";
 
 void main(List<String> args) {
   var parser = new ArgParser(allowTrailingOptions: true);

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -261,10 +261,25 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   visitBlock(Block node) {
-    // Don't allow splitting in an empty block.
+    // Treat empty blocks specially. In most cases, they are not allowed to
+    // split. However, an empty block as the then statement of an if with an
+    // else is always split.
     if (node.statements.isEmpty &&
         node.rightBracket.precedingComments == null) {
       token(node.leftBracket);
+
+      // Force a split when used as the then body of an if with an else:
+      //
+      //     if (condition) {
+      //     } else ...
+      if (node.parent is IfStatement) {
+        var ifStatement = node.parent as IfStatement;
+        if (ifStatement.elseStatement != null &&
+            ifStatement.thenStatement == node) {
+          newline();
+        }
+      }
+
       token(node.rightBracket);
       return;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.0.11-dev
+version: 1.0.11
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style

--- a/test/regression/0600/0680.stmt
+++ b/test/regression/0600/0680.stmt
@@ -1,0 +1,22 @@
+>>> (indent 4)
+    if (receiver != null &&
+        receiver is! ThisExpression &&
+        interfaceMember is Procedure &&
+        interfaceMember
+            .isGenericContravariant) {} else if (identical(interfaceMember,
+        'call')) {} else if (interfaceMember == null) {} else if (interfaceMember
+            is Procedure &&
+        interfaceMember.isGenericContravariant) {
+      return MethodContravarianceCheckKind.checkMethodReturn;
+    }
+<<<
+    if (receiver != null &&
+        receiver is! ThisExpression &&
+        interfaceMember is Procedure &&
+        interfaceMember.isGenericContravariant) {
+    } else if (identical(interfaceMember, 'call')) {
+    } else if (interfaceMember == null) {
+    } else if (interfaceMember is Procedure &&
+        interfaceMember.isGenericContravariant) {
+      return MethodContravarianceCheckKind.checkMethodReturn;
+    }

--- a/test/splitting/statements.stmt
+++ b/test/splitting/statements.stmt
@@ -44,3 +44,17 @@ switch (
   case 0:
     return "ok";
 }
+>>> don't split empty block in if without else
+if (condition) {
+
+
+}
+<<<
+if (condition) {}
+>>> split empty block in if if there is an else
+if (condition) {} else {
+
+}
+<<<
+if (condition) {
+} else {}


### PR DESCRIPTION
Fix #680.