### PR TITLE
Handle all metadata annotations for optional "const".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.2.0
 
 * Add `--fix-doc-comments` to turn `/** ... */` doc comments into `///` (#730).
+* Remove `const` in all metadata annotations with --fix-optional-const` (#720).
 
 # 1.1.4
 

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -184,7 +184,11 @@ class SourceVisitor extends ThrowingAstVisitor {
     visit(node.name);
     token(node.period);
     visit(node.constructorName);
+
+    // Metadata annotations are always const contexts.
+    _constNesting++;
     visit(node.arguments);
+    _constNesting--;
   }
 
   /// Visits an argument list.
@@ -2070,12 +2074,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   ///
   /// These always force the annotations to be on the previous line.
   void visitMetadata(NodeList<Annotation> metadata) {
-    // Metadata annotations are always const contexts.
-    _constNesting++;
-
     visitNodes(metadata, between: newline, after: newline);
-
-    _constNesting--;
   }
 
   /// Visit metadata annotations for a directive.

--- a/test/regression/0700/0720.unit
+++ b/test/regression/0700/0720.unit
@@ -1,0 +1,12 @@
+>>> (fix optional-const)
+@meta(const Foo(const []))
+library foo;
+<<<
+@meta(Foo([]))
+library foo;
+>>> (fix optional-const)
+@meta(const Foo(const []))
+import 'foo.dart';
+<<<
+@meta(Foo([]))
+import 'foo.dart';


### PR DESCRIPTION
The visitMetadata() method is only used for metadata annotations on
members and some other things. visitAnnotation() is where all metadata
is handled.

Fix #720.