### PR TITLE
Add --fix-typedefs to Dart formatter.

### DIFF
--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1385,7 +1385,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   /// Writes a `Function` function type.
   ///
   /// Used also by a fix, so there may not be a [functionKeyword].
-  /// In that case [syntheticFunctionPosition] should be the source position
+  /// In that case [functionKeywordPosition] should be the source position
   /// used for the inserted "Function" text.
   void _writeGenericFunctionType(
       AstNode returnType,

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1313,7 +1313,6 @@ class SourceVisitor extends ThrowingAstVisitor {
   visitFunctionTypeAlias(FunctionTypeAlias node) {
     visitMetadata(node.metadata);
 
-
     if (_formatter.fixes.contains(StyleFix.typedefs)) {
       _simpleStatement(node, () {
         token(node.typedefKeyword);

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1325,7 +1325,7 @@ class SourceVisitor extends ThrowingAstVisitor {
         visit(node.returnType, after: space);
         space();
         _writeText("Function", node.name.offset);
-        // TODO(lrn): Recurse and convert function-arguments to Function typed.
+        // Recursively convert function-arguments to Function typed.
         _insideNewTypedefFix = true;
         visit(node.parameters);
         _insideNewTypedefFix = false;

--- a/lib/src/style_fix.dart
+++ b/lib/src/style_fix.dart
@@ -1,4 +1,5 @@
 // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -19,7 +20,7 @@ class StyleFix {
       "doc-comments", 'Use triple slash for documentation comments.');
 
   static const typedefs =
-      const StyleFix._("typedefs", "Use new typedef syntax for typedefs");
+      const StyleFix._("typedefs", 'Use new typedef syntax for typedefs.');
 
   static const all = const [
     namedDefaultSeparator,

--- a/lib/src/style_fix.dart
+++ b/lib/src/style_fix.dart
@@ -18,8 +18,8 @@ class StyleFix {
   static const docComments = const StyleFix._(
       "doc-comments", 'Use triple slash for documentation comments.');
 
-  static const typedefs = const StyleFix._(
-      "typedefs", "Use new typedef syntax for typedefs");
+  static const typedefs =
+      const StyleFix._("typedefs", "Use new typedef syntax for typedefs");
 
   static const all = const [
     namedDefaultSeparator,

--- a/lib/src/style_fix.dart
+++ b/lib/src/style_fix.dart
@@ -18,11 +18,15 @@ class StyleFix {
   static const docComments = const StyleFix._(
       "doc-comments", 'Use triple slash for documentation comments.');
 
+  static const typedefs = const StyleFix._(
+      "typedefs", "Use new typedef syntax for typedefs");
+
   static const all = const [
     namedDefaultSeparator,
     optionalConst,
     optionalNew,
     docComments,
+    typedefs,
   ];
 
   final String name;

--- a/test/fix_test.dart
+++ b/test/fix_test.dart
@@ -17,4 +17,5 @@ void main() {
   testFile("fixes/doc_comments.stmt", [StyleFix.docComments]);
   testFile("fixes/optional_const.unit", [StyleFix.optionalConst]);
   testFile("fixes/optional_new.stmt", [StyleFix.optionalNew]);
+  testFile("fixes/typedefs.unit", [StyleFix.typedefs]);
 }

--- a/test/fixes/typedefs.unit
+++ b/test/fixes/typedefs.unit
@@ -1,4 +1,150 @@
 40 columns                              |
+>>>
+typedef void A();
+<<<
+typedef A = void Function();
+>>>
+typedef void A(String name);
+<<<
+typedef A = void Function(String name);
+>>>
+typedef bool A(int count);
+<<<
+typedef A = bool Function(int count);
+>>>
+typedef void A<T>();
+<<<
+typedef A<T> = void Function();
+>>>
+typedef void A<T>(T x);
+<<<
+typedef A<T> = void Function(T x);
+>>>
+typedef void A<T>(x);
+<<<
+typedef A<T> = void Function(dynamic x);
+>>>
+typedef V A<K, V>();
+<<<
+typedef A<K, V> = V Function();
+>>>
+typedef V A<K, V>(K key);
+<<<
+typedef A<K, V> = V Function(K key);
+>>>
+typedef K A<K, V>(V value);
+<<<
+typedef A<K, V> = K Function(V value);
+>>>
+typedef F<T> = void Function(T);
+<<<
+typedef F<T> = void Function(T);
+>>>
+@meta typedef void X(y);
+<<<
+@meta
+typedef X = void Function(dynamic y);
+>>> split type parameters
+typedef G = T Function<TypeOne, TypeTwo, TypeThree>();
+<<<
+typedef G = T Function<TypeOne, TypeTwo,
+    TypeThree>();
+>>> split all type parameters
+typedef G = T Function<TypeOne, TypeTwo, TypeThree, TypeFour, TypeFive, TypeSix>();
+<<<
+typedef G = T Function<
+    TypeOne,
+    TypeTwo,
+    TypeThree,
+    TypeFour,
+    TypeFive,
+    TypeSix>();
+>>> split type and value parameters
+typedef G = T Function<TypeOne, TypeTwo, TypeThree>(TypeOne one, TypeTwo two, TypeThree three);
+<<<
+typedef G = T Function<TypeOne, TypeTwo,
+        TypeThree>(TypeOne one,
+    TypeTwo two, TypeThree three);
+>>> generic typedef parameters on one line
+typedef Foo<T, S> = Function();
+<<<
+typedef Foo<T, S> = Function();
+>>> generic typedef parameters that split
+typedef LongfunctionType<First, Second, Third, Fourth, Fifth, Sixth> = Function(First first, Second second, Third third, Fourth fourth);
+<<<
+typedef LongfunctionType<First, Second,
+        Third, Fourth, Fifth, Sixth>
+    = Function(
+        First first,
+        Second second,
+        Third third,
+        Fourth fourth);
+>>> both type parameter lists split
+typedef LongfunctionType<First, Second, Third, Fourth, Fifth, Sixth> = Function<Seventh>(First first, Second second, Third third, Fourth fourth);
+<<<
+typedef LongfunctionType<First, Second,
+        Third, Fourth, Fifth, Sixth>
+    = Function<Seventh>(
+        First first,
+        Second second,
+        Third third,
+        Fourth fourth);
+>>> all three parameter lists split
+typedef LongfunctionType<First, Second, Third, Fourth, Fifth, Sixth> = Function<Seventh, Eighth, Ninth, Tenth, Eleventh, Twelfth, Thirteenth>(First first, Second second, Third third, Fourth fourth);
+<<<
+typedef LongfunctionType<First, Second,
+        Third, Fourth, Fifth, Sixth>
+    = Function<
+            Seventh,
+            Eighth,
+            Ninth,
+            Tenth,
+            Eleventh,
+            Twelfth,
+            Thirteenth>(
+        First first,
+        Second second,
+        Third third,
+        Fourth fourth);
+>>> old generic typedef syntax
+typedef Foo  <  T  ,S  >(T t,S s);
+<<<
+typedef Foo<T, S> = Function(T t, S s);
+>>> non-generic in typedef
+typedef   SomeFunc=ReturnType  Function(int param,   double other);
+<<<
+typedef SomeFunc = ReturnType Function(
+    int param, double other);
+>>> generic in typedef
+typedef Generic = T Function<T>(T param, double other);
+<<<
+typedef Generic = T Function<T>(
+    T param, double other);
+>>> no return type
+typedef SomeFunc = Function();
+<<<
+typedef SomeFunc = Function();
+>>> nested
+typedef SomeFunc = Function(int first, Function(int first, bool second, String third) second, String third);
+<<<
+typedef SomeFunc = Function(
+    int first,
+    Function(int first, bool second,
+            String third)
+        second,
+    String third);
+>>> without param names
+typedef F = Function(int, bool, String);
+<<<
+typedef F = Function(int, bool, String);
+>>> generic
+typedef    Foo < A ,B>=Function ( A a,   B b );
+<<<
+typedef Foo<A, B> = Function(A a, B b);
+>>> generic function
+typedef    Foo  =Function  < A ,B  >   ( A a,B b );
+<<<
+typedef Foo = Function<A, B>(A a, B b);
 >>> simple typedef
 typedef int Foo(int x);
 <<<

--- a/test/fixes/typedefs.unit
+++ b/test/fixes/typedefs.unit
@@ -155,9 +155,37 @@ typedef S Foo<S extends num>(S x);
 typedef Foo<S extends num> = S Function(
     S x);
 >>> named argument
-typedef int Foo(x);
+typedef int Foo({x});
 <<<
-typedef Foo = int Function(dynamic x);
+typedef Foo = int Function({dynamic x});
+>>> optional positional argument
+typedef int Foo([x]);
+<<<
+typedef Foo = int Function([dynamic x]);
+>>> metadata and keywords
+typedef int Foo(@meta v1, final v2, var v3, /*c*/ v4);
+<<<
+typedef Foo = int Function(
+    @meta dynamic v1,
+    final dynamic v2,
+    var dynamic v3,
+    /*c*/ dynamic v4);
+>>> metadata and keywords optional positional
+typedef int Foo([@meta v1, final v2, var v3, /*c*/ v4]);
+<<<
+typedef Foo = int Function(
+    [@meta dynamic v1,
+    final dynamic v2,
+    var dynamic v3,
+    /*c*/ dynamic v4]);
+>>> metadata and keywords named
+typedef int Foo({@meta v1, final v2, var v3, /*c*/ v4});
+<<<
+typedef Foo = int Function(
+    {@meta dynamic v1,
+    final dynamic v2,
+    var dynamic v3,
+    /*c*/ dynamic v4});
 >>> function argument
 typedef int Foo(int callback(int x));
 <<<
@@ -193,3 +221,31 @@ typedef Foo(foo(x));
 <<<
 typedef Foo = Function(
     Function(dynamic x) foo);
+>>> block comments in typedef
+typedef/*0*/void/*1*/Foo/*2*/<T>/*3*/(/*4*/T/*5*/foo(/*6*/x));
+<<<
+typedef /*1*/ Foo /*2*/ <T>
+    = /*0*/ void Function /*3*/ (
+        /*4*/ T Function(
+            /*6*/ dynamic x) /*5*/ foo);
+>>> eol comments in typedef
+typedef//0
+void//1
+Foo//2
+<T>//3
+(//4
+T//5
+foo(//6
+x));
+<<<
+typedef //1
+    Foo //2
+    <T>
+    = //0
+    void Function //3
+    (
+        //4
+        T Function(
+                //6
+                dynamic x) //5
+            foo);

--- a/test/fixes/typedefs.unit
+++ b/test/fixes/typedefs.unit
@@ -21,14 +21,14 @@ typedef Foo = int Function(
 typedef int Foo(int cb(int Function(int) cb2));
 <<<
 typedef Foo = int Function(
-    int Function(
-        int Function(int) cb2) cb);
+    int Function(int Function(int) cb2)
+        cb);
 >>> nested generic function
 typedef T Foo<T>(T cb<S>(T cb2(S x)));
 <<<
 typedef Foo<T> = T Function(
-    T Function<S>(
-        T Function(S x) cb2) cb);
+    T Function<S>(T Function(S x) cb2)
+        cb);
 >>> new-style function type unchanged
 typedef int Foo(int Function(int) cb);
 <<<
@@ -38,3 +38,12 @@ typedef Foo = int Function(
 typedef Foo = int Function(int);
 <<<
 typedef Foo = int Function(int);
+>>> simple typedef, no types
+typedef Foo(x);
+<<<
+typedef Foo = Function(dynamic x);
+>>> nested function types, no types
+typedef Foo(foo(x));
+<<<
+typedef Foo = Function(
+    Function(dynamic x) foo);

--- a/test/fixes/typedefs.unit
+++ b/test/fixes/typedefs.unit
@@ -1,0 +1,40 @@
+40 columns                              |
+>>> simple typedef
+typedef int Foo(int x);
+<<<
+typedef Foo = int Function(int x);
+>>> generic typedef
+typedef S Foo<S extends num>(S x);
+<<<
+typedef Foo<S extends num> = S Function(
+    S x);
+>>> named argument
+typedef int Foo(x);
+<<<
+typedef Foo = int Function(dynamic x);
+>>> function argument
+typedef int Foo(int callback(int x));
+<<<
+typedef Foo = int Function(
+    int Function(int x) callback);
+>>> nested Function type
+typedef int Foo(int cb(int Function(int) cb2));
+<<<
+typedef Foo = int Function(
+    int Function(
+        int Function(int) cb2) cb);
+>>> nested generic function
+typedef T Foo<T>(T cb<S>(T cb2(S x)));
+<<<
+typedef Foo<T> = T Function(
+    T Function<S>(
+        T Function(S x) cb2) cb);
+>>> new-style function type unchanged
+typedef int Foo(int Function(int) cb);
+<<<
+typedef Foo = int Function(
+    int Function(int) cb);
+>>> don't change correct typedef
+typedef Foo = int Function(int);
+<<<
+typedef Foo = int Function(int);


### PR DESCRIPTION
WDYT?
Would it be better to build a new node for the converted syntax and then visit that node, instead of physically building the output? It would ensure consistent formatting.