### PR TITLE
Update map literal formatting test

### DIFF
--- a/test/splitting/invocations.stmt
+++ b/test/splitting/invocations.stmt
@@ -248,9 +248,9 @@ someVeryLongTargetFunction(
   element
 ].someLongMethod();
 >>> do not split on "." when target is map
-{"key": "value", "another": "another value"}.someLongMethod();
+<String,String>{"key": "value", "another": "another value"}.someLongMethod();
 <<<
-{
+<String, String>{
   "key": "value",
   "another": "another value"
 }.someLongMethod();


### PR DESCRIPTION
This test case is invalid Dart syntax that the old analyzer parser let slide by.
From section 17.2 of the language spec...

> An expression statement consists of an expression other than a non-constant map literal (16.8) that has no explicit type arguments. The restriction on maps is designed to resolve an ambiguity in the grammar, when a statement begins with {.
