### PR TITLE
Add tests for null-aware index expressions.

### DIFF
--- a/test/splitting/expressions.stmt
+++ b/test/splitting/expressions.stmt
@@ -131,6 +131,12 @@ identifier[longArgument][longArgument][longArgument][longArgument][longArgument]
 identifier[longArgument][longArgument]
         [longArgument][longArgument]
     [longArgument];
+>>> null-aware indexes
+identifier?.[longArgument][longArgument]?.[longArgument][longArgument]?.[longArgument];
+<<<
+identifier?.[longArgument][longArgument]
+        ?.[longArgument][longArgument]
+    ?.[longArgument];
 >>> is
 verylongIdentifier.property is LongTypeName;
 <<<

--- a/test/splitting/invocations.stmt
+++ b/test/splitting/invocations.stmt
@@ -426,3 +426,13 @@ compiler!.a(() {
 })!.b(() {
   ;
 })!;
+>>> null-aware index
+receiver.property1.property2
+        .property3?.[0][1]?.[2]
+    .method1()?.[0][1]?.[2]
+    .method2();
+<<<
+receiver.property1.property2
+    .property3?.[0][1]?.[2]
+    .method1()?.[0][1]?.[2]
+    .method2();

--- a/test/whitespace/expressions.stmt
+++ b/test/whitespace/expressions.stmt
@@ -159,3 +159,7 @@ obj!.getter!.method(arg)! + 3;
 obj ! [ index ] ! ( call ) ! + 3;
 <<<
 obj![index]!(call)! + 3;
+>>> null-aware index expressions
+obj   ?.[  foo];
+<<<
+obj?.[foo];


### PR DESCRIPTION
No code changes are needed since "?.[" is treated as a single token by
the parser and dartfmt just preserves the whole lexeme.