### PR TITLE
Preserve leading indentation in fixed doc comments (#821).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add `--fix-single-cascade-statements`.
 * Correctly handle `var` in `--fix-function-typedefs` (#826).
+* Preserve leading indentation in fixed doc comments (#821).
 
 # 1.3.3
 

--- a/test/fixes/doc_comments.stmt
+++ b/test/fixes/doc_comments.stmt
@@ -157,3 +157,39 @@ m() {}
 /// Thing.
 /// Another * thing.
 m() {}
+>>> missing "*" but indented (#821)
+/**
+This is an ugly dartdoc comment that contains a code block.
+
+    class Foo {
+      final int x;
+      Foo(this.x);
+    }
+
+The formatting gets messed up by `dartfmt --fix-doc-comments`.
+*/
+m() {}
+<<<
+/// This is an ugly dartdoc comment that contains a code block.
+///
+///     class Foo {
+///       final int x;
+///       Foo(this.x);
+///     }
+///
+/// The formatting gets messed up by `dartfmt --fix-doc-comments`.
+m() {}
+>>> strip leading indentation shared by all lines
+/**    4
+   3
+  *     5
+ *  2
+       7 */
+m() {}
+<<<
+///   4
+///  3
+///    5
+/// 2
+///      7
+m() {}


### PR DESCRIPTION
This was done for comment lines starting with "`*`" but not ones without
the (correct) JavaDoc marker. Now it does so for doc comment lines that
lack a leading "`*`".