### PR TITLE
Add more tests for doc comment fix and fix an edge case.

### DIFF
--- a/lib/src/chunk_builder.dart
+++ b/lib/src/chunk_builder.dart
@@ -22,8 +22,8 @@ final _trailingIdentifierChar = new RegExp(r"[a-zA-Z0-9_]$");
 /// "*/" or "**/".
 final _javaDocComment = new RegExp(r"^/\*\*([^*/][\s\S]*?)\*?\*/$");
 
-/// Matches an intermediate "*" line in the middle of a JavaDoc-style comment.
-var _javaDocLine = new RegExp(r"\s*\*(.*)");
+/// Matches the leading "*" in a line in the middle of a JavaDoc-style comment.
+var _javaDocLine = new RegExp(r"^\s*\*(.*)");
 
 /// Takes the incremental serialized output of [SourceVisitor]--the source text
 /// along with any comments and preserved whitespace--and produces a coherent
@@ -357,13 +357,9 @@ class ChunkBuilder {
       return;
     }
 
-    // Trim the first and last lines if empty.
-    var lines = match.group(1).split("\n").toList();
-    if (lines.first.trim().isEmpty) lines.removeAt(0);
-    if (lines.isNotEmpty && lines.last.trim().isEmpty) lines.removeLast();
-
     // Remove a leading "*" from the middle lines.
-    for (var i = 0; i < lines.length; i++) {
+    var lines = match.group(1).split("\n").toList();
+    for (var i = 1; i < lines.length - 1; i++) {
       var line = lines[i];
       var match = _javaDocLine.firstMatch(line);
       if (match != null) {
@@ -375,6 +371,10 @@ class ChunkBuilder {
       }
       lines[i] = line;
     }
+
+    // Trim the first and last lines if empty.
+    if (lines.first.trim().isEmpty) lines.removeAt(0);
+    if (lines.isNotEmpty && lines.last.trim().isEmpty) lines.removeLast();
 
     // Don't completely eliminate an empty block comment.
     if (lines.isEmpty) lines.add("");

--- a/test/fixes/doc_comments.stmt
+++ b/test/fixes/doc_comments.stmt
@@ -111,3 +111,49 @@ m() {}
  * STUFF
  *******/
 m() {}
+>>> nested comment
+/**
+ * Floo the grumshack.
+ *
+ * Example:
+ * ```dart
+ * /** Doc comment */
+ * var grumshack = getGrumshack();
+ * /* Do the floo */
+ * grumshack.floo();
+ * ```
+*/
+m() {}
+<<<
+/// Floo the grumshack.
+///
+/// Example:
+/// ```dart
+/// /** Doc comment */
+/// var grumshack = getGrumshack();
+/// /* Do the floo */
+/// grumshack.floo();
+/// ```
+m() {}
+>>>
+/** Does a [foo](http://example.org/*example*/doc). **/
+m() {}
+<<<
+/// Does a [foo](http://example.org/*example*/doc).
+m() {}
+>>>
+/** Does a [foo](http://example.org/*example*/doc). */
+m() {}
+<<<
+/// Does a [foo](http://example.org/*example*/doc).
+m() {}
+>>> non-leading "*"
+/**
+ * Thing.
+ Another * thing.
+*/
+m() {}
+<<<
+/// Thing.
+/// Another * thing.
+m() {}


### PR DESCRIPTION
A line that didn't have a leading `*` but did have a `*` elsewhere in
the line would have everything before the `*` trimmed.

cc @lrhn 