### PR TITLE
remove enableSetLiterals flag

### DIFF
--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -114,7 +114,6 @@ class DartFormatter {
     // Parse it.
     var parser = new Parser(stringSource, errorListener);
     parser.enableOptionalNewAndConst = true;
-    parser.enableSetLiterals = true;
 
     AstNode node;
     if (source.isCompilationUnit) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.35.0"
+    version: "0.35.1"
   args:
     dependency: "direct main"
     description:
@@ -77,7 +77,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.10"
+    version: "0.1.11"
   glob:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.10"
+    version: "0.3.11"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.34.0 <0.36.0'
+  analyzer: '>=0.35.1 <0.36.0'
   args: '>=0.12.1 <2.0.0'
   path: ^1.0.0
   source_span: ^1.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.2.3
+version: 1.2.4-dev
 author: Dart Team <misc@dartlang.org>
 description: Opinionated, automatic Dart source code formatter.
 homepage: https://github.com/dart-lang/dart_style


### PR DESCRIPTION
Now that set literals are enabled by default, this is a step towards removing this feature's experimental flag from the analyzer/parser base.