### PR TITLE
Don't split inside string interpolation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.2
+
+* Don't split inside string interpolations.
+
 # 1.1.1
 
 * Format expressions in string interpolations (#226).

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -15,7 +15,7 @@ import 'package:dart_style/src/source_code.dart';
 import 'package:dart_style/src/style_fix.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const version = "1.1.1";
+const version = "1.1.2";
 
 void main(List<String> args) {
   var parser = new ArgParser(allowTrailingOptions: true);

--- a/lib/src/chunk_builder.dart
+++ b/lib/src/chunk_builder.dart
@@ -93,14 +93,15 @@ class ChunkBuilder {
   /// block.
   bool _firstFlushLeft = false;
 
-  /// Splitting is completely disabled inside string interpolation. We do still
-  /// want to fix the whitespace inside interpolation, though, so we still
-  /// format them.
+  /// The number of calls to [preventSplit()] that have not been ended by a
+  /// call to [endPreventSplit()].
   ///
-  /// This indicates the number of calls to [preventSplit()] that have not been
-  /// ended by a call to [endPreventSplit()]. (We can't use a simple bool
-  /// because interpolation can nest.) When this is non-zero, splits are
-  /// ignored.
+  /// Splitting is completely disabled inside string interpolation. We do want
+  /// to fix the whitespace inside interpolation, though, so we still format
+  /// them. This tracks whether we're inside an interpolation. We can't use a
+  /// simple bool because interpolation can nest.
+  ///
+  /// When this is non-zero, splits are ignored.
   int _preventSplitNesting = 0;
 
   /// Whether there is pending whitespace that depends on the number of

--- a/lib/src/chunk_builder.dart
+++ b/lib/src/chunk_builder.dart
@@ -93,6 +93,16 @@ class ChunkBuilder {
   /// block.
   bool _firstFlushLeft = false;
 
+  /// Splitting is completely disabled inside string interpolation. We do still
+  /// want to fix the whitespace inside interpolation, though, so we still
+  /// format them.
+  ///
+  /// This indicates the number of calls to [preventSplit()] that have not been
+  /// ended by a call to [endPreventSplit()]. (We can't use a simple bool
+  /// because interpolation can nest.) When this is non-zero, splits are
+  /// ignored.
+  int _preventSplitNesting = 0;
+
   /// Whether there is pending whitespace that depends on the number of
   /// newlines in the source.
   ///
@@ -501,6 +511,10 @@ class ChunkBuilder {
   ///
   /// Nested blocks are handled using their own independent [LineWriter].
   ChunkBuilder startBlock(Chunk argumentChunk) {
+    // If we are not allowed to split at all, don't create a new block. Instead,
+    // the block contents will end up in the current chunk.
+    if (_preventSplitNesting > 0) return this;
+
     var chunk = _chunks.last;
     chunk.makeBlock(argumentChunk);
 
@@ -523,6 +537,11 @@ class ChunkBuilder {
   ///
   /// Returns the previous writer for the surrounding block.
   ChunkBuilder endBlock(Rule ignoredSplit, {bool forceSplit}) {
+    // If we are not allowed to split at all, we didn't create a new block and
+    // thus didn't create a new ChunkBuilder, so there is no builder to pop.
+    // We are still in the current one.
+    if (_preventSplitNesting > 0) return this;
+
     _divideChunks();
 
     // If we don't already know if the block is going to split, see if it
@@ -600,6 +619,15 @@ class ChunkBuilder {
         isCompilationUnit: _source.isCompilationUnit,
         selectionStart: selectionStart,
         selectionLength: selectionLength);
+  }
+
+  void preventSplit() {
+    _preventSplitNesting++;
+  }
+
+  void endPreventSplit() {
+    _preventSplitNesting--;
+    assert(_preventSplitNesting >= 0, "Mismatched calls.");
   }
 
   /// Writes the current pending [Whitespace] to the output, if any.
@@ -738,6 +766,21 @@ class ChunkBuilder {
   /// to be at column zero. Otherwise, it uses the normal indentation and
   /// nesting behavior.
   void _writeHardSplit({bool isDouble, bool flushLeft, bool nest: false}) {
+    // If we are not allowed to split at all, simply write a space. Instead of:
+    //
+    //     foo("${() {
+    //       a;
+    //       b;
+    //     }}");
+    //
+    // produces:
+    //
+    //     foo("${() { a; b; }}");
+    if (_preventSplitNesting > 0) {
+      _writeText(" ");
+      return;
+    }
+
     // A hard split overrides any other whitespace.
     _pendingWhitespace = null;
     _writeSplit(new Rule.hard(),
@@ -749,7 +792,16 @@ class ChunkBuilder {
   /// Returns the chunk.
   Chunk _writeSplit(Rule rule,
       {bool flushLeft, bool isDouble, bool nest, bool space}) {
-    if (nest == null) nest = true;
+    nest ??= true;
+    space ??= false;
+
+    // If we are not allowed to split at all, don't. Returning null for the
+    // chunk is safe since the rule that uses the chunk will itself get
+    // discarded because no chunk references it.
+    if (_preventSplitNesting > 0) {
+      if (space) write(" ");
+      return null;
+    }
 
     if (_chunks.isEmpty) {
       if (flushLeft != null) _firstFlushLeft = flushLeft;

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1559,11 +1559,13 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   visitInterpolationExpression(InterpolationExpression node) {
+    builder.preventSplit();
     token(node.leftBracket);
     builder.startSpan();
     visit(node.expression);
     builder.endSpan();
     token(node.rightBracket);
+    builder.endPreventSplit();
   }
 
   visitInterpolationString(InterpolationString node) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.1.1
+version: 1.1.2
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style

--- a/test/regression/0000/0057.stmt
+++ b/test/regression/0000/0057.stmt
@@ -5,8 +5,7 @@ zero: 'none', one: 'one', other: 'some')} plus some text.",
 name: 'embeddedPlural2', desc: 'An embedded plural', args: [n]);
 <<<
 embeddedPlural2(n) => Intl.message(
-    "${Intl.plural(n,
-        zero: 'none', one: 'one', other: 'some')} plus some text.",
+    "${Intl.plural(n, zero: 'none', one: 'one', other: 'some')} plus some text.",
     name: 'embeddedPlural2',
     desc: 'An embedded plural',
     args: [n]);

--- a/test/regression/0100/0189.stmt
+++ b/test/regression/0100/0189.stmt
@@ -11,9 +11,8 @@
   nestedSelect(currency, amount) => Intl.select(
       currency,
       {
-        "CDN": """${Intl.plural(amount,
-            one: '$amount Canadian dollar',
-            other: '$amount Canadian dollars')}""",
+        "CDN":
+            """${Intl.plural(amount, one: '$amount Canadian dollar', other: '$amount Canadian dollars')}""",
         "other": "Whatever",
       },
       name: "nestedSelect",

--- a/test/regression/0400/0467.unit
+++ b/test/regression/0400/0467.unit
@@ -21,8 +21,6 @@ class MyElement extends PolymerElement {
         'nodesAndEntryPoints',
         new PolymerDom(this).children.map((child) =>
             '${child.outerHtml} ------> '
-            '${(new PolymerDom(child).getDestinationInsertionPoints()[0]
-                    as Element)
-                .outerHtml}'));
+            '${(new PolymerDom(child).getDestinationInsertionPoints()[0] as Element).outerHtml}'));
   }
 }

--- a/test/regression/0500/0500.unit
+++ b/test/regression/0500/0500.unit
@@ -26,10 +26,9 @@
         for (int i = 0; i < names.length; ++i) {
           env.initialize(names[i],
               getter: (TopLevelBinding binding, ExprCont ek, ExprCont k) {
-                binding.getter =
-                    (TopLevelBinding _, ExprCont ek0, ExprCont k0) => ek0(
-                        "Reading static variable '${binding
-                            .name}' during its initialization");
+                binding.getter = (TopLevelBinding _, ExprCont ek0,
+                        ExprCont k0) =>
+                    ek0("Reading static variable '${binding.name}' during its initialization");
                 initializers[i](env, ek, (v) {
                   binding.getter =
                       (TopLevelBinding _, ExprCont ek1, ExprCont k1) => k1(v);

--- a/test/splitting/strings.stmt
+++ b/test/splitting/strings.stmt
@@ -138,17 +138,31 @@ someMethod("""
   "many",
   "elements"
 ]);
->>> interpolation in multi-line does not force unneeded splits
+>>> interpolation is not split even when line is too long
+someMethod("some text that is pretty long ${    interpolate +
+a + thing   } more text");
+<<<
+someMethod(
+    "some text that is pretty long ${interpolate + a + thing} more text");
+>>> multi-line string interpolation does not split
 someMethod("foo", """
   some text that is pretty long
-  some more text that is pretty long
-  ${    inpolate + a + thing   }
-  more text
+  some more text that is pretty long ${    interpolate + a + thing   } more text
 """);
 <<<
 someMethod("foo", """
   some text that is pretty long
-  some more text that is pretty long
-  ${inpolate + a + thing}
-  more text
+  some more text that is pretty long ${interpolate + a + thing} more text
 """);
+>>> nested interpolation is not split
+someMethod("some text that is ${pretty +  'long ${    interpolate +
+a + thing   } more'} text", "another arg");
+<<<
+someMethod(
+    "some text that is ${pretty + 'long ${interpolate + a + thing} more'} text",
+    "another arg");
+>>> hard splits are not split in interpolation
+someMethod("before ${(){statement();statement();statement();}} after");
+<<<
+someMethod(
+    "before ${() { statement(); statement(); statement(); }} after");


### PR DESCRIPTION
When it happens, it's usually a sign that you should split the string
yourself to avoid it. But it still looks terrible. And in multi-line
strings, you may *want* to have lines longer than the page width, in
which case the splitting is really bad.