### PR TITLE
Fix inconsistencies after revert

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   source_span: ^1.4.0
 
 dev_dependencies:
-  async: '>=1.0.0 <=3.0.0'
   grinder: ^0.8.0
   js: ^0.6.0
   node_preamble: ^1.0.0

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -6,7 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:grinder/grinder.dart';
-import "package:node_preamble/preamble.dart" as preamble;
+import 'package:node_preamble/preamble.dart' as preamble;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart' as yaml;
 


### PR DESCRIPTION
- Remove `async` dep since it is unused.
- Use consistent single quotes for imports.