### PR TITLE
Stop using deprecated AST classes/methods.

### DIFF
--- a/lib/src/argument_list_visitor.dart
+++ b/lib/src/argument_list_visitor.dart
@@ -504,9 +504,7 @@ class ArgumentSublist {
     // TODO(rnystrom): Should we step into parenthesized expressions?
 
     if (expression is ListLiteral) return expression.leftBracket;
-    // TODO(rnystrom): should we return expression.leftBracket for sets as well?
-    if (expression is SetOrMapLiteral && !expression.isSet)
-      return expression.leftBracket;
+    if (expression is SetOrMapLiteral) return expression.leftBracket;
     if (expression is SingleStringLiteral && expression.isMultiline) {
       return expression.beginToken;
     }

--- a/lib/src/argument_list_visitor.dart
+++ b/lib/src/argument_list_visitor.dart
@@ -504,7 +504,9 @@ class ArgumentSublist {
     // TODO(rnystrom): Should we step into parenthesized expressions?
 
     if (expression is ListLiteral) return expression.leftBracket;
-    if (expression is MapLiteral) return expression.leftBracket;
+    // TODO(rnystrom): should we return expression.leftBracket for sets as well?
+    if (expression is SetOrMapLiteral && !expression.isSet)
+      return expression.leftBracket;
     if (expression is SingleStringLiteral && expression.isMultiline) {
       return expression.beginToken;
     }

--- a/lib/src/call_chain_visitor.dart
+++ b/lib/src/call_chain_visitor.dart
@@ -311,8 +311,7 @@ class CallChainVisitor {
 
     // Don't split right after a collection literal.
     if (expression is ListLiteral) return false;
-    // TODO(rnystrom): should we return false for sets as well?
-    if (expression is SetOrMapLiteral && !expression.isSet) return false;
+    if (expression is SetOrMapLiteral) return false;
 
     // Don't split right after a non-empty curly-bodied function.
     if (expression is FunctionExpression) {

--- a/lib/src/call_chain_visitor.dart
+++ b/lib/src/call_chain_visitor.dart
@@ -311,7 +311,8 @@ class CallChainVisitor {
 
     // Don't split right after a collection literal.
     if (expression is ListLiteral) return false;
-    if (expression is MapLiteral) return false;
+    // TODO(rnystrom): should we return false for sets as well?
+    if (expression is SetOrMapLiteral && !expression.isSet) return false;
 
     // Don't split right after a non-empty curly-bodied function.
     if (expression is FunctionExpression) {

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -503,8 +503,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   ///     ]..addAll(numbers);
   bool _isCollectionLike(Expression expression) {
     if (expression is ListLiteral) return false;
-    // TODO(rnystrom): should we return false for sets as well?
-    if (expression is SetOrMapLiteral && !expression.isSet) return false;
+    if (expression is SetOrMapLiteral) return false;
 
     // If the target is a call with a trailing comma in the argument list,
     // treat it like a collection literal.
@@ -2177,18 +2176,14 @@ class SourceVisitor extends ThrowingAstVisitor {
 
     // Don't allow a split between a name and a collection. Instead, we want
     // the collection itself to split, or to split before the argument.
-    // TODO(rnystrom): do we want the "if" test below to apply to sets as well
-    // as maps?
-    var nodeExpression = node.expression;
-    if (nodeExpression is ListLiteral ||
-        (nodeExpression is SetOrMapLiteral && nodeExpression.isSet)) {
+    if (node.expression is ListLiteral || node.expression is SetOrMapLiteral) {
       space();
     } else {
       var split = soloSplit();
       if (rule != null) split.imply(rule);
     }
 
-    visit(nodeExpression);
+    visit(node.expression);
     builder.endSpan();
     builder.unnest();
   }
@@ -2708,10 +2703,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   ///         new SomeBuilderClass()..method()..method();
   int _assignmentCost(Expression rightHandSide) {
     if (rightHandSide is ListLiteral) return Cost.assignBlock;
-    // TODO(rnystrom): or do we want the "if" test on the line below to apply to
-    // both maps and sets?
-    if (rightHandSide is SetOrMapLiteral && !rightHandSide.isSet)
-      return Cost.assignBlock;
+    if (rightHandSide is SetOrMapLiteral) return Cost.assignBlock;
     if (rightHandSide is CascadeExpression) return Cost.assignBlock;
 
     return Cost.assign;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.35.1"
+    version: "0.35.3"
   args:
     dependency: "direct main"
     description:
@@ -77,7 +77,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.11"
+    version: "0.1.13"
   glob:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3+3"
+    version: "0.13.4+1"
   http:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.11"
+    version: "0.3.13"
   logging:
     dependency: transitive
     description:
@@ -203,7 +203,7 @@ packages:
       name: package_resolver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.10"
   path:
     dependency: "direct main"
     description:
@@ -217,7 +217,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   plugin:
     dependency: transitive
     description:
@@ -287,7 +287,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.4"
+    version: "1.5.5"
   stack_trace:
     dependency: transitive
     description:
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "2.1.15"
 sdks:
-  dart: ">=2.1.0 <3.0.0"
+  dart: ">=2.1.1-dev.0.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.35.1 <0.36.0'
+  analyzer: '>=0.35.3 <0.36.0'
   args: '>=0.12.1 <2.0.0'
   path: ^1.0.0
   source_span: ^1.4.0

--- a/test/comments/sets.stmt
+++ b/test/comments/sets.stmt
@@ -50,8 +50,9 @@ var set = <int>{
 >>> multiple inline block comments
 var set = <int>{  /* 1 */   /* 2 */   /* 3 */  };
 <<<
-var set =
-    <int>{/* 1 */ /* 2 */ /* 3 */};
+var set = <int>{
+  /* 1 */ /* 2 */ /* 3 */
+};
 >>> multiline trailing block comment
 var set = <int>{  /* comment
 */  };

--- a/test/splitting/sets.stmt
+++ b/test/splitting/sets.stmt
@@ -90,8 +90,12 @@ var s = {
 >>> const
 var set = const {"foo", "bar", "fuz", null};
 <<<
-var set =
-    const {"foo", "bar", "fuz", null};
+var set = const {
+  "foo",
+  "bar",
+  "fuz",
+  null
+};
 >>> trailing comma forces split
 var set = {"foo", "bar" , };
 <<<


### PR DESCRIPTION
As part of implementing the "UI as code" feature
(https://github.com/dart-lang/language/blob/master/accepted/future-releases/unified-collections/feature-specification.md)
the analyzer is deprecating the following classes and methods:

- ForStatement and ForEachStatement (ForStatement2 is now used for
  both kinds of loops)

- ListLiteral.elements (use elements2, which has a more general return
  type)

- AstVisitor.visitForEachStatement and AstVisitor.visitForStatement
  (visitForStatement2 is now used for both kinds of loops)

- AstVisitor.visitMapLiteral and AstVisitor.visitSetLiteral
  (visitSetOrMapLiteral is now used for both kinds of literals).

See deprecation CL: https://dart-review.googlesource.com/c/sdk/+/95665/

Analyzer clients need to be adapted to stop using the deprecated
classes and methods.