### PR TITLE
no extra-indent of expression function as argument with trailing comma

### DIFF
--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1022,11 +1022,24 @@ class SourceVisitor extends ThrowingAstVisitor {
 
     if (_isInLambda(node)) builder.endSpan();
 
-    builder.startBlockArgumentNesting();
+    // If this function invocation appears in an argument list with trailing
+    // comma, don't add extra nesting to preserve normal indentation.
+    var isArgWithTrailingComma = false;
+    var parent = node.parent;
+    if (parent is FunctionExpression) {
+      var argList = parent?.parent;
+      if (argList is NamedExpression) argList = argList.parent;
+      if (argList is ArgumentList &&
+          argList.arguments.last.endToken.next.type == TokenType.COMMA) {
+        isArgWithTrailingComma = true;
+      }
+    }
+
+    if (!isArgWithTrailingComma) builder.startBlockArgumentNesting();
     builder.startSpan();
     visit(node.expression);
     builder.endSpan();
-    builder.endBlockArgumentNesting();
+    if (!isArgWithTrailingComma) builder.endBlockArgumentNesting();
 
     if (node.expression is BinaryExpression) builder.endRule();
 

--- a/test/splitting/function_arguments.stmt
+++ b/test/splitting/function_arguments.stmt
@@ -201,3 +201,14 @@ longFunction(
       ;
     },
     c: argument);
+>>> avoid extra-indent for expression function as argument with trailing comma
+function(() => P(p,),a: () => A(a,),);
+<<<
+function(
+  () => P(
+    p,
+  ),
+  a: () => A(
+    a,
+  ),
+);


### PR DESCRIPTION
Actual:

```dart
      onTap: () {
        Navigator.of(context).push(CupertinoPageRoute<void>(
          title: colorName,
          builder: (BuildContext context) => Tab1ItemPage(
                color: color,
                colorName: colorName,
                index: index,
              ),
        ));
      },
```

Expected:

```dart
      onTap: () {
        Navigator.of(context).push(CupertinoPageRoute<void>(
          title: colorName,
          builder: (BuildContext context) => Tab1ItemPage(
            color: color,
            colorName: colorName,
            index: index,
          ),
        ));
      },
```
