### PR TITLE
handle method with trailing comma like block in method chain

### DIFF
--- a/lib/src/argument_list_visitor.dart
+++ b/lib/src/argument_list_visitor.dart
@@ -503,6 +503,16 @@ class ArgumentSublist {
       return expression.beginToken;
     }
 
+    // instance creation or method invocation with trailing comma are like block
+    if (expression is InstanceCreationExpression &&
+        expression.argumentList.endToken.previous.type == TokenType.COMMA) {
+      return expression.argumentList.beginToken;
+    }
+    if (expression is MethodInvocation &&
+        expression.argumentList.endToken.previous.type == TokenType.COMMA) {
+      return expression.argumentList.beginToken;
+    }
+
     // Not a collection literal.
     return null;
   }

--- a/lib/src/call_chain_visitor.dart
+++ b/lib/src/call_chain_visitor.dart
@@ -157,8 +157,12 @@ class CallChainVisitor {
       // See if this call is a method call whose arguments are block formatted.
       var isBlockCall = false;
       if (call is MethodInvocation) {
-        var args = ArgumentListVisitor(visitor, call.argumentList);
-        isBlockCall = args.hasBlockArguments;
+        if (call.argumentList.endToken.previous.type == TokenType.COMMA) {
+          isBlockCall = true;
+        } else {
+          var args = ArgumentListVisitor(visitor, call.argumentList);
+          isBlockCall = args.hasBlockArguments;
+        }
       }
 
       if (isBlockCall) {

--- a/test/splitting/mixed.stmt
+++ b/test/splitting/mixed.stmt
@@ -118,6 +118,14 @@ receiver.first([
   secondItem,
   thirdItem
 ]).second();
+>>> trailing comma inside method chain
+receiver.first(a, b, c,).second();
+<<<
+receiver.first(
+  a,
+  b,
+  c,
+).second();
 >>> list at end of method chain
 receiver.first().second([listItem, secondItem, thirdItem, fourthItem]);
 <<<

--- a/test/splitting/mixed.stmt
+++ b/test/splitting/mixed.stmt
@@ -126,6 +126,22 @@ receiver.first(
   b,
   c,
 ).second();
+>>> trailing comma inside method chain
+receiver.first(new A(a, b, c,)).second();
+<<<
+receiver.first(new A(
+  a,
+  b,
+  c,
+)).second();
+>>> trailing comma inside method chain
+receiver.first(f(a, b, c,)).second();
+<<<
+receiver.first(f(
+  a,
+  b,
+  c,
+)).second();
 >>> list at end of method chain
 receiver.first().second([listItem, secondItem, thirdItem, fourthItem]);
 <<<


### PR DESCRIPTION
This PR will produce:

```dart
padding: MediaQuery.of(context).removePadding(
  removeTop: true,
  removeLeft: true,
  removeRight: true,
).padding,
```

instead of:

```dart
padding: MediaQuery.of(context)
    .removePadding(
      removeTop: true,
      removeLeft: true,
      removeRight: true,
    )
    .padding,
```