### PR TITLE
Add support for non-whitespace opt-in "style fixes".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.0-dev
+
+* Add support for "style fixes", opt-in non-whitespace changes.
+* Add fix to convert ":" to "=" as the named parameter default value separator.
+
 # 1.0.14
 
 * Support metadata on enum cases (#688).

--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ if (tag == 'style' ||
 The formatter will never break your code&mdash;you can safely invoke it
 automatically from build and presubmit scripts.
 
+## Style fixes
+
+The formatter can also apply non-whitespace changes to make your code
+consistently idiomatic. You must opt into these by passing either `--fix` which
+applies all style fixes, or any of the `--fix-`-prefixed flags to apply
+specific fixes.
+
+For example, running with `--fix-named-default-separator` changes this:
+
+```dart
+greet(String name, {String title: "Captain"}) {
+  print("Greetings, $title $name!");
+}
+```
+
+into:
+
+```dart
+greet(String name, {String title = "Captain"}) {
+  print("Greetings, $title $name!");
+}
+```
+
 ## Getting dartfmt
 
 Dartfmt is included in the Dart SDK, so you might want to add the SDK's bin

--- a/lib/dart_style.dart
+++ b/lib/dart_style.dart
@@ -6,4 +6,5 @@ library dart_style;
 
 export 'src/dart_formatter.dart';
 export 'src/exceptions.dart';
+export 'src/style_fix.dart';
 export 'src/source_code.dart';

--- a/lib/src/formatter_options.dart
+++ b/lib/src/formatter_options.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'source_code.dart';
+import 'style_fix.dart';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 class FormatterOptions {
@@ -24,8 +25,14 @@ class FormatterOptions {
   /// Whether symlinks should be traversed when formatting a directory.
   final bool followLinks;
 
+  /// The style fixes to apply while formatting.
+  final Iterable<StyleFix> fixes;
+
   FormatterOptions(this.reporter,
-      {this.indent: 0, this.pageWidth: 80, this.followLinks: false});
+      {this.indent: 0,
+      this.pageWidth: 80,
+      this.followLinks: false,
+      this.fixes});
 }
 
 /// How the formatter reports the results it produces.

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -67,8 +67,10 @@ bool processDirectory(FormatterOptions options, Directory directory) {
 bool processFile(FormatterOptions options, File file, {String label}) {
   if (label == null) label = file.path;
 
-  var formatter =
-      new DartFormatter(indent: options.indent, pageWidth: options.pageWidth);
+  var formatter = new DartFormatter(
+      indent: options.indent,
+      pageWidth: options.pageWidth,
+      fixes: options.fixes);
   try {
     var source = new SourceCode(file.readAsStringSync(), uri: file.path);
     options.reporter.beforeFile(file, label);

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -19,6 +19,7 @@ import 'rule/metadata.dart';
 import 'rule/rule.dart';
 import 'rule/type_argument.dart';
 import 'source_code.dart';
+import 'style_fix.dart';
 import 'whitespace.dart';
 
 /// Visits every token of the AST and passes all of the relevant bits to a
@@ -831,9 +832,16 @@ class SourceVisitor extends ThrowingAstVisitor {
       builder.startSpan();
       builder.nestExpression();
 
-      // The '=' separator is preceded by a space, ":" is not.
-      if (node.separator.type == TokenType.EQ) space();
-      token(node.separator);
+      if (_formatter.fixes.contains(StyleFix.namedDefaultSeparator)) {
+        // Change the separator to "=".
+        space();
+        writePrecedingCommentsAndNewlines(node.separator);
+        _writeText("=", node.separator.offset);
+      } else {
+        // The '=' separator is preceded by a space, ":" is not.
+        if (node.separator.type == TokenType.EQ) space();
+        token(node.separator);
+      }
 
       soloSplit(_assignmentCost(node.defaultValue));
       visit(node.defaultValue);

--- a/lib/src/style_fix.dart
+++ b/lib/src/style_fix.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Enum-like class for the different syntactic fixes that can be applied while
+/// formatting.
+class StyleFix {
+  static const namedDefaultSeparator = const StyleFix._(
+      "named-default-separator",
+      'Use "=" as the separator before named parameter default values.');
+
+  static const all = const [namedDefaultSeparator];
+
+  final String name;
+  final String description;
+
+  const StyleFix._(this.name, this.description);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.0.14
+version: 1.1.0-dev
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style

--- a/test/command_line_test.dart
+++ b/test/command_line_test.dart
@@ -233,6 +233,33 @@ void main() {
     });
   });
 
+  group("fix", () {
+    // TODO(rnystrom): This will get more useful when other fixes are supported.
+    test("--fix applies all fixes", () async {
+      var process = await runFormatter(["--fix"]);
+      process.stdin.writeln("foo({a:1}) {}");
+      await process.stdin.close();
+
+      expect(await process.stdout.next, "foo({a = 1}) {}");
+      await process.shouldExit(0);
+    });
+
+    test("--fix-named-default-separator", () async {
+      var process = await runFormatter(["--fix-named-default-separator"]);
+      process.stdin.writeln("foo({a:1}) {}");
+      await process.stdin.close();
+
+      expect(await process.stdout.next, "foo({a = 1}) {}");
+      await process.shouldExit(0);
+    });
+
+    test("errors with --fix and specific fix flag", () async {
+      var process =
+          await runFormatter(["--fix", "--fix-named-default-separator"]);
+      await process.shouldExit(64);
+    });
+  });
+
   group("with no paths", () {
     test("errors on --overwrite", () async {
       var process = await runFormatter(["--overwrite"]);

--- a/test/fix_test.dart
+++ b/test/fix_test.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn("vm")
+library dart_style.test.fix_test;
+
+import 'package:test/test.dart';
+
+import 'package:dart_style/dart_style.dart';
+
+import 'utils.dart';
+
+void main() {
+  testFile(
+      "fixes/named_default_separator.unit", [StyleFix.namedDefaultSeparator]);
+}

--- a/test/fixes/named_default_separator.unit
+++ b/test/fixes/named_default_separator.unit
@@ -1,0 +1,36 @@
+40 columns                              |
+>>>
+foo({int a, int c:    1, d: 2, e=3}) {}
+<<<
+foo({int a, int c = 1, d = 2, e = 3}) {}
+>>> preserves block comments before
+foo({a/* b */    /* c */:1}) {}
+<<<
+foo({a /* b */ /* c */ = 1}) {}
+>>> preserves block comments after
+foo({a   :    /* b */ /* c */1}) {}
+<<<
+foo({a = /* b */ /* c */ 1}) {}
+>>> preserves line comments before
+foo({a// b
+
+
+ // c
+ :1}) {}
+<<<
+foo(
+    {a // b
+
+    // c
+    = 1}) {}
+>>> preserves line comments after
+foo({a   :    // b
+
+  // c
+1}) {}
+<<<
+foo(
+    {a = // b
+
+        // c
+        1}) {}

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -9,11 +9,16 @@ import 'dart:io';
 import 'dart:mirrors';
 
 import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
+import 'package:dart_style/dart_style.dart';
+
 const unformattedSource = 'void  main()  =>  print("hello") ;';
 const formattedSource = 'void main() => print("hello");\n';
+
+final _indentPattern = new RegExp(r"^\(indent (\d+)\)\s*");
 
 /// Runs the command line formatter, passing it [args].
 Future<TestProcess> runFormatter([List<String> args]) {
@@ -46,4 +51,132 @@ Future<TestProcess> runFormatter([List<String> args]) {
 Future<TestProcess> runFormatterOnDir([List<String> args]) {
   if (args == null) args = [];
   return runFormatter([d.sandbox]..addAll(args));
+}
+
+/// Run tests defined in "*.unit" and "*.stmt" files inside directory [name].
+void testDirectory(String name, [Iterable<StyleFix> fixes]) {
+  // Locate the "test" directory. Use mirrors so that this works with the test
+  // package, which loads this suite into an isolate.
+  var testDir = p.dirname(currentMirrorSystem()
+      .findLibrary(#dart_style.test.utils)
+      .uri
+      .toFilePath());
+
+  var entries = new Directory(p.join(testDir, name))
+      .listSync(recursive: true, followLinks: false);
+  for (var entry in entries) {
+    if (!entry.path.endsWith(".stmt") && !entry.path.endsWith(".unit")) {
+      continue;
+    }
+
+    _testFile(name, entry.path, fixes);
+  }
+}
+
+void testFile(String path, [Iterable<StyleFix> fixes]) {
+  // Locate the "test" directory. Use mirrors so that this works with the test
+  // package, which loads this suite into an isolate.
+  var testDir = p.dirname(currentMirrorSystem()
+      .findLibrary(#dart_style.test.utils)
+      .uri
+      .toFilePath());
+
+  _testFile(p.dirname(path), p.join(testDir, path), fixes);
+}
+
+void _testFile(String name, String path, Iterable<StyleFix> fixes) {
+  group("$name ${p.basename(path)}", () {
+    // Explicitly create a File, in case the entry is a Link.
+    var lines = new File(path).readAsLinesSync();
+
+    // The first line may have a "|" to indicate the page width.
+    var pageWidth;
+    if (lines[0].endsWith("|")) {
+      pageWidth = lines[0].indexOf("|");
+      lines = lines.skip(1).toList();
+    }
+
+    var i = 0;
+    while (i < lines.length) {
+      var description = lines[i++].replaceAll(">>>", "").trim();
+
+      // Let the test specify a leading indentation. This is handy for
+      // regression tests which often come from a chunk of nested code.
+      var leadingIndent = 0;
+      var indentMatch = _indentPattern.firstMatch(description);
+      if (indentMatch != null) {
+        leadingIndent = int.parse(indentMatch[1]);
+        description = description.substring(indentMatch.end);
+      }
+
+      if (description == "") {
+        description = "line ${i + 1}";
+      } else {
+        description = "line ${i + 1}: $description";
+      }
+
+      var input = "";
+      while (!lines[i].startsWith("<<<")) {
+        input += lines[i++] + "\n";
+      }
+
+      var expectedOutput = "";
+      while (++i < lines.length && !lines[i].startsWith(">>>")) {
+        expectedOutput += lines[i] + "\n";
+      }
+
+      // TODO(rnystrom): Stop skipping these tests when possible.
+      if (description.contains("(skip:")) {
+        print("skipping $description");
+        continue;
+      }
+
+      test(description, () {
+        var isCompilationUnit = p.extension(path) == ".unit";
+
+        var inputCode =
+            _extractSelection(input, isCompilationUnit: isCompilationUnit);
+
+        var expected = _extractSelection(expectedOutput,
+            isCompilationUnit: isCompilationUnit);
+
+        var formatter = new DartFormatter(
+            pageWidth: pageWidth, indent: leadingIndent, fixes: fixes);
+
+        var actual = formatter.formatSource(inputCode);
+
+        // The test files always put a newline at the end of the expectation.
+        // Statements from the formatter (correctly) don't have that, so add
+        // one to line up with the expected result.
+        var actualText = actual.text;
+        if (!isCompilationUnit) actualText += "\n";
+
+        // Fail with an explicit message because it's easier to read than
+        // the matcher output.
+        if (actualText != expected.text) {
+          fail("Formatting did not match expectation. Expected:\n"
+              "${expected.text}\nActual:\n$actualText");
+        }
+
+        expect(actual.selectionStart, equals(expected.selectionStart));
+        expect(actual.selectionLength, equals(expected.selectionLength));
+      });
+    }
+  });
+}
+
+/// Given a source string that contains ‹ and › to indicate a selection, returns
+/// a [SourceCode] with the text (with the selection markers removed) and the
+/// correct selection range.
+SourceCode _extractSelection(String source, {bool isCompilationUnit: false}) {
+  var start = source.indexOf("‹");
+  source = source.replaceAll("‹", "");
+
+  var end = source.indexOf("›");
+  source = source.replaceAll("›", "");
+
+  return new SourceCode(source,
+      isCompilationUnit: isCompilationUnit,
+      selectionStart: start == -1 ? null : start,
+      selectionLength: end == -1 ? null : end - start);
 }


### PR DESCRIPTION
Implement the first fix, converting ":" to "=" as the named default
value separator.