### PR TITLE
Simplify dep version constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.3.0
+version: 1.3.1-dev
 author: Dart Team <misc@dartlang.org>
 description: >-
   Opinionated, automatic Dart source code formatter.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.38.3 <0.39.0'
-  args: '>=0.12.1 <2.0.0'
+  analyzer: ^0.38.3
+  args: ^1.0.0
   path: ^1.0.0
   source_span: ^1.4.0
 


### PR DESCRIPTION
- Switch `analyzer` dep to caret style since it's a shorter way to
  express the same constraint.
- Switch `args` dep to caret style since there are no earlier version
  which also support the SDK used by this package.