### PR TITLE
Don't indent adjacent strings directly inside "=>" functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.7
+
+* Improve indentation of adjacent strings inside `=>` functions.
+
 # 1.2.6
 
 * Properly format trailing commas in assertions.

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -15,7 +15,7 @@ import 'package:dart_style/src/source_code.dart';
 import 'package:dart_style/src/style_fix.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const version = "1.2.6";
+const version = "1.2.7";
 
 void main(List<String> args) {
   var parser = ArgParser(allowTrailingOptions: true);

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -210,15 +210,13 @@ class SourceVisitor extends ThrowingAstVisitor {
     // expression is the only string in an argument list.
     var shouldNest = true;
 
-    isString(AstNode node) => node is StringLiteral || node is AdjacentStrings;
-
     var parent = node.parent;
     if (parent is ArgumentList) {
       shouldNest = false;
 
       for (var argument in parent.arguments) {
         if (argument == node) continue;
-        if (isString(argument)) {
+        if (argument is StringLiteral) {
           shouldNest = true;
           break;
         }
@@ -226,11 +224,11 @@ class SourceVisitor extends ThrowingAstVisitor {
     } else if (parent is Assertion) {
       // Treat asserts like argument lists.
       shouldNest = false;
-      if (parent.condition != node && isString(parent.condition)) {
+      if (parent.condition != node && parent.condition is StringLiteral) {
         shouldNest = true;
       }
 
-      if (parent.message != node && isString(parent.message)) {
+      if (parent.message != node && parent.message is StringLiteral) {
         shouldNest = true;
       }
     } else if (parent is VariableDeclaration ||
@@ -243,7 +241,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       //         "no extra"
       //         "indent";
       shouldNest = false;
-    } else if (parent is NamedExpression) {
+    } else if (parent is NamedExpression || parent is ExpressionFunctionBody) {
       shouldNest = false;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.2.6
+version: 1.2.7
 author: Dart Team <misc@dartlang.org>
 description: >-
   Opinionated, automatic Dart source code formatter.

--- a/test/regression/0400/0467.unit
+++ b/test/regression/0400/0467.unit
@@ -19,7 +19,8 @@ class MyElement extends PolymerElement {
   void showNodesAndEntryPoints([_, __]) {
     addAll(
         'nodesAndEntryPoints',
-        new PolymerDom(this).children.map((child) => '${child.outerHtml} ------> '
+        new PolymerDom(this).children.map((child) =>
+            '${child.outerHtml} ------> '
             '${(new PolymerDom(child).getDestinationInsertionPoints()[0] as Element).outerHtml}'));
   }
 }

--- a/test/regression/0800/0802.unit
+++ b/test/regression/0800/0802.unit
@@ -1,0 +1,24 @@
+>>>
+class C {
+  @override
+  String get message =>
+      'Unrecognized keys: [${unrecognizedKeys.join(', ')}]; supported keys: '
+          '[${allowedKeys.join(', ')}]';
+}
+<<<
+class C {
+  @override
+  String get message =>
+      'Unrecognized keys: [${unrecognizedKeys.join(', ')}]; supported keys: '
+      '[${allowedKeys.join(', ')}]';
+}
+>>>
+String _link(String version, String owner, String name) =>
+    '${_anchorUriForName(owner, name)}: '
+        'https://pub.dartlang.org/documentation/json_annotation/$version/'
+        'json_annotation/$owner/$name.html';
+<<<
+String _link(String version, String owner, String name) =>
+    '${_anchorUriForName(owner, name)}: '
+    'https://pub.dartlang.org/documentation/json_annotation/$version/'
+    'json_annotation/$owner/$name.html';

--- a/test/whitespace/adjacent_strings.stmt
+++ b/test/whitespace/adjacent_strings.stmt
@@ -137,10 +137,36 @@ var set = {
 };
 >>> don't indent in => body
 main() => "adjacent"
-"string";
+"string"
+"another";
 <<<
 main() => "adjacent"
-    "string";
+    "string"
+    "another";
+>>> don't indent in long => body
+main() => "very very very very long adjacent"
+"string"
+"another";
+<<<
+main() =>
+    "very very very very long adjacent"
+    "string"
+    "another";
+>>> don't indent in => lambda
+function(
+  (parameter) => "string"
+  "adjacent",
+  (parameter) => "long long long long string"
+  "adjacent",
+  another);
+<<<
+function(
+    (parameter) => "string"
+        "adjacent",
+    (parameter) =>
+        "long long long long string"
+        "adjacent",
+    another);
 >>> indent in then branch of ?:
 var string = c ? "adjacent"
 "string" : "other";


### PR DESCRIPTION
Fixes #802.

I ran it on a big corpus and compared to 1.2.6, the only changes are expected ones around these functions.