### PR TITLE
Preserve commas after nullable function-typed parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.2
+
+* Preserve comma after nullable function-typed parameters (#862).
+
 # 1.3.1
 
 * Fix crash in formatting complex method chains (#855).

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -15,7 +15,7 @@ import 'package:dart_style/src/source_code.dart';
 import 'package:dart_style/src/style_fix.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const version = "1.3.1";
+const version = "1.3.2";
 
 void main(List<String> args) {
   var parser = ArgParser(allowTrailingOptions: true);

--- a/lib/src/argument_list_visitor.dart
+++ b/lib/src/argument_list_visitor.dart
@@ -207,7 +207,7 @@ class ArgumentListVisitor {
         _visitor.visit(argument);
 
         // Write the following comma.
-        if (argument.endToken.next.type == TokenType.COMMA) {
+        if (_visitor.hasCommaAfter(argument)) {
           _visitor.token(argument.endToken.next);
         }
       }
@@ -480,7 +480,7 @@ class ArgumentSublist {
     }
 
     // Write the following comma.
-    if (argument.endToken.next.type == TokenType.COMMA) {
+    if (visitor.hasCommaAfter(argument)) {
       visitor.token(argument.endToken.next);
     }
   }

--- a/lib/src/call_chain_visitor.dart
+++ b/lib/src/call_chain_visitor.dart
@@ -321,7 +321,7 @@ class CallChainVisitor {
     var argument = argumentList.arguments.last;
 
     // If the argument list has a trailing comma, treat it like a collection.
-    if (argument.endToken.next.type == TokenType.COMMA) return false;
+    if (_visitor.hasCommaAfter(argument)) return false;
 
     if (argument is NamedExpression) {
       argument = (argument as NamedExpression).expression;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.3.1
+version: 1.3.2
 author: Dart Team <misc@dartlang.org>
 description: >-
   Opinionated, automatic Dart source code formatter.

--- a/test/regression/0800/0862.unit
+++ b/test/regression/0800/0862.unit
@@ -1,0 +1,64 @@
+>>>
+class JsonCodec {
+  const JsonCodec({
+      Object? reviver(Object? key, Object? value)?,
+      Object? toEncodable(dynamic object)?})
+      : _reviver = reviver,
+        _toEncodable = toEncodable;
+}
+<<<
+class JsonCodec {
+  const JsonCodec(
+      {Object? reviver(Object? key, Object? value)?,
+      Object? toEncodable(dynamic object)?})
+      : _reviver = reviver,
+        _toEncodable = toEncodable;
+}
+>>>
+class JsonUtf8Encoder {
+  JsonUtf8Encoder(
+      [String? indent, dynamic toEncodable(dynamic object)?, int? bufferSize])
+      : _indent = _utf8Encode(indent),
+        _toEncodable = toEncodable,
+        _bufferSize = bufferSize ?? _defaultBufferSize;
+}
+<<<
+class JsonUtf8Encoder {
+  JsonUtf8Encoder(
+      [String? indent, dynamic toEncodable(dynamic object)?, int? bufferSize])
+      : _indent = _utf8Encode(indent),
+        _toEncodable = toEncodable,
+        _bufferSize = bufferSize ?? _defaultBufferSize;
+}
+>>> comma between parameters
+mandatory(f()?,i) {}
+optional([f()?,i]) {}
+named({f()?,i}) {}
+<<<
+mandatory(f()?, i) {}
+optional([f()?, i]) {}
+named({f()?, i}) {}
+>>> trailing commas
+mandatory(f()?,) {}
+optional([f()?,]) {}
+named({f()?,}) {}
+<<<
+mandatory(
+  f()?,
+) {}
+optional([
+  f()?,
+]) {}
+named({
+  f()?,
+}) {}
+>>> constructor initializer trailing comma
+class C {
+  C(f()?,) : field = 3;
+}
+<<<
+class C {
+  C(
+    f()?,
+  ) : field = 3;
+}

--- a/test/whitespace/functions.unit
+++ b/test/whitespace/functions.unit
@@ -167,9 +167,19 @@ function(int   foo  <  T  ,S >(T t, S s)) {}
 <<<
 function(int foo<T, S>(T t, S s)) {}
 >>> nullable old style function typed parameter
-function(int? callback()?) {}
+function(int? callback()    ?  ) {}
 <<<
 function(int? callback()?) {}
+>>> nullable old style function typed parameter with trailing comma
+function(int? f()?  ,p) {}
+<<<
+function(int? f()?, p) {}
+>>> nullable old style function typed parameter with trailing comma
+function(int? callback()   ?   ,    ) {}
+<<<
+function(
+  int? callback()?,
+) {}
 >>> required parameters
 class A {
 f({   required    int a,required   b}) {}


### PR DESCRIPTION
Fix #862. This is a workaround for:

https://github.com/dart-lang/sdk/issues/38990

cc @leafpetersen 