### PR TITLE
Reformat expressions inside interpolated expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.1
+
+* Format expressions in string interpolations (#226).
+* Apply fixes inside string interpolations (#707).
+
 # 1.1.0
 
 * Add support for "style fixes", opt-in non-whitespace changes.

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -15,7 +15,7 @@ import 'package:dart_style/src/source_code.dart';
 import 'package:dart_style/src/style_fix.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const version = "1.1.0";
+const version = "1.1.1";
 
 void main(List<String> args) {
   var parser = new ArgParser(allowTrailingOptions: true);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -366,4 +366,4 @@ packages:
     source: hosted
     version: "2.1.14"
 sdks:
-  dart: ">=2.0.0-dev.62.0 <=2.0.0-edge.83cb0c425dde6023625b9f9816136338f5df1b16"
+  dart: ">=2.0.0-dev.62.0 <=2.0.0-edge.edf26852e6f6f096bb935ab8a545ce0646cf05a6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.1.1-dev
+version: 1.1.1
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.1.0
+version: 1.1.1-dev
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style

--- a/test/fixes/optional_new.stmt
+++ b/test/fixes/optional_new.stmt
@@ -65,3 +65,7 @@ A();
 A<int>(A<int>.named());
 <<<
 A<int>(A<int>.named());
+>>> inside string interpolation
+"before ${new Foo()} after";
+<<<
+"before ${Foo()} after";

--- a/test/regression/0000/0057.stmt
+++ b/test/regression/0000/0057.stmt
@@ -6,7 +6,7 @@ name: 'embeddedPlural2', desc: 'An embedded plural', args: [n]);
 <<<
 embeddedPlural2(n) => Intl.message(
     "${Intl.plural(n,
-zero: 'none', one: 'one', other: 'some')} plus some text.",
+        zero: 'none', one: 'one', other: 'some')} plus some text.",
     name: 'embeddedPlural2',
     desc: 'An embedded plural',
     args: [n]);

--- a/test/regression/0100/0189.stmt
+++ b/test/regression/0100/0189.stmt
@@ -11,7 +11,8 @@
   nestedSelect(currency, amount) => Intl.select(
       currency,
       {
-        "CDN": """${Intl.plural(amount, one: '$amount Canadian dollar',
+        "CDN": """${Intl.plural(amount,
+            one: '$amount Canadian dollar',
             other: '$amount Canadian dollars')}""",
         "other": "Whatever",
       },

--- a/test/regression/0200/0226.stmt
+++ b/test/regression/0200/0226.stmt
@@ -1,0 +1,4 @@
+>>>
+test('Bad Request${(detail!='' ? ': ' : '')}$detail');
+<<<
+test('Bad Request${(detail != '' ? ': ' : '')}$detail');

--- a/test/regression/0400/0467.unit
+++ b/test/regression/0400/0467.unit
@@ -21,6 +21,8 @@ class MyElement extends PolymerElement {
         'nodesAndEntryPoints',
         new PolymerDom(this).children.map((child) =>
             '${child.outerHtml} ------> '
-            '${(new PolymerDom(child).getDestinationInsertionPoints()[0] as Element).outerHtml}'));
+            '${(new PolymerDom(child).getDestinationInsertionPoints()[0]
+                    as Element)
+                .outerHtml}'));
   }
 }

--- a/test/regression/0500/0500.unit
+++ b/test/regression/0500/0500.unit
@@ -26,9 +26,10 @@
         for (int i = 0; i < names.length; ++i) {
           env.initialize(names[i],
               getter: (TopLevelBinding binding, ExprCont ek, ExprCont k) {
-                binding.getter = (TopLevelBinding _, ExprCont ek0,
-                        ExprCont k0) =>
-                    ek0("Reading static variable '${binding.name}' during its initialization");
+                binding.getter =
+                    (TopLevelBinding _, ExprCont ek0, ExprCont k0) => ek0(
+                        "Reading static variable '${binding
+                            .name}' during its initialization");
                 initializers[i](env, ek, (v) {
                   binding.getter =
                       (TopLevelBinding _, ExprCont ek1, ExprCont k1) => k1(v);

--- a/test/regression/0700/0707.stmt
+++ b/test/regression/0700/0707.stmt
@@ -1,0 +1,4 @@
+>>> (indent 4) (fix optional-new)
+    sink.write('FILE ACCESSED ${new DateTime.now()}\n');
+<<<
+    sink.write('FILE ACCESSED ${DateTime.now()}\n');

--- a/test/regression/other/analysis_server.unit
+++ b/test/regression/other/analysis_server.unit
@@ -259,3 +259,23 @@ final ListResultDescriptor<AnalysisError> HINTS =
         .variables[0]
         .name
         .staticElement;
+>>>
+main() {
+  addTestFile('''
+    library libA;
+    part "${convertPathForImport('/testA.dart')}";
+    import "dart:math";
+    /// The [^]
+    main(aaa, bbb) {}
+    ''');
+}
+<<<
+main() {
+  addTestFile('''
+    library libA;
+    part "${convertPathForImport('/testA.dart')}";
+    import "dart:math";
+    /// The [^]
+    main(aaa, bbb) {}
+    ''');
+}

--- a/test/splitting/strings.stmt
+++ b/test/splitting/strings.stmt
@@ -138,3 +138,17 @@ someMethod("""
   "many",
   "elements"
 ]);
+>>> interpolation in multi-line does not force unneeded splits
+someMethod("foo", """
+  some text that is pretty long
+  some more text that is pretty long
+  ${    inpolate + a + thing   }
+  more text
+""");
+<<<
+someMethod("foo", """
+  some text that is pretty long
+  some more text that is pretty long
+  ${inpolate + a + thing}
+  more text
+""");

--- a/test/whitespace/expressions.stmt
+++ b/test/whitespace/expressions.stmt
@@ -143,3 +143,7 @@ function(
 method   <int,String   ,    bool>  ();
 <<<
 method<int, String, bool>();
+>>> inside interpolation
+" ${   interp+olate } and ${fn  (  1 ) } end";
+<<<
+" ${interp + olate} and ${fn(1)} end";


### PR DESCRIPTION
If it ever ends up splitting inside an interpolation, it looks pretty
gnarly, but that's mostly a signal to the user to split up the string.
It does nicely clean up the whitespace.

More importantly, this means fixes apply inside interpolation too.

Fix #226. Fix #707.