### PR TITLE
Ignore all non syntactic errors

### DIFF
--- a/lib/src/error_listener.dart
+++ b/lib/src/error_listener.dart
@@ -13,7 +13,12 @@ class ErrorListener implements AnalysisErrorListener {
   final _errors = <AnalysisError>[];
 
   void onError(AnalysisError error) {
-    _errors.add(error);
+    ErrorCode errorCode = error.errorCode;
+    // The fasta parser produces some semantic errors,
+    // which should be ignored by the formatter.
+    if (errorCode.type == ErrorType.SYNTACTIC_ERROR) {
+      _errors.add(error);
+    }
   }
 
   /// Throws a [FormatterException] if any errors have been reported.


### PR DESCRIPTION
The fasta parser produces some semantic errors (e.g. final variable not initialized) which the dart formatter can safely ignore.