### PR TITLE
Fix crash on hanging property calls following block arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.1
+
+* Fix crash in formatting complex method chains (#855).
+
 # 1.3.0
 
 * Add support for formatting extension methods (#830).

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -15,7 +15,7 @@ import 'package:dart_style/src/source_code.dart';
 import 'package:dart_style/src/style_fix.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const version = "1.3.0";
+const version = "1.3.1";
 
 void main(List<String> args) {
   var parser = ArgParser(allowTrailingOptions: true);

--- a/lib/src/call_chain_visitor.dart
+++ b/lib/src/call_chain_visitor.dart
@@ -96,7 +96,7 @@ class CallChainVisitor {
   /// need to split before its `.` and this accommodates the common pattern of
   /// a trailing `toList()` or `toSet()` after a series of higher-order methods
   /// on an iterable.
-  final _MethodSelector _hangingCall;
+  final _Selector _hangingCall;
 
   /// Whether or not a [Rule] is currently active for the call chain.
   bool _ruleEnabled = false;
@@ -136,7 +136,7 @@ class CallChainVisitor {
 
     // Separate out the block calls, if there are any.
     List<_MethodSelector> blockCalls;
-    _MethodSelector hangingCall;
+    _Selector hangingCall;
 
     var inBlockCalls = false;
     for (var call in calls) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.3.0
+version: 1.3.1
 author: Dart Team <misc@dartlang.org>
 description: >-
   Opinionated, automatic Dart source code formatter.

--- a/test/regression/0800/0855.unit
+++ b/test/regression/0800/0855.unit
@@ -1,0 +1,46 @@
+>>>
+Method _main() => Method((b) => b
+  ..name = 'main'
+  ..modifier = MethodModifier.async
+  ..requiredParameters.add(Parameter((b) => b
+    ..name = 'args'
+    ..type = TypeReference((b) => b
+      ..symbol = 'List'
+      ..types.add(refer('String')))))
+  ..optionalParameters.add(Parameter((b) => b
+    ..name = 'sendPort'
+    ..type = refer('SendPort', 'dart:isolate')))
+  ..body = Block.of([
+    refer('run', 'package:build_runner/build_runner.dart')
+        .call([refer('args'), refer('_builders')])
+        .awaited
+        .assignVar('result')
+        .statement,
+    refer('sendPort')
+        .nullSafeProperty('send')
+        .call([refer('result')]).statement,
+    refer('exitCode', 'dart:io').assign(refer('result')).statement,
+  ]));
+<<<
+Method _main() => Method((b) => b
+  ..name = 'main'
+  ..modifier = MethodModifier.async
+  ..requiredParameters.add(Parameter((b) => b
+    ..name = 'args'
+    ..type = TypeReference((b) => b
+      ..symbol = 'List'
+      ..types.add(refer('String')))))
+  ..optionalParameters.add(Parameter((b) => b
+    ..name = 'sendPort'
+    ..type = refer('SendPort', 'dart:isolate')))
+  ..body = Block.of([
+    refer('run', 'package:build_runner/build_runner.dart')
+        .call([refer('args'), refer('_builders')])
+        .awaited
+        .assignVar('result')
+        .statement,
+    refer('sendPort')
+        .nullSafeProperty('send')
+        .call([refer('result')]).statement,
+    refer('exitCode', 'dart:io').assign(refer('result')).statement,
+  ]));


### PR DESCRIPTION
A _Selector gets assigned to a variable and field whose type was the
subclass _MethodSelector. However, sometimes the value is actually a
_PropertySelector. Alas, that unsafe downcast isn't caught at compile
time because of implicit downcasts. :(

Fix #855.