### PR TITLE
Attempt to uniformly format code with or without "new"/"const".

### DIFF
--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -327,10 +327,10 @@ class Cost {
   static const splitBlocks = 2;
 
   /// Splitting on the "." in a named constructor.
-  static const constructorName = 3;
+  static const constructorName = 4;
 
   /// Splitting a `[...]` index operator.
-  static const index = 3;
+  static const index = 4;
 
   /// Splitting before a type argument or type parameter.
   static const typeArgument = 4;

--- a/lib/src/debug.dart
+++ b/lib/src/debug.dart
@@ -104,7 +104,11 @@ void dumpChunks(int start, List<Chunk> chunks) {
       for (var span in spans) {
         if (chunk.spans.contains(span)) {
           if (index == 0 || !chunks[index - 1].spans.contains(span)) {
-            spanBars += "╖";
+            if (span.cost == 1) {
+              spanBars += "╖";
+            } else {
+              spanBars += span.cost.toString();
+            }
           } else {
             spanBars += "║";
           }

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -22,9 +22,69 @@ import 'source_code.dart';
 import 'style_fix.dart';
 import 'whitespace.dart';
 
+final _capitalPattern = new RegExp(r"^_?[A-Z].*[a-z]");
+
 /// Visits every token of the AST and passes all of the relevant bits to a
 /// [ChunkBuilder].
 class SourceVisitor extends ThrowingAstVisitor {
+  /// Returns `true` if [node] is a method invocation that looks like it might
+  /// be a static method or constructor call without a `new` keyword.
+  ///
+  /// With optional `new`, we can no longer reliably identify constructor calls
+  /// statically, but we still don't want to mix named constructor calls into
+  /// a call chain like:
+  ///
+  ///     Iterable
+  ///         .generate(...)
+  ///         .toList();
+  ///
+  /// And instead prefer:
+  ///
+  ///     Iterable.generate(...)
+  ///         .toList();
+  ///
+  /// So we try to identify these calls syntactically. The heuristic we use is
+  /// that a target that's a capitalized name (possibly prefixed by "_") is
+  /// assumed to be a class.
+  ///
+  /// This has the effect of also keeping static method calls with the class,
+  /// but that tends to look pretty good too, and is certainly better than
+  /// splitting up named constructors.
+  static bool looksLikeStaticCall(Expression node) {
+    if (node is! MethodInvocation) return false;
+    var invocation = node as MethodInvocation;
+    if (invocation.target == null) return false;
+
+    // A prefixed unnamed constructor call:
+    //
+    //     prefix.Foo();
+    if (invocation.target is SimpleIdentifier &&
+        _looksLikeClassName(invocation.methodName.name)) {
+      return true;
+    }
+
+    // A prefixed or unprefixed named constructor call:
+    //
+    //     Foo.named();
+    //     prefix.Foo.named();
+    var target = invocation.target;
+    if (target is PrefixedIdentifier) {
+      target = (target as PrefixedIdentifier).identifier;
+    }
+
+    return target is SimpleIdentifier && _looksLikeClassName(target.name);
+  }
+
+  static bool _looksLikeClassName(String name) {
+    // Handle the weird lowercase corelib names.
+    if (name == "bool") return true;
+    if (name == "double") return true;
+    if (name == "int") return true;
+    if (name == "num") return true;
+
+    return _capitalPattern.hasMatch(name);
+  }
+
   /// The builder for the block that is currently being visited.
   ChunkBuilder builder;
 
@@ -1555,15 +1615,33 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   visitMethodInvocation(MethodInvocation node) {
     // If there's no target, this is a "bare" function call like "foo(1, 2)",
-    // or a section in a cascade. Handle this case specially.
-    if (node.target == null) {
+    // or a section in a cascade.
+    //
+    // If it looks like a constructor or static call, we want to keep the
+    // target and method together instead of including the method in the
+    // subsequent method chain. When this happens, it's important that this
+    // code here has the same rules as in [visitInstanceCreationExpression].
+    //
+    // That ensures that the way some code is formatted is not affected by the
+    // presence or absence of `new`/`const`. In particular, it means that if
+    // they run `dartfmt --fix`, and then run `dartfmt` *again*, the second run
+    // will not produce any additional changes.
+    if (node.target == null || looksLikeStaticCall(node)) {
       // Try to keep the entire method invocation one line.
-      builder.startSpan();
       builder.nestExpression();
+      builder.startSpan();
 
-      // This will be non-null for cascade sections.
+      if (node.target != null) {
+        builder.startSpan(Cost.constructorName);
+        visit(node.target);
+        soloZeroSplit();
+      }
+
+      // If target is null, this will be `..` for a cascade.
       token(node.operator);
       visit(node.methodName);
+
+      if (node.target != null) builder.endSpan();
 
       // TODO(rnystrom): Currently, there are no constraints between a generic
       // method's type arguments and arguments. That can lead to some funny
@@ -1576,11 +1654,13 @@ class SourceVisitor extends ThrowingAstVisitor {
       // The indentation is fine, but splitting in the middle of each argument
       // list looks kind of strange. If this ends up happening in real world
       // code, consider putting a constraint between them.
+      builder.nestExpression();
       visit(node.typeArguments);
       visitArgumentList(node.argumentList, nestExpression: false);
-
       builder.unnest();
+
       builder.endSpan();
+      builder.unnest();
       return;
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -366,4 +366,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.54.0 <=2.0.0-edge.9ff283218499ccc46fe7bb59f6aa4a40f31331c0"
+  dart: ">=2.0.0-dev.54.0 <=2.0.0-edge.9cfe8b844e24e14545f75b2b06a8e2f984ea97be"

--- a/test/regression/0000/0083.unit
+++ b/test/regression/0000/0083.unit
@@ -12,7 +12,8 @@ main() {
 main() {
   test('some string here', () {
     return aVeryLongFunctionThatNeedsToWrap(
-        toASecondLine, wrapWap, onThe, argsHere).then((_) {
+            toASecondLine, wrapWap, onThe, argsHere)
+        .then((_) {
       someLongFunctionHereToo(
           'value value value value value value valvalue value value value');
     });

--- a/test/regression/0100/0189.stmt
+++ b/test/regression/0100/0189.stmt
@@ -24,8 +24,7 @@
       equals(TextDirection.RTL.value));
 <<<
   expect(
-      Bidi
-          .estimateDirectionOfText(
+      Bidi.estimateDirectionOfText(
               'CAPTCHA \u05de\u05e9\u05d5\u05db\u05dc\u05dc '
               '\u05de\u05d3\u05d9?')
           .value,

--- a/test/regression/0200/0224.stmt
+++ b/test/regression/0200/0224.stmt
@@ -31,15 +31,14 @@
             ]))
         .catchError(cannotGetConveyorBeltRunning)
         .then((_) => tellEveryoneDonutsAreJustAboutDone())
-        .then((_) => Future
-            .wait([
+        .then((_) => Future.wait([
               croissantFactory.start(),
               _giantBakingOvens.start(),
               butterbutterer.start()
             ])
-            .catchError(_handleBakingFailures)
-            .timeout(scriptLoadingTimeout, onTimeout: _handleBakingFailures)
-            .catchError(cannotGetConveyorBeltRunning))
+                .catchError(_handleBakingFailures)
+                .timeout(scriptLoadingTimeout, onTimeout: _handleBakingFailures)
+                .catchError(cannotGetConveyorBeltRunning))
         .catchError(cannotGetConveyorBeltRunning)
         .then((_) {
       _logger.info("Let's eat!");

--- a/test/regression/other/angular.unit
+++ b/test/regression/other/angular.unit
@@ -54,8 +54,8 @@ class IoControllerComponent implements ScopeAware {}
 <<<
     main() {
       expect(matcher.match(
-              CssSelector
-                  .parse("someOtherTag.someOtherClass[someOtherAttr]")[0],
+              CssSelector.parse(
+                  "someOtherTag.someOtherClass[someOtherAttr]")[0],
               selectableCollector))
           .toEqual(false);
     }

--- a/test/regression/other/pkg.unit
+++ b/test/regression/other/pkg.unit
@@ -1,0 +1,19 @@
+>>> (indent 2)
+  Iterable<VariableDeclaration> createCapturedTryVariables() => Iterable
+      .generate(
+      capturedTryDepth,
+      (depth) =>
+          VariableDeclaration(ContinuationVariables.savedTryContextVar(depth)));
+<<<
+  Iterable<VariableDeclaration> createCapturedTryVariables() =>
+      Iterable.generate(
+          capturedTryDepth,
+          (depth) => VariableDeclaration(
+              ContinuationVariables.savedTryContextVar(depth)));
+>>> (indent 10)
+          TypeParameterElementImpl typeParameter = TypeParameterElementImpl
+              .forNode(AstTestFactory.identifier3(parameterNames[i]));
+<<<
+          TypeParameterElementImpl typeParameter =
+              TypeParameterElementImpl.forNode(
+                  AstTestFactory.identifier3(parameterNames[i]));

--- a/test/splitting/constructors.unit
+++ b/test/splitting/constructors.unit
@@ -162,3 +162,12 @@ class A {
   ) : parameter =
             "some very very long param";
 }
+>>> split at name if necessary
+main() {
+  new VeryLongClassName.veryLongNamedConstructor();
+}
+<<<
+main() {
+  new VeryLongClassName
+      .veryLongNamedConstructor();
+}

--- a/test/splitting/invocations.stmt
+++ b/test/splitting/invocations.stmt
@@ -289,3 +289,57 @@ function(
     .method()
     .method()
     .method();
+>>> if invocation looks like named constructor, don't put in chain
+Foo.named().method().method().method().method().method();
+<<<
+Foo.named()
+    .method()
+    .method()
+    .method()
+    .method()
+    .method();
+>>> if invocation looks like prefixed constructor, don't put in chain
+prefix.Foo().method().method().method().method().method();
+<<<
+prefix.Foo()
+    .method()
+    .method()
+    .method()
+    .method()
+    .method();
+>>> if invocation looks like prefixed named constructor, don't put in chain
+prefix.Foo.named().method().method().method().method().method();
+<<<
+prefix.Foo.named()
+    .method()
+    .method()
+    .method()
+    .method()
+    .method();
+>>> if invocation looks like private named constructor, don't put in chain
+_Foo.named().method().method().method().method().method();
+<<<
+_Foo.named()
+    .method()
+    .method()
+    .method()
+    .method()
+    .method();
+>>> if invocation looks like private prefixed constructor, don't put in chain
+prefix._Foo().method().method().method().method().method();
+<<<
+prefix._Foo()
+    .method()
+    .method()
+    .method()
+    .method()
+    .method();
+>>> if invocation looks like private prefixed named constructor, don't put in chain
+prefix._Foo.named().method().method().method().method().method();
+<<<
+prefix._Foo.named()
+    .method()
+    .method()
+    .method()
+    .method()
+    .method();


### PR DESCRIPTION
One problem with optional new is that dartfmt can no longer reliably
tell what's a constructor call versus some other kind of invocation
(usually a static method on a class). In particular, named constructor
calls do not get formatted as part of a method chain. You get this:

  new Foo().named()
      .method()
      .method()
      .method();

Not:

  new Foo()
      .named()
      .method()
      .method()
      .method();

But if that were a static method call, you *would* get:

  Foo()
      .named()
      .method()
      .method()
      .method();

This means that removing the "new"/"const" keywords from your code can
change how its formatted (beyond just the changes caused by the lines
being shorter). In particular, it means if you run:

  dartfmt --fix -w .
  dartfmt -w .

The second invocation may produce changes, even though it should be
strictly redundant. That's because the first call *does* know which
calls are constructors because the keywords are still there when it's
parsed, but the second does not.

That violates an expectation that dartfmt is idempotent.

This addresses that by having a uniform set of formatting rules for
constructors and other invocations. To avoid ugly cases where a named
constructor would get slurped into a method chain, it pulls out all
static calls from method chains. So with this change you *would* get:

  Foo().named()
      .method()
      .method()
      .method();

It does this for all static calls, not just constructors. That makes
this a fairly large change. I've run it on a large corpus, and I
actually think it looks pretty good with that style.

There is no fully reliably way to identify a "static" call just from
syntax. Instead, it uses the heuristic that class names are capitalized
(but not all caps). This seems to work correctly on all but the weirdest
code I've seen in the wild.