### PR TITLE
Remove "--verbose" as a general flag.

### DIFF
--- a/bin/format.dart
+++ b/bin/format.dart
@@ -19,19 +19,19 @@ const version = '1.3.3';
 void main(List<String> args) {
   var parser = ArgParser(allowTrailingOptions: true);
 
-  var verbose = args.contains('-v') || args.contains('--verbose');
-  var hide = !verbose;
+  var showAllOptions = false;
+  if (args.contains('--help')) {
+    args = args.toList();
+    showAllOptions = args.remove('-v');
+  }
 
   parser.addSeparator('Common options:');
   parser.addFlag('help',
       abbr: 'h',
       negatable: false,
-      help:
-          'Shows this usage information.  Add --verbose to show hidden options.');
+      help: 'Shows this usage information. Add -v to show hidden options.');
   parser.addFlag('version',
       negatable: false, help: 'Shows version information.');
-  parser.addFlag('verbose',
-      abbr: 'v', negatable: false, help: 'Verbose output.');
   parser.addOption('line-length',
       abbr: 'l', help: 'Wrap lines longer than this.', defaultsTo: '80');
   parser.addFlag('overwrite',
@@ -51,35 +51,36 @@ void main(List<String> args) {
     parser.addFlag('fix-${fix.name}', negatable: false, help: fix.description);
   }
 
-  if (verbose) {
+  if (showAllOptions) {
     parser.addSeparator('Other options:');
   }
   parser.addOption('indent',
       abbr: 'i',
       help: 'Spaces of leading indentation.',
       defaultsTo: '0',
-      hide: hide);
+      hide: !showAllOptions);
   parser.addFlag('machine',
       abbr: 'm',
       negatable: false,
       help: 'Produce machine-readable JSON output.',
-      hide: hide);
+      hide: !showAllOptions);
   parser.addFlag('set-exit-if-changed',
       negatable: false,
       help: 'Return exit code 1 if there are any formatting changes.',
-      hide: hide);
+      hide: !showAllOptions);
   parser.addFlag('follow-links',
       negatable: false,
       help: 'Follow links to files and directories.\n'
           'If unset, links will be ignored.',
-      hide: hide);
+      hide: !showAllOptions);
   parser.addOption('preserve',
-      help: 'Selection to preserve, formatted as "start:length".', hide: hide);
+      help: 'Selection to preserve, formatted as "start:length".',
+      hide: !showAllOptions);
   parser.addOption('stdin-name',
       help: 'The path name to show when an error occurs in source read from '
           'stdin.',
       defaultsTo: '<stdin>',
-      hide: hide);
+      hide: !showAllOptions);
 
   parser.addFlag('profile', negatable: false, hide: true);
   parser.addFlag('transform', abbr: 't', negatable: false, hide: true);

--- a/test/command_line_test.dart
+++ b/test/command_line_test.dart
@@ -81,8 +81,8 @@ void main() {
     await process.shouldExit(0);
   });
 
-  test('--help --verbose', () async {
-    var process = await runFormatter(['--help', '--verbose']);
+  test('--help -v', () async {
+    var process = await runFormatter(['--help', '-v']);
     await expectLater(
         process.stdout, emits('Idiomatically formats Dart source code.'));
     await expectLater(process.stdout, emits(''));
@@ -91,6 +91,13 @@ void main() {
     await expectLater(process.stdout, emitsThrough('Other options:'));
     await expectLater(process.stdout, emits(startsWith('-i, --indent')));
     await process.shouldExit(0);
+  });
+
+  test('-v is only allowed for --help', () async {
+    var process = await runFormatter(['-v']);
+    await expectLater(process.stdout,
+        emits(contains('Could not find an option or flag "-v".')));
+    await process.shouldExit(64);
   });
 
   test('only prints a hidden directory once', () async {


### PR DESCRIPTION
Dartfmt doesn't have verbose *output*, it just has verbose *help*, so
only allow "-v" as an option to "--help".