### PR TITLE
Update covariant modifier test

### DIFF
--- a/test/whitespace/metadata.unit
+++ b/test/whitespace/metadata.unit
@@ -248,12 +248,14 @@ function(
       longParameter2,
 ) {}
 >>> keep "covariant" with parameter
-function(@Annotation @VeryLongMetadataAnnotation covariant longParameter) {}
+class A { function(@Annotation @VeryLongMetadataAnnotation covariant longParameter) {} }
 <<<
-function(
-    @Annotation
-    @VeryLongMetadataAnnotation
-        covariant longParameter) {}
+class A {
+  function(
+      @Annotation
+      @VeryLongMetadataAnnotation
+          covariant longParameter) {}
+}
 >>> metadata on function typedef
 @foo typedef Fn = Function();
 <<<


### PR DESCRIPTION
This test case is invalid Dart syntax that the old analyzer parser let slide by.
From the end of section 9.2.1 of the language spec

> It is a compile-time error if the modifier covariant occurs on a parameter of a function which is not an instance method, instance setter, or instance operator.