### PR TITLE
Restore the command line output inadvertently removed in 1.3.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.5-dev
+
+* Restore command line output accidentally removed in 1.3.4.
+
 # 1.3.4
 
 * Add `--fix-single-cascade-statements`.

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -53,7 +53,7 @@ void main(List<String> args) {
     usageError(parser, 'Cannot use --$chosen and --$other at the same time.');
   }
 
-  var show = Show.overwrite;
+  var show = Show.legacy;
   var summary = Summary.none;
   var output = Output.show;
   var setExitIfChanged = false;
@@ -71,6 +71,7 @@ void main(List<String> args) {
           'Cannot use --overwrite without providing any paths to format.');
     }
 
+    show = Show.overwrite;
     output = Output.write;
   } else if (argResults['machine']) {
     output = Output.json;

--- a/lib/src/cli/show.dart
+++ b/lib/src/cli/show.dart
@@ -14,6 +14,9 @@ abstract class Show {
   /// Only files whose formatting changed.
   static const Show changed = _ChangedShow();
 
+  /// The legacy dartfmt output style when not overwriting files.
+  static const Show legacy = _LegacyShow();
+
   /// The legacy dartfmt output style when overwriting files.
   static const Show overwrite = _OverwriteShow();
 
@@ -53,13 +56,7 @@ abstract class Show {
   }
 }
 
-class _NoneShow extends Show {
-  const _NoneShow() : super._();
-}
-
-class _AllShow extends Show {
-  const _AllShow() : super._();
-
+mixin _ShowFileMixin on Show {
   @override
   bool file(String path, {bool changed, bool overwritten}) {
     if (changed) {
@@ -72,25 +69,10 @@ class _AllShow extends Show {
   }
 }
 
-class _ChangedShow extends Show {
-  const _ChangedShow() : super._();
-
-  @override
-  bool file(String path, {bool changed, bool overwritten}) {
-    if (changed) _showFileChange(path, overwritten: overwritten);
-    return changed;
-  }
-}
-
-class _OverwriteShow extends Show {
-  const _OverwriteShow() : super._();
-
+mixin _LegacyMixin on Show {
   @override
   String displayPath(String directory, String file) =>
       p.relative(file, from: directory);
-
-  @override
-  bool file(String path, {bool changed, bool overwritten}) => true;
 
   @override
   void directory(String directory) {
@@ -106,6 +88,32 @@ class _OverwriteShow extends Show {
   void hiddenPath(String path) {
     print('Skipping hidden path $path');
   }
+}
+
+class _NoneShow extends Show {
+  const _NoneShow() : super._();
+}
+
+class _AllShow extends Show with _ShowFileMixin {
+  const _AllShow() : super._();
+}
+
+class _ChangedShow extends Show {
+  const _ChangedShow() : super._();
+
+  @override
+  bool file(String path, {bool changed, bool overwritten}) {
+    if (changed) _showFileChange(path, overwritten: overwritten);
+    return changed;
+  }
+}
+
+class _LegacyShow extends Show with _LegacyMixin {
+  const _LegacyShow() : super._();
+}
+
+class _OverwriteShow extends Show with _ShowFileMixin, _LegacyMixin {
+  const _OverwriteShow() : super._();
 }
 
 class _DryRunShow extends Show {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.3.4
+version: 1.3.5-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/command_line_test.dart
+++ b/test/command_line_test.dart
@@ -35,6 +35,28 @@ void main() {
     await d.dir('code', [d.file('c.dart', unformattedSource)]).validate();
   });
 
+  test('Overwrites files', () async {
+    await d.dir('code', [
+      d.file('a.dart', unformattedSource),
+      d.file('b.dart', formattedSource),
+      d.file('c.dart', unformattedSource)
+    ]).create();
+
+    var process = await runFormatterOnDir(['--overwrite']);
+    await expectLater(
+        process.stdout, emits(startsWith('Formatting directory')));
+
+    // Prints whether each file was changed.
+    await expectLater(process.stdout, emits('Formatted code/a.dart'));
+    await expectLater(process.stdout, emits('Unchanged code/b.dart'));
+    await expectLater(process.stdout, emits('Formatted code/c.dart'));
+    await process.shouldExit(0);
+
+    // Overwrites the files.
+    await d.dir('code', [d.file('a.dart', formattedSource)]).validate();
+    await d.dir('code', [d.file('c.dart', formattedSource)]).validate();
+  });
+
   test('exits with 64 on a command line argument error', () async {
     var process = await runFormatter(['-wat']);
     await process.shouldExit(64);
@@ -164,7 +186,6 @@ void main() {
       var process = await runFormatterOnDir(['--machine']);
 
       // The order isn't specified.
-
       expect(await process.stdout.next, anyOf(jsonA, jsonB));
       expect(await process.stdout.next, anyOf(jsonA, jsonB));
       await process.shouldExit();


### PR DESCRIPTION
That release contains a new separate hidden library for running the CLI.
The new library has a different command line interface, but the current
interface exposed by "dartfmt" should be unchanged. Unfortunately, I
accidentally broke that and running the formatter stopped showing the
names of files that were formatted or unchanged.

This restores that (and adds tests, which I thought already existed).