### PR TITLE
Don't remove "new" and "const" from dartfmt itself yet.

### DIFF
--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -25,7 +25,7 @@ void main(List<String> args) {
   // Run the benchmark several times. This ensures the VM is warmed up and lets
   // us see how much variance there is.
   for (var i = 0; i <= NUM_TRIALS; i++) {
-    var start = DateTime.now();
+    var start = new DateTime.now();
 
     // For a single benchmark, format the source multiple times.
     var result;
@@ -34,7 +34,7 @@ void main(List<String> args) {
     }
 
     var elapsed =
-        DateTime.now().difference(start).inMilliseconds / FORMATS_PER_TRIAL;
+        new DateTime.now().difference(start).inMilliseconds / FORMATS_PER_TRIAL;
 
     // Keep track of the best run so far.
     if (elapsed >= best) continue;
@@ -58,7 +58,7 @@ void main(List<String> args) {
 
 String loadFile(String name) {
   var path = p.join(p.dirname(p.fromUri(Platform.script)), name);
-  return File(path).readAsStringSync();
+  return new File(path).readAsStringSync();
 }
 
 void printResult(String label, double time) {
@@ -76,6 +76,6 @@ String padLeft(input, int length) {
 }
 
 String formatSource() {
-  var formatter = DartFormatter();
+  var formatter = new DartFormatter();
   return formatter.format(source);
 }

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -18,7 +18,7 @@ import 'package:dart_style/src/style_fix.dart';
 const version = "1.0.14";
 
 void main(List<String> args) {
-  var parser = ArgParser(allowTrailingOptions: true);
+  var parser = new ArgParser(allowTrailingOptions: true);
 
   parser.addSeparator("Common options:");
   parser.addFlag("help",
@@ -127,11 +127,11 @@ void main(List<String> args) {
   }
 
   if (argResults["profile"]) {
-    reporter = ProfileReporter(reporter);
+    reporter = new ProfileReporter(reporter);
   }
 
   if (argResults["set-exit-if-changed"]) {
-    reporter = SetExitReporter(reporter);
+    reporter = new SetExitReporter(reporter);
   }
 
   var pageWidth;
@@ -148,7 +148,7 @@ void main(List<String> args) {
 
   try {
     indent = int.parse(argResults["indent"]);
-    if (indent < 0 || indent.toInt() != indent) throw FormatException();
+    if (indent < 0 || indent.toInt() != indent) throw new FormatException();
   } on FormatException catch (_) {
     usageError(
         parser,
@@ -170,7 +170,7 @@ void main(List<String> args) {
     }
   }
 
-  var options = FormatterOptions(reporter,
+  var options = new FormatterOptions(reporter,
       indent: indent,
       pageWidth: pageWidth,
       followLinks: followLinks,
@@ -192,7 +192,7 @@ List<int> parseSelection(String selection) {
 
   var coordinates = selection.split(":");
   if (coordinates.length != 2) {
-    throw FormatException(
+    throw new FormatException(
         'Selection should be a colon-separated pair of integers, "123:45".');
   }
 
@@ -209,15 +209,15 @@ void formatStdin(FormatterOptions options, List<int> selection) {
     selectionLength = selection[1];
   }
 
-  var input = StringBuffer();
-  stdin.transform(Utf8Decoder()).listen(input.write, onDone: () {
-    var formatter = DartFormatter(
+  var input = new StringBuffer();
+  stdin.transform(new Utf8Decoder()).listen(input.write, onDone: () {
+    var formatter = new DartFormatter(
         indent: options.indent,
         pageWidth: options.pageWidth,
         fixes: options.fixes);
     try {
       options.reporter.beforeFile(null, "<stdin>");
-      var source = SourceCode(input.toString(),
+      var source = new SourceCode(input.toString(),
           uri: "stdin",
           selectionStart: selectionStart,
           selectionLength: selectionLength);
@@ -241,7 +241,7 @@ $stack''');
 /// Formats all of the files and directories given by [paths].
 void formatPaths(FormatterOptions options, List<String> paths) {
   for (var path in paths) {
-    var directory = Directory(path);
+    var directory = new Directory(path);
     if (directory.existsSync()) {
       if (!processDirectory(options, directory)) {
         exitCode = 65;
@@ -249,7 +249,7 @@ void formatPaths(FormatterOptions options, List<String> paths) {
       continue;
     }
 
-    var file = File(path);
+    var file = new File(path);
     if (file.existsSync()) {
       if (!processFile(options, file)) {
         exitCode = 65;

--- a/example/format.dart
+++ b/example/format.dart
@@ -35,7 +35,7 @@ void formatUnit(String source, [int pageWidth = 80]) {
 
 void runFormatter(String source, int pageWidth, {bool isCompilationUnit}) {
   try {
-    var formatter = DartFormatter(pageWidth: pageWidth);
+    var formatter = new DartFormatter(pageWidth: pageWidth);
 
     var result;
     if (isCompilationUnit) {
@@ -61,7 +61,7 @@ void drawRuler(String label, int width) {
 /// Runs the formatter test starting on [line] at [path] inside the "test"
 /// directory.
 void runTest(String path, int line) {
-  var indentPattern = RegExp(r"^\(indent (\d+)\)\s*");
+  var indentPattern = new RegExp(r"^\(indent (\d+)\)\s*");
 
   // Locate the "test" directory. Use mirrors so that this works with the test
   // package, which loads this suite into an isolate.
@@ -72,7 +72,7 @@ void runTest(String path, int line) {
           .path),
       "../test");
 
-  var lines = File(p.join(testDir, path)).readAsLinesSync();
+  var lines = new File(p.join(testDir, path)).readAsLinesSync();
 
   // The first line may have a "|" to indicate the page width.
   var pageWidth = 80;
@@ -121,7 +121,8 @@ void runTest(String path, int line) {
     var expected =
         _extractSelection(expectedOutput, isCompilationUnit: isCompilationUnit);
 
-    var formatter = DartFormatter(pageWidth: pageWidth, indent: leadingIndent);
+    var formatter =
+        new DartFormatter(pageWidth: pageWidth, indent: leadingIndent);
 
     var actual = formatter.formatSource(inputCode);
 
@@ -150,14 +151,14 @@ void runTest(String path, int line) {
 /// Given a source string that contains ‹ and › to indicate a selection, returns
 /// a [SourceCode] with the text (with the selection markers removed) and the
 /// correct selection range.
-SourceCode _extractSelection(String source, {bool isCompilationUnit = false}) {
+SourceCode _extractSelection(String source, {bool isCompilationUnit: false}) {
   var start = source.indexOf("‹");
   source = source.replaceAll("‹", "");
 
   var end = source.indexOf("›");
   source = source.replaceAll("›", "");
 
-  return SourceCode(source,
+  return new SourceCode(source,
       isCompilationUnit: isCompilationUnit,
       selectionStart: start == -1 ? null : start,
       selectionLength: end == -1 ? null : end - start);

--- a/lib/src/argument_list_visitor.dart
+++ b/lib/src/argument_list_visitor.dart
@@ -57,7 +57,7 @@ class ArgumentListVisitor {
       _arguments._blocks.isNotEmpty || _functions != null;
 
   factory ArgumentListVisitor(SourceVisitor visitor, ArgumentList node) {
-    return ArgumentListVisitor.forArguments(
+    return new ArgumentListVisitor.forArguments(
         visitor, node.leftParenthesis, node.rightParenthesis, node.arguments);
   }
 
@@ -147,8 +147,14 @@ class ArgumentListVisitor {
 
     if (functionsStart == null) {
       // No functions, so there is just a single argument list.
-      return ArgumentListVisitor._(visitor, leftParenthesis, rightParenthesis,
-          arguments, ArgumentSublist(arguments, arguments), null, null);
+      return new ArgumentListVisitor._(
+          visitor,
+          leftParenthesis,
+          rightParenthesis,
+          arguments,
+          new ArgumentSublist(arguments, arguments),
+          null,
+          null);
     }
 
     // Split the arguments into two independent argument lists with the
@@ -157,14 +163,14 @@ class ArgumentListVisitor {
     var functions = arguments.sublist(functionsStart, functionsEnd);
     var argumentsAfter = arguments.skip(functionsEnd).toList();
 
-    return ArgumentListVisitor._(
+    return new ArgumentListVisitor._(
         visitor,
         leftParenthesis,
         rightParenthesis,
         arguments,
-        ArgumentSublist(arguments, argumentsBefore),
+        new ArgumentSublist(arguments, argumentsBefore),
         functions,
-        ArgumentSublist(arguments, argumentsAfter));
+        new ArgumentSublist(arguments, argumentsAfter));
   }
 
   ArgumentListVisitor._(
@@ -364,7 +370,7 @@ class ArgumentSublist {
       blocks.clear();
     }
 
-    return ArgumentSublist._(
+    return new ArgumentSublist._(
         allArguments, positional, named, blocks, leadingBlocks, trailingBlocks);
   }
 
@@ -373,7 +379,7 @@ class ArgumentSublist {
 
   void visit(SourceVisitor visitor) {
     if (_blocks.isNotEmpty) {
-      _blockRule = Rule(Cost.splitBlocks);
+      _blockRule = new Rule(Cost.splitBlocks);
     }
 
     var rule = _visitPositional(visitor);
@@ -388,7 +394,7 @@ class ArgumentSublist {
     // Only count the blocks in the positional rule.
     var leadingBlocks = math.min(_leadingBlocks, _positional.length);
     var trailingBlocks = math.max(_trailingBlocks - _named.length, 0);
-    var rule = PositionalRule(_blockRule, leadingBlocks, trailingBlocks);
+    var rule = new PositionalRule(_blockRule, leadingBlocks, trailingBlocks);
     _visitArguments(visitor, _positional, rule);
 
     return rule;
@@ -401,7 +407,7 @@ class ArgumentSublist {
     // Only count the blocks in the named rule.
     var leadingBlocks = math.max(_leadingBlocks - _positional.length, 0);
     var trailingBlocks = math.min(_trailingBlocks, _named.length);
-    var namedRule = NamedRule(_blockRule, leadingBlocks, trailingBlocks);
+    var namedRule = new NamedRule(_blockRule, leadingBlocks, trailingBlocks);
 
     // Let the positional args force the named ones to split.
     if (positionalRule != null) {

--- a/lib/src/call_chain_visitor.dart
+++ b/lib/src/call_chain_visitor.dart
@@ -157,7 +157,7 @@ class CallChainVisitor {
       // See if this call is a method call whose arguments are block formatted.
       var isBlockCall = false;
       if (call is MethodInvocation) {
-        var args = ArgumentListVisitor(visitor, call.argumentList);
+        var args = new ArgumentListVisitor(visitor, call.argumentList);
         isBlockCall = args.hasBlockArguments;
       }
 
@@ -187,7 +187,7 @@ class CallChainVisitor {
       calls.remove(hangingCall);
     }
 
-    return CallChainVisitor._(
+    return new CallChainVisitor._(
         visitor, target, properties, calls, blockCalls, hangingCall);
   }
 
@@ -214,7 +214,7 @@ class CallChainVisitor {
 
     if (splitOnTarget) {
       if (_properties.length > 1) {
-        _propertyRule = PositionalRule(null, 0, 0);
+        _propertyRule = new PositionalRule(null, 0, 0);
         _visitor.builder.startLazyRule(_propertyRule);
       } else {
         _enableRule(lazy: true);
@@ -230,7 +230,7 @@ class CallChainVisitor {
       _writeCall(_properties.single);
     } else if (_properties.length > 1) {
       if (!splitOnTarget) {
-        _propertyRule = PositionalRule(null, 0, 0);
+        _propertyRule = new PositionalRule(null, 0, 0);
         _visitor.builder.startRule(_propertyRule);
       }
 
@@ -432,11 +432,11 @@ class CallChainVisitor {
   }
 
   /// Creates a new method chain [Rule] if one is not already active.
-  void _enableRule({bool lazy = false}) {
+  void _enableRule({bool lazy: false}) {
     if (_ruleEnabled) return;
 
     // If the properties split, force the calls to split too.
-    var rule = Rule();
+    var rule = new Rule();
     if (_propertyRule != null) _propertyRule.setNamedArgsRule(rule);
 
     if (lazy) {

--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -225,7 +225,7 @@ class Chunk extends Selection {
   /// Turns this chunk into one that can contain a block of child chunks.
   void makeBlock(Chunk blockArgument) {
     assert(_block == null);
-    _block = ChunkBlock(blockArgument);
+    _block = new ChunkBlock(blockArgument);
   }
 
   /// Returns `true` if the block body owned by this chunk should be expression

--- a/lib/src/chunk_builder.dart
+++ b/lib/src/chunk_builder.dart
@@ -15,7 +15,7 @@ import 'source_code.dart';
 import 'whitespace.dart';
 
 /// Matches if the last character of a string is an identifier character.
-final _trailingIdentifierChar = RegExp(r"[a-zA-Z0-9_]$");
+final _trailingIdentifierChar = new RegExp(r"[a-zA-Z0-9_]$");
 
 /// Takes the incremental serialized output of [SourceVisitor]--the source text
 /// along with any comments and preserved whitespace--and produces a coherent
@@ -58,7 +58,7 @@ class ChunkBuilder {
   /// the hard split appears. For example, a hard split in a positional
   /// argument list needs to force the named arguments to split too, but we
   /// don't create that rule until after the positional arguments are done.
-  final _hardSplitRules = Set<Rule>();
+  final _hardSplitRules = new Set<Rule>();
 
   /// The list of rules that are waiting until the next whitespace has been
   /// written before they start.
@@ -68,7 +68,7 @@ class ChunkBuilder {
   final _openSpans = <OpenSpan>[];
 
   /// The current state.
-  final _nesting = NestingBuilder();
+  final _nesting = new NestingBuilder();
 
   /// The stack of nesting levels where block arguments may start.
   ///
@@ -362,7 +362,7 @@ class ChunkBuilder {
   ///
   /// Each call to this needs a later matching call to [endSpan].
   void startSpan([int cost = Cost.normal]) {
-    _openSpans.add(OpenSpan(_currentChunkIndex, cost));
+    _openSpans.add(new OpenSpan(_currentChunkIndex, cost));
   }
 
   /// Ends the innermost span.
@@ -374,7 +374,7 @@ class ChunkBuilder {
     if (openSpan.start == end) return;
 
     // Add the span to every chunk that can split it.
-    var span = Span(openSpan.cost);
+    var span = new Span(openSpan.cost);
     for (var i = openSpan.start; i < end; i++) {
       var chunk = _chunks[i];
       if (!chunk.rule.isHardened) chunk.spans.add(span);
@@ -385,7 +385,7 @@ class ChunkBuilder {
   ///
   /// If omitted, defaults to a new [Rule].
   void startRule([Rule rule]) {
-    if (rule == null) rule = Rule();
+    if (rule == null) rule = new Rule();
 
     // If there are any pending lazy rules, start them now so that the proper
     // stack ordering of rules is maintained.
@@ -413,7 +413,7 @@ class ChunkBuilder {
   ///
   /// If [rule] is omitted, defaults to a new [Rule].
   void startLazyRule([Rule rule]) {
-    if (rule == null) rule = Rule();
+    if (rule == null) rule = new Rule();
 
     _lazyRules.add(rule);
   }
@@ -504,7 +504,8 @@ class ChunkBuilder {
     var chunk = _chunks.last;
     chunk.makeBlock(argumentChunk);
 
-    var builder = ChunkBuilder._(this, _formatter, _source, chunk.block.chunks);
+    var builder =
+        new ChunkBuilder._(this, _formatter, _source, chunk.block.chunks);
 
     // A block always starts off indented one level.
     builder.indent();
@@ -576,7 +577,7 @@ class ChunkBuilder {
       debug.log();
     }
 
-    var writer = LineWriter(_formatter, _chunks);
+    var writer = new LineWriter(_formatter, _chunks);
     var result = writer.writeLines(_formatter.indent,
         isCompilationUnit: _source.isCompilationUnit);
 
@@ -594,7 +595,7 @@ class ChunkBuilder {
       selectionLength = selectionEnd - selectionStart;
     }
 
-    return SourceCode(result.text,
+    return new SourceCode(result.text,
         uri: _source.uri,
         isCompilationUnit: _source.isCompilationUnit,
         selectionStart: selectionStart,
@@ -736,10 +737,10 @@ class ChunkBuilder {
   /// If [flushLeft] is `true`, then the split will always cause the next line
   /// to be at column zero. Otherwise, it uses the normal indentation and
   /// nesting behavior.
-  void _writeHardSplit({bool isDouble, bool flushLeft, bool nest = false}) {
+  void _writeHardSplit({bool isDouble, bool flushLeft, bool nest: false}) {
     // A hard split overrides any other whitespace.
     _pendingWhitespace = null;
-    _writeSplit(Rule.hard(),
+    _writeSplit(new Rule.hard(),
         flushLeft: flushLeft, isDouble: isDouble, nest: nest);
   }
 
@@ -756,8 +757,8 @@ class ChunkBuilder {
       return null;
     }
 
-    _chunks.last.applySplit(
-        rule, _nesting.indentation, nest ? _nesting.nesting : NestingLevel(),
+    _chunks.last.applySplit(rule, _nesting.indentation,
+        nest ? _nesting.nesting : new NestingLevel(),
         flushLeft: flushLeft, isDouble: isDouble, space: space);
 
     if (_chunks.last.rule.isHardened) _handleHardSplit();
@@ -770,7 +771,7 @@ class ChunkBuilder {
     if (_chunks.isNotEmpty && _chunks.last.canAddText) {
       _chunks.last.appendText(text);
     } else {
-      _chunks.add(Chunk(text));
+      _chunks.add(new Chunk(text));
     }
   }
 

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -36,7 +36,7 @@ class DartFormatter {
   /// The number of characters of indentation to prefix the output lines with.
   final int indent;
 
-  final Set<StyleFix> fixes = Set();
+  final Set<StyleFix> fixes = new Set();
 
   /// Creates a new formatter for Dart code.
   ///
@@ -68,16 +68,17 @@ class DartFormatter {
     } else if (uri is String) {
       // Do nothing.
     } else {
-      throw ArgumentError("uri must be `null`, a Uri, or a String.");
+      throw new ArgumentError("uri must be `null`, a Uri, or a String.");
     }
 
-    return formatSource(SourceCode(source, uri: uri, isCompilationUnit: true))
+    return formatSource(
+            new SourceCode(source, uri: uri, isCompilationUnit: true))
         .text;
   }
 
   /// Formats the given [source] string containing a single Dart statement.
   String formatStatement(String source) {
-    return formatSource(SourceCode(source, isCompilationUnit: false)).text;
+    return formatSource(new SourceCode(source, isCompilationUnit: false)).text;
   }
 
   /// Formats the given [source].
@@ -85,14 +86,14 @@ class DartFormatter {
   /// Returns a new [SourceCode] containing the formatted code and the resulting
   /// selection, if any.
   SourceCode formatSource(SourceCode source) {
-    var errorListener = ErrorListener();
+    var errorListener = new ErrorListener();
 
     // Tokenize the source.
-    var reader = CharSequenceReader(source.text);
-    var stringSource = StringSource(source.text, source.uri);
-    var scanner = Scanner(stringSource, reader, errorListener);
+    var reader = new CharSequenceReader(source.text);
+    var stringSource = new StringSource(source.text, source.uri);
+    var scanner = new Scanner(stringSource, reader, errorListener);
     var startToken = scanner.tokenize();
-    var lineInfo = LineInfo(scanner.lineStarts);
+    var lineInfo = new LineInfo(scanner.lineStarts);
 
     // Infer the line ending if not given one. Do it here since now we know
     // where the lines start.
@@ -110,7 +111,7 @@ class DartFormatter {
     errorListener.throwIfErrors();
 
     // Parse it.
-    var parser = Parser(stringSource, errorListener);
+    var parser = new Parser(stringSource, errorListener);
     parser.enableOptionalNewAndConst = true;
 
     AstNode node;
@@ -122,27 +123,27 @@ class DartFormatter {
       // Make sure we consumed all of the source.
       var token = node.endToken.next;
       if (token.type != TokenType.EOF) {
-        var error = AnalysisError(
+        var error = new AnalysisError(
             stringSource,
             token.offset,
             math.max(token.length, 1),
             ParserErrorCode.UNEXPECTED_TOKEN,
             [token.lexeme]);
 
-        throw FormatterException([error]);
+        throw new FormatterException([error]);
       }
     }
 
     errorListener.throwIfErrors();
 
     // Format it.
-    var visitor = SourceVisitor(this, lineInfo, source);
+    var visitor = new SourceVisitor(this, lineInfo, source);
     var output = visitor.run(node);
 
     // Sanity check that only whitespace was changed if that's all we expect.
     if (fixes.isEmpty &&
         !string_compare.equalIgnoringWhitespace(source.text, output.text)) {
-      throw UnexpectedOutputException(source.text, output.text);
+      throw new UnexpectedOutputException(source.text, output.text);
     }
 
     return output;

--- a/lib/src/debug.dart
+++ b/lib/src/debug.dart
@@ -71,7 +71,7 @@ void dumpChunks(int start, List<Chunk> chunks) {
 
   // Show the spans as vertical bands over their range (unless there are too
   // many).
-  var spanSet = Set<Span>();
+  var spanSet = new Set<Span>();
   addSpans(List<Chunk> chunks) {
     for (var chunk in chunks) {
       spanSet.addAll(chunk.spans);
@@ -171,14 +171,14 @@ void dumpChunks(int start, List<Chunk> chunks) {
     addChunk(chunks, "", i);
   }
 
-  var rowWidths = List.filled(rows.first.length, 0);
+  var rowWidths = new List.filled(rows.first.length, 0);
   for (var row in rows) {
     for (var i = 0; i < row.length; i++) {
       rowWidths[i] = math.max(rowWidths[i], row[i].length);
     }
   }
 
-  var buffer = StringBuffer();
+  var buffer = new StringBuffer();
   for (var row in rows) {
     for (var i = 0; i < row.length; i++) {
       var cell = row[i].padRight(rowWidths[i]);
@@ -227,7 +227,7 @@ void dumpConstraints(List<Chunk> chunks) {
 /// It will determine how best to split it into multiple lines of output and
 /// return a single string that may contain one or more newline characters.
 void dumpLines(List<Chunk> chunks, int firstLineIndent, SplitSet splits) {
-  var buffer = StringBuffer();
+  var buffer = new StringBuffer();
 
   writeIndent(indent) => buffer.write(gray("| " * (indent ~/ 2)));
 

--- a/lib/src/error_listener.dart
+++ b/lib/src/error_listener.dart
@@ -20,6 +20,6 @@ class ErrorListener implements AnalysisErrorListener {
   void throwIfErrors() {
     if (_errors.isEmpty) return;
 
-    throw FormatterException(_errors);
+    throw new FormatterException(_errors);
   }
 }

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -18,7 +18,7 @@ class FormatterException implements Exception {
 
   /// Creates a human-friendly representation of the analysis errors.
   String message({bool color}) {
-    var buffer = StringBuffer();
+    var buffer = new StringBuffer();
     buffer.writeln("Could not format because the source could not be parsed:");
 
     // In case we get a huge series of cascaded errors, just show the first few.
@@ -35,7 +35,7 @@ class FormatterException implements Exception {
         source += " " * (error.offset + error.length - source.length);
       }
 
-      var file = SourceFile.fromString(source, url: error.source.fullName);
+      var file = new SourceFile.fromString(source, url: error.source.fullName);
       var span = file.span(error.offset, error.offset + error.length);
       if (buffer.isNotEmpty) buffer.writeln();
       buffer.write(span.message(error.message, color: color));

--- a/lib/src/formatter_options.dart
+++ b/lib/src/formatter_options.dart
@@ -29,9 +29,9 @@ class FormatterOptions {
   final Iterable<StyleFix> fixes;
 
   FormatterOptions(this.reporter,
-      {this.indent = 0,
-      this.pageWidth = 80,
-      this.followLinks = false,
+      {this.indent: 0,
+      this.pageWidth: 80,
+      this.followLinks: false,
       this.fixes});
 }
 
@@ -39,17 +39,17 @@ class FormatterOptions {
 abstract class OutputReporter {
   /// Prints only the names of files whose contents are different from their
   /// formatted version.
-  static final OutputReporter dryRun = _DryRunReporter();
+  static final OutputReporter dryRun = new _DryRunReporter();
 
   /// Prints the formatted results of each file to stdout.
-  static final OutputReporter print = _PrintReporter();
+  static final OutputReporter print = new _PrintReporter();
 
   /// Prints the formatted result and selection info of each file to stdout as
   /// a JSON map.
-  static final OutputReporter printJson = _PrintJsonReporter();
+  static final OutputReporter printJson = new _PrintJsonReporter();
 
   /// Overwrites each file with its formatted result.
-  static final OutputReporter overwrite = _OverwriteReporter();
+  static final OutputReporter overwrite = new _OverwriteReporter();
 
   /// Describe the directory whose contents are about to be processed.
   void showDirectory(String path) {}
@@ -200,7 +200,7 @@ class ProfileReporter extends _ReporterDecorator {
   /// Called when [file] is about to be formatted.
   void beforeFile(File file, String label) {
     super.beforeFile(file, label);
-    _ongoing[label] = DateTime.now();
+    _ongoing[label] = new DateTime.now();
   }
 
   /// Describe the processed file at [path] whose formatted result is [output].
@@ -208,7 +208,7 @@ class ProfileReporter extends _ReporterDecorator {
   /// If the contents of the file are the same as the formatted output,
   /// [changed] will be false.
   void afterFile(File file, String label, SourceCode output, {bool changed}) {
-    var elapsed = DateTime.now().difference(_ongoing.remove(label));
+    var elapsed = new DateTime.now().difference(_ongoing.remove(label));
     if (elapsed.inMilliseconds >= 10) {
       _elapsed[label] = elapsed;
     } else {

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -22,7 +22,7 @@ bool processDirectory(FormatterOptions options, Directory directory) {
   options.reporter.showDirectory(directory.path);
 
   var success = true;
-  var shownHiddenPaths = Set<String>();
+  var shownHiddenPaths = new Set<String>();
 
   for (var entry in directory.listSync(
       recursive: true, followLinks: options.followLinks)) {
@@ -67,12 +67,12 @@ bool processDirectory(FormatterOptions options, Directory directory) {
 bool processFile(FormatterOptions options, File file, {String label}) {
   if (label == null) label = file.path;
 
-  var formatter = DartFormatter(
+  var formatter = new DartFormatter(
       indent: options.indent,
       pageWidth: options.pageWidth,
       fixes: options.fixes);
   try {
-    var source = SourceCode(file.readAsStringSync(), uri: file.path);
+    var source = new SourceCode(file.readAsStringSync(), uri: file.path);
     options.reporter.beforeFile(file, label);
     var output = formatter.formatSource(source);
     options.reporter

--- a/lib/src/line_splitting/line_splitter.dart
+++ b/lib/src/line_splitting/line_splitter.dart
@@ -119,7 +119,7 @@ class LineSplitter {
   /// This is sorted lowest-cost first. This ensures that as soon as we find a
   /// solution that fits in the page, we know it will be the lowest cost one
   /// and can stop looking.
-  final _queue = SolveStateQueue();
+  final _queue = new SolveStateQueue();
 
   /// The lowest cost solution found so far.
   SolveState _bestSolution;
@@ -128,7 +128,7 @@ class LineSplitter {
   /// page width.
   LineSplitter(this.writer, List<Chunk> chunks, int blockIndentation,
       int firstLineIndent,
-      {bool flushLeft = false})
+      {bool flushLeft: false})
       : chunks = chunks,
         // Collect the set of rules that we need to select values for.
         rules = chunks
@@ -163,7 +163,7 @@ class LineSplitter {
   /// first line of output with.
   SplitSet apply() {
     // Start with a completely unbound, unsplit solution.
-    _queue.add(SolveState(this, RuleSet(rules.length)));
+    _queue.add(new SolveState(this, new RuleSet(rules.length)));
 
     var attempts = 0;
     while (_queue.isNotEmpty) {

--- a/lib/src/line_splitting/rule_set.dart
+++ b/lib/src/line_splitting/rule_set.dart
@@ -18,7 +18,7 @@ import '../rule/rule.dart';
 class RuleSet {
   List<int> _values;
 
-  RuleSet(int numRules) : this._(List(numRules));
+  RuleSet(int numRules) : this._(new List(numRules));
 
   RuleSet._(this._values);
 
@@ -53,7 +53,7 @@ class RuleSet {
   }
 
   /// Creates a new [RuleSet] with the same bound rule values as this one.
-  RuleSet clone() => RuleSet._(_values.toList(growable: false));
+  RuleSet clone() => new RuleSet._(_values.toList(growable: false));
 
   /// Binds [rule] to [value] then checks to see if that violates any
   /// constraints.
@@ -137,7 +137,7 @@ class SplitSet {
   int _cost;
 
   /// Creates a new empty split set for a line with [numChunks].
-  SplitSet(int numChunks) : _columns = List(numChunks - 1);
+  SplitSet(int numChunks) : _columns = new List(numChunks - 1);
 
   /// Marks the line after chunk [index] as starting at [column].
   void add(int index, int column) {

--- a/lib/src/line_splitting/solve_state.dart
+++ b/lib/src/line_splitting/solve_state.dart
@@ -63,7 +63,7 @@ class SolveState {
   /// There is one other set of rules that go in here. Sometimes a bound rule
   /// in the solve state constrains some other unbound rule to split. In that
   /// case, we also consider that active so we know to not leave it at zero.
-  final _liveRules = Set<Rule>();
+  final _liveRules = new Set<Rule>();
 
   /// The set of splits chosen for this state.
   SplitSet get splits => _splits;
@@ -205,7 +205,7 @@ class SolveState {
           // Make sure we don't violate the constraints of the bound rules.
           if (!valid) continue;
 
-          var state = SolveState(_splitter, boundRules);
+          var state = new SolveState(_splitter, boundRules);
 
           // If some unbound rules are constrained to split, remember that.
           if (mustSplitRules != null) {
@@ -281,7 +281,7 @@ class SolveState {
   void _calculateSplits() {
     // Figure out which expression nesting levels got split and need to be
     // assigned columns.
-    var usedNestingLevels = Set<NestingLevel>();
+    var usedNestingLevels = new Set<NestingLevel>();
     for (var i = 0; i < _splitter.chunks.length - 1; i++) {
       var chunk = _splitter.chunks[i];
       if (chunk.rule.isSplit(getValue(chunk.rule), chunk)) {
@@ -294,7 +294,7 @@ class SolveState {
       nesting.refreshTotalUsedIndent(usedNestingLevels);
     }
 
-    _splits = SplitSet(_splitter.chunks.length);
+    _splits = new SplitSet(_splitter.chunks.length);
     for (var i = 0; i < _splitter.chunks.length - 1; i++) {
       var chunk = _splitter.chunks[i];
       if (chunk.rule.isSplit(getValue(chunk.rule), chunk)) {
@@ -354,7 +354,7 @@ class SolveState {
     // The set of spans that contain chunks that ended up splitting. We store
     // these in a set so a span's cost doesn't get double-counted if more than
     // one split occurs in it.
-    var splitSpans = Set();
+    var splitSpans = new Set();
 
     // The nesting level of the chunk that ended the previous line.
     var previousNesting;
@@ -454,9 +454,9 @@ class SolveState {
   void _ensureBoundRulesInUnboundLines() {
     if (_boundRulesInUnboundLines != null) return;
 
-    _boundRulesInUnboundLines = Set<Rule>();
+    _boundRulesInUnboundLines = new Set<Rule>();
 
-    var boundInLine = Set<Rule>();
+    var boundInLine = new Set<Rule>();
     var hasUnbound = false;
 
     for (var i = 0; i < _splitter.chunks.length - 1; i++) {
@@ -488,8 +488,8 @@ class SolveState {
   void _ensureConstraints() {
     if (_constraints != null) return;
 
-    _unboundRules = Set();
-    _boundRules = Set();
+    _unboundRules = new Set();
+    _boundRules = new Set();
 
     for (var rule in _splitter.rules) {
       if (_ruleValues.contains(rule)) {
@@ -553,7 +553,7 @@ class SolveState {
           }
 
           if (disallowedValues == null) {
-            disallowedValues = Set<int>();
+            disallowedValues = new Set<int>();
             _unboundConstraints[unbound] = disallowedValues;
           }
 
@@ -564,7 +564,7 @@ class SolveState {
   }
 
   String toString() {
-    var buffer = StringBuffer();
+    var buffer = new StringBuffer();
 
     buffer.writeAll(_splitter.rules.map((rule) {
       var valueLength = "${rule.fullySplitValue}".length;

--- a/lib/src/line_splitting/solve_state_queue.dart
+++ b/lib/src/line_splitting/solve_state_queue.dart
@@ -25,7 +25,7 @@ class SolveStateQueue {
   LineSplitter _splitter;
 
   /// List implementation of a heap.
-  List<SolveState> _queue = List<SolveState>(_INITIAL_CAPACITY);
+  List<SolveState> _queue = new List<SolveState>(_INITIAL_CAPACITY);
 
   /// Number of elements in queue.
   /// The heap is implemented in the first [_length] entries of [_queue].
@@ -50,7 +50,7 @@ class SolveStateQueue {
       var newCapacity = _queue.length * 2 + 1;
       if (newCapacity < _INITIAL_CAPACITY) newCapacity = _INITIAL_CAPACITY;
 
-      var newQueue = List<SolveState>(newCapacity);
+      var newQueue = new List<SolveState>(newCapacity);
       newQueue.setRange(0, _length, _queue);
       _queue = newQueue;
     }

--- a/lib/src/line_writer.dart
+++ b/lib/src/line_writer.dart
@@ -13,7 +13,7 @@ import 'whitespace.dart';
 /// Given a series of chunks, splits them into lines and writes the result to
 /// a buffer.
 class LineWriter {
-  final _buffer = StringBuffer();
+  final _buffer = new StringBuffer();
 
   final List<Chunk> _chunks;
 
@@ -75,13 +75,13 @@ class LineWriter {
   ///
   /// When we format the anonymous lambda, [column] will be 2, not 4.
   FormatResult formatBlock(Chunk chunk, int column) {
-    var key = _BlockKey(chunk, column);
+    var key = new _BlockKey(chunk, column);
 
     // Use the cached one if we have it.
     var cached = _blockCache[key];
     if (cached != null) return cached;
 
-    var writer = LineWriter._(
+    var writer = new LineWriter._(
         chunk.block.chunks, _lineEnding, pageWidth, column, _blockCache);
 
     // TODO(rnystrom): Passing in an initial indent here is hacky. The
@@ -97,7 +97,7 @@ class LineWriter {
   /// Since this is linear and line splitting is worse it's good to feed the
   /// line splitter smaller lists of chunks when possible.
   FormatResult writeLines(int firstLineIndent,
-      {bool isCompilationUnit = false, bool flushLeft = false}) {
+      {bool isCompilationUnit: false, bool flushLeft: false}) {
     // Now that we know what hard splits there will be, break the chunks into
     // independently splittable lines.
     var newlines = 0;
@@ -127,7 +127,7 @@ class LineWriter {
     // Be a good citizen, end with a newline.
     if (isCompilationUnit) _buffer.write(_lineEnding);
 
-    return FormatResult(
+    return new FormatResult(
         _buffer.toString(), totalCost, _selectionStart, _selectionEnd);
   }
 
@@ -149,7 +149,7 @@ class LineWriter {
     }
 
     // Run the line splitter.
-    var splitter = LineSplitter(this, chunks, _blockIndentation, indent,
+    var splitter = new LineSplitter(this, chunks, _blockIndentation, indent,
         flushLeft: flushLeft);
     var splits = splitter.apply();
 

--- a/lib/src/nesting_builder.dart
+++ b/lib/src/nesting_builder.dart
@@ -58,7 +58,7 @@ class NestingBuilder {
 
   /// The current nesting, ignoring any pending nesting.
   NestingLevel get nesting => _nesting;
-  NestingLevel _nesting = NestingLevel();
+  NestingLevel _nesting = new NestingLevel();
 
   /// The current nesting, including any pending nesting.
   NestingLevel get currentNesting =>

--- a/lib/src/nesting_level.dart
+++ b/lib/src/nesting_level.dart
@@ -48,7 +48,7 @@ class NestingLevel extends FastHash {
 
   /// Creates a new deeper level of nesting indented [spaces] more characters
   /// that the outer level.
-  NestingLevel nest(int spaces) => NestingLevel._(this, spaces);
+  NestingLevel nest(int spaces) => new NestingLevel._(this, spaces);
 
   /// Clears the previously calculated total indent of this nesting level.
   void clearTotalUsedIndent() {

--- a/lib/src/rule/combinator.dart
+++ b/lib/src/rule/combinator.dart
@@ -46,7 +46,7 @@ import 'rule.dart';
 /// the beginning of the line.
 class CombinatorRule extends Rule {
   /// The set of chunks before the combinators.
-  final Set<Chunk> _combinators = Set();
+  final Set<Chunk> _combinators = new Set();
 
   /// A list of sets of chunks prior to each name in a combinator.
   ///
@@ -72,7 +72,7 @@ class CombinatorRule extends Rule {
   /// This must be called before adding any names.
   void addCombinator(Chunk chunk) {
     _combinators.add(chunk);
-    _names.add(Set());
+    _names.add(new Set());
   }
 
   /// Adds a chunk prior to a name to the current combinator.

--- a/lib/src/rule/rule.dart
+++ b/lib/src/rule/rule.dart
@@ -59,7 +59,7 @@ class Rule extends FastHash {
   ///
   /// This contains all direct as well as transitive relationships. If A
   /// contains B which contains C, C's outerRules contains both B and A.
-  final Set<Rule> _implied = Set<Rule>();
+  final Set<Rule> _implied = new Set<Rule>();
 
   /// Marks [other] as implied by this one.
   ///
@@ -172,7 +172,7 @@ class Rule extends FastHash {
         rule.constrainedRules.forEach(visit);
       }
 
-      _allConstrainedRules = Set();
+      _allConstrainedRules = new Set();
       visit(this);
     }
 

--- a/lib/src/source_code.dart
+++ b/lib/src/source_code.dart
@@ -51,32 +51,32 @@ class SourceCode {
 
   SourceCode(this.text,
       {this.uri,
-      this.isCompilationUnit = true,
+      this.isCompilationUnit: true,
       this.selectionStart,
       this.selectionLength}) {
     // Must either provide both selection bounds or neither.
     if ((selectionStart == null) != (selectionLength == null)) {
-      throw ArgumentError(
+      throw new ArgumentError(
           "Is selectionStart is provided, selectionLength must be too.");
     }
 
     if (selectionStart != null) {
       if (selectionStart < 0) {
-        throw ArgumentError("selectionStart must be non-negative.");
+        throw new ArgumentError("selectionStart must be non-negative.");
       }
 
       if (selectionStart > text.length) {
-        throw ArgumentError("selectionStart must be within text.");
+        throw new ArgumentError("selectionStart must be within text.");
       }
     }
 
     if (selectionLength != null) {
       if (selectionLength < 0) {
-        throw ArgumentError("selectionLength must be non-negative.");
+        throw new ArgumentError("selectionLength must be non-negative.");
       }
 
       if (selectionStart + selectionLength > text.length) {
-        throw ArgumentError("selectionLength must end within text.");
+        throw new ArgumentError("selectionLength must end within text.");
       }
     }
   }

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -22,7 +22,7 @@ import 'source_code.dart';
 import 'style_fix.dart';
 import 'whitespace.dart';
 
-final _capitalPattern = RegExp(r"^_?[A-Z].*[a-z]");
+final _capitalPattern = new RegExp(r"^_?[A-Z].*[a-z]");
 
 /// Visits every token of the AST and passes all of the relevant bits to a
 /// [ChunkBuilder].
@@ -149,7 +149,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   /// Initialize a newly created visitor to write source code representing
   /// the visited nodes to the given [writer].
   SourceVisitor(this._formatter, this._lineInfo, this._source) {
-    builder = ChunkBuilder(_formatter, _source);
+    builder = new ChunkBuilder(_formatter, _source);
   }
 
   /// Runs the visitor on [node], formatting its contents.
@@ -198,7 +198,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   /// 4. Split between one or more positional arguments, trying to keep as many
   ///    on earlier lines as possible.
   /// 5. Split the named arguments each onto their own line.
-  visitArgumentList(ArgumentList node, {bool nestExpression = true}) {
+  visitArgumentList(ArgumentList node, {bool nestExpression: true}) {
     // Corner case: handle empty argument lists.
     if (node.arguments.isEmpty) {
       token(node.leftParenthesis);
@@ -220,7 +220,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     }
 
     if (nestExpression) builder.nestExpression();
-    ArgumentListVisitor(this, node).visit();
+    new ArgumentListVisitor(this, node).visit();
     if (nestExpression) builder.unnest();
   }
 
@@ -243,7 +243,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     if (node.message != null) arguments.add(node.message);
 
     builder.nestExpression();
-    var visitor = ArgumentListVisitor.forArguments(
+    var visitor = new ArgumentListVisitor.forArguments(
         this, node.leftParenthesis, node.rightParenthesis, arguments);
     visitor.visit();
     builder.unnest();
@@ -256,7 +256,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       var arguments = [node.condition];
       if (node.message != null) arguments.add(node.message);
 
-      var visitor = ArgumentListVisitor.forArguments(
+      var visitor = new ArgumentListVisitor.forArguments(
           this, node.leftParenthesis, node.rightParenthesis, arguments);
       visitor.visit();
     });
@@ -421,7 +421,8 @@ class SourceVisitor extends ThrowingAstVisitor {
     // If the cascade sections have consistent names they can be broken
     // normally otherwise they always get their own line.
     if (splitIfOperandsSplit) {
-      builder.startLazyRule(_allowInlineCascade(node) ? Rule() : Rule.hard());
+      builder.startLazyRule(
+          _allowInlineCascade(node) ? new Rule() : new Rule.hard());
     }
 
     // If the target of the cascade is a method call (or chain of them), we
@@ -444,7 +445,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     //           ..cascade()
     //           ..cascade();
     if (node.target is MethodInvocation) {
-      CallChainVisitor(this, node.target).visit(unnest: false);
+      new CallChainVisitor(this, node.target).visit(unnest: false);
     } else {
       visit(node.target);
     }
@@ -455,7 +456,8 @@ class SourceVisitor extends ThrowingAstVisitor {
     // If the cascade section shouldn't cause the cascade to split, end the
     // rule early so it isn't affected by it.
     if (!splitIfOperandsSplit) {
-      builder.startRule(_allowInlineCascade(node) ? Rule() : Rule.hard());
+      builder
+          .startRule(_allowInlineCascade(node) ? new Rule() : new Rule.hard());
     }
 
     zeroSplit();
@@ -578,7 +580,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     visit(node.typeParameters);
     visit(node.extendsClause);
 
-    builder.startRule(CombinatorRule());
+    builder.startRule(new CombinatorRule());
     visit(node.withClause);
     visit(node.implementsClause);
     builder.endRule();
@@ -638,7 +640,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
       visit(node.superclass);
 
-      builder.startRule(CombinatorRule());
+      builder.startRule(new CombinatorRule());
       visit(node.withClause);
       visit(node.implementsClause);
       builder.endRule();
@@ -989,7 +991,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
       _visitConfigurations(node.configurations);
 
-      builder.startRule(CombinatorRule());
+      builder.startRule(new CombinatorRule());
       visitNodes(node.combinators);
       builder.endRule();
     });
@@ -1054,7 +1056,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   visitFieldFormalParameter(FieldFormalParameter node) {
     visitParameterMetadata(node.metadata, () {
-      builder.startLazyRule(Rule(Cost.parameterType));
+      builder.startLazyRule(new Rule(Cost.parameterType));
       builder.nestExpression();
       modifier(node.covariantKeyword);
       token(node.keyword, after: space);
@@ -1121,7 +1123,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   visitFormalParameterList(FormalParameterList node,
-      {bool nestExpression = true}) {
+      {bool nestExpression: true}) {
     // Corner case: empty parameter lists.
     if (node.parameters.isEmpty) {
       token(node.leftParenthesis);
@@ -1151,11 +1153,11 @@ class SourceVisitor extends ThrowingAstVisitor {
     if (nestExpression) builder.nestExpression();
     token(node.leftParenthesis);
 
-    _metadataRules.add(MetadataRule());
+    _metadataRules.add(new MetadataRule());
 
     var rule;
     if (requiredParams.isNotEmpty) {
-      rule = PositionalRule(null, 0, 0);
+      rule = new PositionalRule(null, 0, 0);
       _metadataRules.last.bindPositionalRule(rule);
 
       builder.startRule(rule);
@@ -1187,7 +1189,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     }
 
     if (optionalParams.isNotEmpty) {
-      var namedRule = NamedRule(null, 0, 0);
+      var namedRule = new NamedRule(null, 0, 0);
       if (rule != null) rule.setNamedArgsRule(namedRule);
 
       _metadataRules.last.bindNamedRule(namedRule);
@@ -1469,7 +1471,7 @@ class SourceVisitor extends ThrowingAstVisitor {
         visit(node.prefix);
       }
 
-      builder.startRule(CombinatorRule());
+      builder.startRule(new CombinatorRule());
       visitNodes(node.combinators);
       builder.endRule();
     });
@@ -1681,7 +1683,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       return;
     }
 
-    CallChainVisitor(this, node).visit();
+    new CallChainVisitor(this, node).visit();
   }
 
   visitNamedExpression(NamedExpression node) {
@@ -1745,7 +1747,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   visitPrefixedIdentifier(PrefixedIdentifier node) {
-    CallChainVisitor(this, node).visit();
+    new CallChainVisitor(this, node).visit();
   }
 
   visitPrefixExpression(PrefixExpression node) {
@@ -1769,7 +1771,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       return;
     }
 
-    CallChainVisitor(this, node).visit();
+    new CallChainVisitor(this, node).visit();
   }
 
   visitRedirectingConstructorInvocation(RedirectingConstructorInvocation node) {
@@ -1809,7 +1811,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   visitSimpleFormalParameter(SimpleFormalParameter node) {
     visitParameterMetadata(node.metadata, () {
-      builder.startLazyRule(Rule(Cost.parameterType));
+      builder.startLazyRule(new Rule(Cost.parameterType));
       builder.nestExpression();
       modifier(node.covariantKeyword);
       modifier(node.keyword);
@@ -1973,7 +1975,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   visitTypeParameterList(TypeParameterList node) {
-    _metadataRules.add(MetadataRule());
+    _metadataRules.add(new MetadataRule());
 
     _visitGenericList(node.leftBracket, node.rightBracket, node.typeParameters);
 
@@ -2167,7 +2169,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   /// If [nest] is true, an extra level of expression nesting is added after
   /// the "=".
   void _visitAssignment(Token equalsOperator, Expression rightHandSide,
-      {bool nest = false}) {
+      {bool nest: false}) {
     space();
     token(equalsOperator);
 
@@ -2184,7 +2186,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   /// Visits a type parameter or type argument list.
   void _visitGenericList(
       Token leftBracket, Token rightBracket, List<AstNode> nodes) {
-    var rule = TypeArgumentRule();
+    var rule = new TypeArgumentRule();
     builder.startLazyRule(rule);
     builder.startSpan();
     builder.nestExpression();
@@ -2287,7 +2289,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       builder.nestExpression();
 
       // This rule is ended by visitExpressionFunctionBody().
-      builder.startLazyRule(Rule(Cost.arrow));
+      builder.startLazyRule(new Rule(Cost.arrow));
     }
 
     _visitParameterSignature(typeParameters, parameters);
@@ -2423,13 +2425,13 @@ class SourceVisitor extends ThrowingAstVisitor {
       // on the same line all share an argument-list-like rule that allows
       // splitting between zero, one, or all of them. This is faster in long
       // lists than using individual splits after each element.
-      lineRule = TypeArgumentRule();
+      lineRule = new TypeArgumentRule();
       builder.startLazyRule(lineRule);
     } else {
       // Newlines aren't significant, so use a hard rule to split the elements.
       // The parent chunk of the collection will handle the unsplit case, so
       // this only comes into play when the collection is split.
-      rule = Rule.hard();
+      rule = new Rule.hard();
       builder.startRule(rule);
     }
 
@@ -2443,7 +2445,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
             // Start a new rule for the new line.
             builder.endRule();
-            lineRule = TypeArgumentRule();
+            lineRule = new TypeArgumentRule();
             builder.startLazyRule(lineRule);
           } else {
             lineRule.beforeArgument(split());
@@ -2492,10 +2494,10 @@ class SourceVisitor extends ThrowingAstVisitor {
     // Can't have a trailing comma if there are no parameters.
     assert(parameters.parameters.isNotEmpty);
 
-    _metadataRules.add(MetadataRule());
+    _metadataRules.add(new MetadataRule());
 
     // Always split the parameters.
-    builder.startRule(Rule.hard());
+    builder.startRule(new Rule.hard());
 
     token(parameters.leftParenthesis);
 
@@ -2728,7 +2730,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   /// Writes the beginning of a brace-delimited body and handles indenting and
   /// starting the rule used to split the contents.
-  void _beginBody(Token leftBracket, {bool space = false}) {
+  void _beginBody(Token leftBracket, {bool space: false}) {
     token(leftBracket);
 
     // Indent the body.
@@ -2740,7 +2742,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   /// Finishes the body started by a call to [_beginBody].
-  void _endBody(Token rightBracket, {bool space = false}) {
+  void _endBody(Token rightBracket, {bool space: false}) {
     token(rightBracket, before: () {
       // Split before the closing bracket character.
       builder.unindent();
@@ -2829,7 +2831,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   /// Writes a single space split with its own rule.
   Rule soloSplit([int cost]) {
-    var rule = Rule(cost);
+    var rule = new Rule(cost);
     builder.startRule(rule);
     split();
     builder.endRule();
@@ -2906,7 +2908,7 @@ class SourceVisitor extends ThrowingAstVisitor {
         if (comment == token.precedingComments) linesBefore = 2;
       }
 
-      var sourceComment = SourceComment(text, linesBefore,
+      var sourceComment = new SourceComment(text, linesBefore,
           isLineComment: comment.type == TokenType.SINGLE_LINE_COMMENT,
           flushLeft: flushLeft);
 

--- a/lib/src/style_fix.dart
+++ b/lib/src/style_fix.dart
@@ -5,16 +5,17 @@
 /// Enum-like class for the different syntactic fixes that can be applied while
 /// formatting.
 class StyleFix {
-  static const namedDefaultSeparator = StyleFix._("named-default-separator",
+  static const namedDefaultSeparator = const StyleFix._(
+      "named-default-separator",
       'Use "=" as the separator before named parameter default values.');
 
-  static const optionalConst = StyleFix._(
+  static const optionalConst = const StyleFix._(
       "optional-const", 'Remove "const" keyword inside constant context.');
 
   static const optionalNew =
-      StyleFix._("optional-new", 'Remove "new" keyword.');
+      const StyleFix._("optional-new", 'Remove "new" keyword.');
 
-  static const all = [namedDefaultSeparator, optionalConst, optionalNew];
+  static const all = const [namedDefaultSeparator, optionalConst, optionalNew];
 
   final String name;
   final String description;

--- a/lib/src/whitespace.dart
+++ b/lib/src/whitespace.dart
@@ -26,33 +26,33 @@ class Indent {
 /// encountered to avoid trailing whitespace.
 class Whitespace {
   /// No whitespace.
-  static const none = Whitespace._("none");
+  static const none = const Whitespace._("none");
 
   /// A single non-breaking space.
-  static const space = Whitespace._("space");
+  static const space = const Whitespace._("space");
 
   /// A single newline.
-  static const newline = Whitespace._("newline");
+  static const newline = const Whitespace._("newline");
 
   /// A single newline that takes into account the current expression nesting
   /// for the next line.
-  static const nestedNewline = Whitespace._("nestedNewline");
+  static const nestedNewline = const Whitespace._("nestedNewline");
 
   /// A single newline with all indentation eliminated at the beginning of the
   /// next line.
   ///
   /// Used for subsequent lines in a multiline string.
-  static const newlineFlushLeft = Whitespace._("newlineFlushLeft");
+  static const newlineFlushLeft = const Whitespace._("newlineFlushLeft");
 
   /// Two newlines, a single blank line of separation.
-  static const twoNewlines = Whitespace._("twoNewlines");
+  static const twoNewlines = const Whitespace._("twoNewlines");
 
   /// A split or newline should be output based on whether the current token is
   /// on the same line as the previous one or not.
   ///
   /// In general, we like to avoid using this because it makes the formatter
   /// less prescriptive over the user's whitespace.
-  static const splitOrNewline = Whitespace._("splitOrNewline");
+  static const splitOrNewline = const Whitespace._("splitOrNewline");
 
   /// A split or blank line (two newlines) should be output based on whether
   /// the current token is on the same line as the previous one or not.
@@ -62,14 +62,14 @@ class Whitespace {
   ///
   /// In general, we like to avoid using this because it makes the formatter
   /// less prescriptive over the user's whitespace.
-  static const splitOrTwoNewlines = Whitespace._("splitOrTwoNewlines");
+  static const splitOrTwoNewlines = const Whitespace._("splitOrTwoNewlines");
 
   /// One or two newlines should be output based on how many newlines are
   /// present between the next token and the previous one.
   ///
   /// In general, we like to avoid using this because it makes the formatter
   /// less prescriptive over the user's whitespace.
-  static const oneOrTwoNewlines = Whitespace._("oneOrTwoNewlines");
+  static const oneOrTwoNewlines = const Whitespace._("oneOrTwoNewlines");
 
   final String name;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -366,4 +366,4 @@ packages:
     source: hosted
     version: "2.1.14"
 sdks:
-  dart: ">=2.0.0-dev.62.0 <=2.0.0-edge.14dfd82d69153887b64b379339b9bd94c4453bd3"
+  dart: ">=2.0.0-dev.62.0 <=2.0.0-edge.83cb0c425dde6023625b9f9816136338f5df1b16"

--- a/test/command_line_test.dart
+++ b/test/command_line_test.dart
@@ -71,7 +71,7 @@ void main() {
     var process = await runFormatter(["--version"]);
 
     // Match something roughly semver-like.
-    expect(await process.stdout.next, matches(RegExp(r"\d+\.\d+\.\d+.*")));
+    expect(await process.stdout.next, matches(new RegExp(r"\d+\.\d+\.\d+.*")));
     await process.shouldExit(0);
   });
 

--- a/test/formatter_test.dart
+++ b/test/formatter_test.dart
@@ -19,16 +19,16 @@ void main() {
   testDirectory("whitespace");
 
   test("throws a FormatterException on failed parse", () {
-    var formatter = DartFormatter();
+    var formatter = new DartFormatter();
     expect(() => formatter.format('wat?!'),
-        throwsA(isInstanceOf<FormatterException>()));
+        throwsA(new isInstanceOf<FormatterException>()));
   });
 
   test("FormatterException.message() does not throw", () {
     // This is a regression test for #358 where an error whose position is
     // past the end of the source caused FormatterException to throw.
     try {
-      DartFormatter().format("library");
+      new DartFormatter().format("library");
     } on FormatterException catch (err) {
       var message = err.message();
       expect(message, contains("Could not format"));
@@ -37,7 +37,7 @@ void main() {
 
   test("FormatterException describes parse errors", () {
     try {
-      DartFormatter().format("""
+      new DartFormatter().format("""
 
       var a = some error;
 
@@ -54,25 +54,27 @@ void main() {
   });
 
   test("adds newline to unit", () {
-    expect(DartFormatter().format("var x = 1;"), equals("var x = 1;\n"));
+    expect(new DartFormatter().format("var x = 1;"), equals("var x = 1;\n"));
   });
 
   test("adds newline to unit after trailing comment", () {
-    expect(DartFormatter().format("library foo; //zamm"),
+    expect(new DartFormatter().format("library foo; //zamm"),
         equals("library foo; //zamm\n"));
   });
 
   test("removes extra newlines", () {
-    expect(DartFormatter().format("var x = 1;\n\n\n"), equals("var x = 1;\n"));
+    expect(
+        new DartFormatter().format("var x = 1;\n\n\n"), equals("var x = 1;\n"));
   });
 
   test("does not add newline to statement", () {
-    expect(DartFormatter().formatStatement("var x = 1;"), equals("var x = 1;"));
+    expect(new DartFormatter().formatStatement("var x = 1;"),
+        equals("var x = 1;"));
   });
 
   test("fails if anything is after the statement", () {
     try {
-      DartFormatter().formatStatement("var x = 1;;");
+      new DartFormatter().formatStatement("var x = 1;;");
 
       fail("Should throw.");
     } on FormatterException catch (ex) {
@@ -82,7 +84,7 @@ void main() {
   });
 
   test('preserves initial indent', () {
-    var formatter = DartFormatter(indent: 3);
+    var formatter = new DartFormatter(indent: 3);
     expect(
         formatter.formatStatement('if (foo) {bar;}'),
         equals('   if (foo) {\n'
@@ -97,27 +99,27 @@ void main() {
       // will throw an error if it accidentally makes non-whitespace changes
       // as will occur
       var lineEnding = "\t";
-      expect(DartFormatter(lineEnding: lineEnding).format("var i = 1;"),
+      expect(new DartFormatter(lineEnding: lineEnding).format("var i = 1;"),
           equals("var i = 1;\t"));
     });
 
     test('infers \\r\\n if the first newline uses that', () {
-      expect(DartFormatter().format("var\r\ni\n=\n1;\n"),
+      expect(new DartFormatter().format("var\r\ni\n=\n1;\n"),
           equals("var i = 1;\r\n"));
     });
 
     test('infers \\n if the first newline uses that', () {
-      expect(DartFormatter().format("var\ni\r\n=\r\n1;\r\n"),
+      expect(new DartFormatter().format("var\ni\r\n=\r\n1;\r\n"),
           equals("var i = 1;\n"));
     });
 
     test('defaults to \\n if there are no newlines', () {
-      expect(DartFormatter().format("var i =1;"), equals("var i = 1;\n"));
+      expect(new DartFormatter().format("var i =1;"), equals("var i = 1;\n"));
     });
 
     test('handles Windows line endings in multiline strings', () {
       expect(
-          DartFormatter(lineEnding: "\r\n").formatStatement('  """first\r\n'
+          new DartFormatter(lineEnding: "\r\n").formatStatement('  """first\r\n'
               'second\r\n'
               'third"""  ;'),
           equals('"""first\r\n'
@@ -129,8 +131,8 @@ void main() {
   test('throws an UnexpectedOutputException on non-whitespace changes', () {
     // Use an invalid line ending character to ensure the formatter will
     // attempt to make non-whitespace changes.
-    var formatter = DartFormatter(lineEnding: '%');
+    var formatter = new DartFormatter(lineEnding: '%');
     expect(() => formatter.format("var i = 1;"),
-        throwsA(isInstanceOf<UnexpectedOutputException>()));
+        throwsA(new isInstanceOf<UnexpectedOutputException>()));
   });
 }

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -17,17 +17,17 @@ import 'package:dart_style/src/formatter_options.dart';
 import 'utils.dart';
 
 void main() {
-  var overwriteOptions = FormatterOptions(OutputReporter.overwrite);
+  var overwriteOptions = new FormatterOptions(OutputReporter.overwrite);
 
   var followOptions =
-      FormatterOptions(OutputReporter.overwrite, followLinks: true);
+      new FormatterOptions(OutputReporter.overwrite, followLinks: true);
 
   test('handles directory ending in ".dart"', () async {
     await d.dir('code.dart', [
       d.file('a.dart', unformattedSource),
     ]).create();
 
-    var dir = Directory(d.sandbox);
+    var dir = new Directory(d.sandbox);
     processDirectory(overwriteOptions, dir);
 
     await d.dir('code.dart', [
@@ -42,15 +42,15 @@ void main() {
     ]).create();
 
     DateTime modTime(String file) =>
-        File(p.join(d.sandbox, 'code', file)).statSync().modified;
+        new File(p.join(d.sandbox, 'code', file)).statSync().modified;
 
     var badBefore = modTime('bad.dart');
     var goodBefore = modTime('good.dart');
 
     // Wait a bit so the mod time of a formatted file will be different.
-    await Future.delayed(Duration(seconds: 1));
+    await new Future.delayed(new Duration(seconds: 1));
 
-    var dir = Directory(p.join(d.sandbox, 'code'));
+    var dir = new Directory(p.join(d.sandbox, 'code'));
     processDirectory(overwriteOptions, dir);
 
     // Should be touched.
@@ -67,7 +67,7 @@ void main() {
       d.dir('.skip', [d.file('a.dart', unformattedSource)])
     ]).create();
 
-    var dir = Directory(d.sandbox);
+    var dir = new Directory(d.sandbox);
     processDirectory(overwriteOptions, dir);
 
     await d.dir('code', [
@@ -79,7 +79,7 @@ void main() {
       () async {
     await d.dir('.code', [d.file('a.dart', unformattedSource)]).create();
 
-    var dir = Directory(p.join(d.sandbox, '.code'));
+    var dir = new Directory(p.join(d.sandbox, '.code'));
     processDirectory(overwriteOptions, dir);
 
     await d.dir('.code', [d.file('a.dart', formattedSource)]).validate();
@@ -95,10 +95,10 @@ void main() {
     ]).create();
 
     // Create a link to the target directory in the code directory.
-    Link(p.join(d.sandbox, 'code', 'linked_dir'))
+    new Link(p.join(d.sandbox, 'code', 'linked_dir'))
         .createSync(p.join(d.sandbox, 'target_dir'));
 
-    var dir = Directory(p.join(d.sandbox, 'code'));
+    var dir = new Directory(p.join(d.sandbox, 'code'));
     processDirectory(overwriteOptions, dir);
 
     await d.dir('code', [
@@ -119,10 +119,10 @@ void main() {
     ]).create();
 
     // Create a link to the target directory in the code directory.
-    Link(p.join(d.sandbox, 'code', 'linked_dir'))
+    new Link(p.join(d.sandbox, 'code', 'linked_dir'))
         .createSync(p.join(d.sandbox, 'target_dir'));
 
-    var dir = Directory(p.join(d.sandbox, 'code'));
+    var dir = new Directory(p.join(d.sandbox, 'code'));
     processDirectory(followOptions, dir);
 
     await d.dir('code', [
@@ -141,7 +141,7 @@ void main() {
 
       Process.runSync("chmod", ["-w", p.join(d.sandbox, 'a.dart')]);
 
-      var file = File(p.join(d.sandbox, 'a.dart'));
+      var file = new File(p.join(d.sandbox, 'a.dart'));
       processFile(overwriteOptions, file);
 
       // Should not have been formatted.
@@ -153,10 +153,10 @@ void main() {
       await d.file('target_file.dart', unformattedSource).create();
 
       // Create a link to the target file in the code directory.
-      Link(p.join(d.sandbox, 'code', 'linked_file.dart'))
+      new Link(p.join(d.sandbox, 'code', 'linked_file.dart'))
           .createSync(p.join(d.sandbox, 'target_file.dart'));
 
-      var dir = Directory(p.join(d.sandbox, 'code'));
+      var dir = new Directory(p.join(d.sandbox, 'code'));
       processDirectory(overwriteOptions, dir);
 
       await d.dir('code', [
@@ -169,10 +169,10 @@ void main() {
       await d.file('target_file.dart', unformattedSource).create();
 
       // Create a link to the target file in the code directory.
-      Link(p.join(d.sandbox, 'code', 'linked_file.dart'))
+      new Link(p.join(d.sandbox, 'code', 'linked_file.dart'))
           .createSync(p.join(d.sandbox, 'target_file.dart'));
 
-      var dir = Directory(p.join(d.sandbox, 'code'));
+      var dir = new Directory(p.join(d.sandbox, 'code'));
       processDirectory(followOptions, dir);
 
       await d.dir('code', [

--- a/test/source_code_test.dart
+++ b/test/source_code_test.dart
@@ -9,43 +9,44 @@ import 'package:test/test.dart';
 import 'package:dart_style/dart_style.dart';
 
 void main() {
-  var selection = SourceCode("123456;", selectionStart: 3, selectionLength: 2);
-  var noSelection = SourceCode("123456;");
+  var selection =
+      new SourceCode("123456;", selectionStart: 3, selectionLength: 2);
+  var noSelection = new SourceCode("123456;");
 
   group('constructor', () {
     test('throws on negative start', () {
       expect(() {
-        SourceCode("12345;", selectionStart: -1, selectionLength: 0);
+        new SourceCode("12345;", selectionStart: -1, selectionLength: 0);
       }, throwsArgumentError);
     });
 
     test('throws on out of bounds start', () {
       expect(() {
-        SourceCode("12345;", selectionStart: 7, selectionLength: 0);
+        new SourceCode("12345;", selectionStart: 7, selectionLength: 0);
       }, throwsArgumentError);
     });
 
     test('throws on negative length', () {
       expect(() {
-        SourceCode("12345;", selectionStart: 1, selectionLength: -1);
+        new SourceCode("12345;", selectionStart: 1, selectionLength: -1);
       }, throwsArgumentError);
     });
 
     test('throws on out of bounds length', () {
       expect(() {
-        SourceCode("12345;", selectionStart: 2, selectionLength: 5);
+        new SourceCode("12345;", selectionStart: 2, selectionLength: 5);
       }, throwsArgumentError);
     });
 
     test('throws is start is null and length is not', () {
       expect(() {
-        SourceCode("12345;", selectionStart: 0);
+        new SourceCode("12345;", selectionStart: 0);
       }, throwsArgumentError);
     });
 
     test('throws is length is null and start is not', () {
       expect(() {
-        SourceCode("12345;", selectionLength: 1);
+        new SourceCode("12345;", selectionLength: 1);
       }, throwsArgumentError);
     });
   });

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -18,11 +18,11 @@ import 'package:dart_style/dart_style.dart';
 const unformattedSource = 'void  main()  =>  print("hello") ;';
 const formattedSource = 'void main() => print("hello");\n';
 
-final _indentPattern = RegExp(r"^\(indent (\d+)\)\s*");
+final _indentPattern = new RegExp(r"^\(indent (\d+)\)\s*");
 
 /// Runs the command line formatter, passing it [args].
 Future<TestProcess> runFormatter([List<String> args]) {
-  args ??= [];
+  if (args == null) args = [];
 
   // Locate the "test" directory. Use mirrors so that this works with the test
   // package, which loads this suite into an isolate.
@@ -33,7 +33,7 @@ Future<TestProcess> runFormatter([List<String> args]) {
 
   var formatterPath = p.normalize(p.join(testDir, "../bin/format.dart"));
 
-  args.insertAll(0, ["--preview-dart-2", formatterPath]);
+  args.insert(0, formatterPath);
 
   // Use the same package root, if there is one.
   if (Platform.packageRoot != null && Platform.packageRoot.isNotEmpty) {
@@ -62,7 +62,7 @@ void testDirectory(String name, [Iterable<StyleFix> fixes]) {
       .uri
       .toFilePath());
 
-  var entries = Directory(p.join(testDir, name))
+  var entries = new Directory(p.join(testDir, name))
       .listSync(recursive: true, followLinks: false);
   for (var entry in entries) {
     if (!entry.path.endsWith(".stmt") && !entry.path.endsWith(".unit")) {
@@ -87,7 +87,7 @@ void testFile(String path, [Iterable<StyleFix> fixes]) {
 void _testFile(String name, String path, Iterable<StyleFix> fixes) {
   group("$name ${p.basename(path)}", () {
     // Explicitly create a File, in case the entry is a Link.
-    var lines = File(path).readAsLinesSync();
+    var lines = new File(path).readAsLinesSync();
 
     // The first line may have a "|" to indicate the page width.
     var pageWidth;
@@ -140,7 +140,7 @@ void _testFile(String name, String path, Iterable<StyleFix> fixes) {
         var expected = _extractSelection(expectedOutput,
             isCompilationUnit: isCompilationUnit);
 
-        var formatter = DartFormatter(
+        var formatter = new DartFormatter(
             pageWidth: pageWidth, indent: leadingIndent, fixes: fixes);
 
         var actual = formatter.formatSource(inputCode);
@@ -168,14 +168,14 @@ void _testFile(String name, String path, Iterable<StyleFix> fixes) {
 /// Given a source string that contains ‹ and › to indicate a selection, returns
 /// a [SourceCode] with the text (with the selection markers removed) and the
 /// correct selection range.
-SourceCode _extractSelection(String source, {bool isCompilationUnit = false}) {
+SourceCode _extractSelection(String source, {bool isCompilationUnit: false}) {
   var start = source.indexOf("‹");
   source = source.replaceAll("‹", "");
 
   var end = source.indexOf("›");
   source = source.replaceAll("›", "");
 
-  return SourceCode(source,
+  return new SourceCode(source,
       isCompilationUnit: isCompilationUnit,
       selectionStart: start == -1 ? null : start,
       selectionLength: end == -1 ? null : end - start);

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -11,7 +11,7 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart' as yaml;
 
 /// Matches the version line in dart_style's pubspec.
-final _versionPattern = RegExp(r"^version: .*$", multiLine: true);
+final _versionPattern = new RegExp(r"^version: .*$", multiLine: true);
 
 main(List<String> args) => grind(args);
 
@@ -19,7 +19,7 @@ main(List<String> args) => grind(args);
 @Task()
 validate() async {
   // Test it.
-  await TestRunner().testAsync();
+  await new TestRunner().testAsync();
 
   // Make sure it's warning clean.
   Analyzer.analyze("bin/format.dart", fatalWarnings: true);
@@ -37,16 +37,16 @@ npm() {
   var fileName = 'index.js';
 
   // Generate modified dart2js output suitable to run on node.
-  var tempFile = File('${Directory.systemTemp.path}/temp.js');
+  var tempFile = new File('${Directory.systemTemp.path}/temp.js');
 
-  Dart2js.compile(File('tool/node_format_service.dart'),
+  Dart2js.compile(new File('tool/node_format_service.dart'),
       outFile: tempFile, categories: 'all');
   var dart2jsOutput = tempFile.readAsStringSync();
-  File('$out/$fileName').writeAsStringSync('''${preamble.getPreamble()}
+  new File('$out/$fileName').writeAsStringSync('''${preamble.getPreamble()}
 self.exports = exports; // Temporary hack for Dart-JS Interop under node.
 $dart2jsOutput''');
 
-  File('$out/package.json')
+  new File('$out/package.json')
       .writeAsStringSync(const JsonEncoder.withIndent('  ').convert({
     "name": "dart-style",
     "version": pubspec["version"],
@@ -99,7 +99,7 @@ bump() async {
   // Read the version from the pubspec.
   var pubspecFile = getFile("pubspec.yaml");
   var pubspec = pubspecFile.readAsStringSync();
-  var version = Version.parse(yaml.loadYaml(pubspec)["version"]);
+  var version = new Version.parse(yaml.loadYaml(pubspec)["version"]);
 
   // Require a "-dev" version since we don't otherwise know what to bump it to.
   if (!version.isPreRelease) throw "Cannot publish non-dev version $version.";
@@ -108,7 +108,7 @@ bump() async {
   // user intended the "+4" to be discarded or not.
   if (version.build.isNotEmpty) throw "Cannot publish build version $version.";
 
-  var bumped = Version(version.major, version.minor, version.patch);
+  var bumped = new Version(version.major, version.minor, version.patch);
 
   // Update the version in the pubspec.
   pubspec = pubspec.replaceAll(_versionPattern, "version: $bumped");
@@ -117,7 +117,7 @@ bump() async {
   // Update the version constant in bin/format.dart.
   var binFormatFile = getFile("bin/format.dart");
   var binFormat = binFormatFile.readAsStringSync().replaceAll(
-      RegExp(r'const version = "[^"]+";'), 'const version = "$bumped";');
+      new RegExp(r'const version = "[^"]+";'), 'const version = "$bumped";');
   binFormatFile.writeAsStringSync(binFormat);
   log("Updated version to '$bumped'.");
 }

--- a/tool/node_format_service.dart
+++ b/tool/node_format_service.dart
@@ -21,11 +21,11 @@ external set formatCode(Function formatter);
 
 void main() {
   formatCode = allowInterop((String source) {
-    var formatter = DartFormatter();
+    var formatter = new DartFormatter();
 
     var exception;
     try {
-      return FormatResult(code: DartFormatter().format(source));
+      return new FormatResult(code: new DartFormatter().format(source));
     } on FormatterException catch (err) {
       // Couldn't parse it as a compilation unit.
       exception = err;
@@ -33,7 +33,7 @@ void main() {
 
     // Maybe it's a statement.
     try {
-      return FormatResult(code: formatter.formatStatement(source));
+      return new FormatResult(code: formatter.formatStatement(source));
     } on FormatterException catch (err) {
       // There is an error when parsing it both as a compilation unit and a
       // statement, so we aren't sure which one the user intended. As a
@@ -45,7 +45,7 @@ void main() {
     }
 
     // If we get here, it couldn't be parsed at all.
-    return FormatResult(code: source, error: "$exception");
+    return new FormatResult(code: source, error: "$exception");
   });
 }
 

--- a/web/main.dart
+++ b/web/main.dart
@@ -40,7 +40,7 @@ void reformat() {
   var source = before.value;
 
   try {
-    after.value = DartFormatter(pageWidth: width).format(source);
+    after.value = new DartFormatter(pageWidth: width).format(source);
     return;
   } on FormatterException {
     // Do nothing.
@@ -48,7 +48,7 @@ void reformat() {
 
   // Maybe it's a statement.
   try {
-    after.value = DartFormatter(pageWidth: width).formatStatement(source);
+    after.value = new DartFormatter(pageWidth: width).formatStatement(source);
   } on FormatterException catch (err) {
     after.value = "Format failed:\n$err";
   }


### PR DESCRIPTION
Reverts d80a1ea82d16a90f06f1c94877a9a5887573e5ca.

Since people import dartfmt as a library, I don't want to require them
to move to Dart 2 just yet, so I'm going to postpone removing "new" and
"const" from dartfmt itself for a while.

It, of course, still supports "--fix" and is able to remove them from
*your* code.