### PR TITLE
Indent blocks in initializers of multiple variable declarations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Split outer nested control flow elements (#869).
 * Always place a blank line after script tags (#782).
 * Don't add unneeded splits on if elements near comments (#888).
+* Indent blocks in initializers of multiple-variable declarations.
 
 # 1.3.3
 

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2698,9 +2698,16 @@ class SourceVisitor extends ThrowingAstVisitor {
     // possible, we split after *every* declaration so that each is on its own
     // line.
     builder.startRule();
-    visitCommaSeparatedNodes(node.variables, between: split);
-    builder.endRule();
 
+    // If there are multiple declarations split across lines, then we want any
+    // blocks in the initializers to indent past the variables.
+    if (node.variables.length > 1) builder.startBlockArgumentNesting();
+
+    visitCommaSeparatedNodes(node.variables, between: split);
+
+    if (node.variables.length > 1) builder.endBlockArgumentNesting();
+
+    builder.endRule();
     _endPossibleConstContext(node.keyword);
   }
 

--- a/test/regression/0900/0900.stmt
+++ b/test/regression/0900/0900.stmt
@@ -1,0 +1,22 @@
+>>>
+void main() {
+  final f = stdin.readLineSync,
+      p = int.parse,
+      n = p(f()),
+      ranges = List.generate(n, (_) {
+    final t = f().split(' '), a = p(t[0]), b = a + p(t[1]);
+    return [a, b];
+  }),
+      dp = List<int>(n);
+}
+<<<
+void main() {
+  final f = stdin.readLineSync,
+      p = int.parse,
+      n = p(f()),
+      ranges = List.generate(n, (_) {
+        final t = f().split(' '), a = p(t[0]), b = a + p(t[1]);
+        return [a, b];
+      }),
+      dp = List<int>(n);
+}

--- a/test/splitting/variables.stmt
+++ b/test/splitting/variables.stmt
@@ -72,3 +72,10 @@ var x = new XXXXXXXXXXXXXXXXXXXXXXXXXXXXX();
 <<<
 var x =
     new XXXXXXXXXXXXXXXXXXXXXXXXXXXXX();
+>>> nest blocks when variables split
+SomeType a = () {;}, b;
+<<<
+SomeType a = () {
+      ;
+    },
+    b;


### PR DESCRIPTION
This fixes the example in the second comment on issue #900, but not
the main issue.