### PR TITLE
Don't give empty spread collections block-like formatting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add support for formatting extension methods (#830).
 * Format `?` in types.
 * Format the `late` modifier.
+* Better formatting of empty spread collections (#831).
 
 # 1.2.10
 

--- a/test/regression/0800/0831.unit
+++ b/test/regression/0800/0831.unit
@@ -1,0 +1,17 @@
+>>>
+foo() {
+  final bar = [
+    if (longVariableName == 'do nothing but be long') ...[] else if (longVariableName ==
+        'show the welcome message')
+      'Hello'
+  ];
+}
+<<<
+foo() {
+  final bar = [
+    if (longVariableName == 'do nothing but be long')
+      ...[]
+    else if (longVariableName == 'show the welcome message')
+      'Hello'
+  ];
+}

--- a/test/splitting/list_collection_if.stmt
+++ b/test/splitting/list_collection_if.stmt
@@ -314,3 +314,99 @@ var list = [
       h
     }
 ];
+>>> empty then spread not treated like block
+var list = [
+  if (condition) ...[] else ...[a,]
+];
+<<<
+var list = [
+  if (condition)
+    ...[]
+  else ...[
+    a,
+  ]
+];
+>>> empty else spread not treated like block
+var list = [
+  if (condition) ...[a,] else ...[]
+];
+<<<
+var list = [
+  if (condition) ...[
+    a,
+  ] else
+    ...[]
+];
+>>> empty then spread does not split
+var list = [
+  if (condition) ...[] else veryLongIdentifier
+];
+<<<
+var list = [
+  if (condition)
+    ...[]
+  else
+    veryLongIdentifier
+];
+>>> empty else spread does not split
+var list = [
+  if (condition) veryLongIdentifier else ...[]
+];
+<<<
+var list = [
+  if (condition)
+    veryLongIdentifier
+  else
+    ...[]
+];
+>>> empty then spread with comment treated like block
+var list = [
+  if (condition) ...[// c
+  ] else ...[a,]
+];
+<<<
+var list = [
+  if (condition) ...[
+    // c
+  ] else ...[
+    a,
+  ]
+];
+>>> empty else spread with comment treated like block
+var list = [
+  if (condition) ...[a,] else ...[// c
+  ]
+];
+<<<
+var list = [
+  if (condition) ...[
+    a,
+  ] else ...[
+    // c
+  ]
+];
+>>> empty then spread with comment splits
+var list = [
+  if (condition) ...[// c
+  ] else veryLongIdentifier
+];
+<<<
+var list = [
+  if (condition) ...[
+    // c
+  ] else
+    veryLongIdentifier
+];
+>>> empty else spread with comment splits
+var list = [
+  if (condition) veryLongIdentifier else ...[// c
+  ]
+];
+<<<
+var list = [
+  if (condition)
+    veryLongIdentifier
+  else ...[
+    // c
+  ]
+];


### PR DESCRIPTION
Spread collection literals are given special block-like formatting to
produce output like:

```dart
    [
      if (condition) ...[
        1,
        2
      ]
    ]
```

This doesn't work for empty literals since they can't split inside.
Instead, we just don't give those block handling at all. That's maybe
not the ideal formatting -- there are cases where splitting the empty
collection would look better, but it works pretty well and is simple.

Fix #831.