### PR TITLE
Add --fix-single-cascade-statements flag.

### DIFF
--- a/lib/src/style_fix.dart
+++ b/lib/src/style_fix.dart
@@ -21,12 +21,16 @@ class StyleFix {
   static const optionalNew =
       StyleFix._("optional-new", 'Remove "new" keyword.');
 
+  static const singleCascadeStatements = StyleFix._("single-cascade-statements",
+      "Remove unnecessary single cascades from expression statements.");
+
   static const all = [
     docComments,
     functionTypedefs,
     namedDefaultSeparator,
     optionalConst,
-    optionalNew
+    optionalNew,
+    singleCascadeStatements,
   ];
 
   final String name;


### PR DESCRIPTION
Automatically cleans up violations of the lint avoid_single_cascade_in_expression_statements.

Before:
```
  o..m = x;
```
After:
```
  o.m = x;
```

Adds parentheses when necessary to avoid changing operator precedence, as in the following examples:

Before:
```
  a as A..x = 42;
```
After:
```
  (a as A).x = 42;
```

Before:
```
  await someFuture
    ..doThing();
```
After:
```
  (await someFuture).doThing();
```