### PR TITLE
Handle Unicode whitespace more gracefully.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.3.7
 
 * Split help into verbose and non-verbose lists (#938).
+* Don't crash when non-ASCII whitespace is trimmed (#901).
 
 # 1.3.6
 

--- a/lib/src/string_compare.dart
+++ b/lib/src/string_compare.dart
@@ -1,8 +1,24 @@
-library dart_style.src.string_compare;
-
 /// Returns `true` if [c] represents a whitespace code unit allowed in Dart
 /// source code.
-bool _isWhitespace(int c) => (c <= 0x000D && c >= 0x0009) || c == 0x0020;
+///
+/// This follows the same rules as `String.trim()` because that's what dartfmt
+/// uses to trim trailing whitespace.
+bool _isWhitespace(int c) {
+  // Not using a set or something more elegant because this code is on the hot
+  // path and this large expression is significantly faster than a set lookup.
+  return c >= 0x0009 && c <= 0x000d || // Control characters.
+      c == 0x0020 || // SPACE.
+      c == 0x0085 || // Control characters.
+      c == 0x00a0 || // NO-BREAK SPACE.
+      c == 0x1680 || // OGHAM SPACE MARK.
+      c >= 0x2000 && c <= 0x200a || // EN QUAD..HAIR SPACE.
+      c == 0x2028 || // LINE SEPARATOR.
+      c == 0x2029 || // PARAGRAPH SEPARATOR.
+      c == 0x202f || // NARROW NO-BREAK SPACE.
+      c == 0x205f || // MEDIUM MATHEMATICAL SPACE.
+      c == 0x3000 || // IDEOGRAPHIC SPACE.
+      c == 0xfeff; // ZERO WIDTH NO_BREAK SPACE.
+}
 
 /// Returns the index of the next non-whitespace character.
 ///

--- a/test/command_line_test.dart
+++ b/test/command_line_test.dart
@@ -122,7 +122,8 @@ void main() {
           emits('Usage:   dartfmt [options...] [files or directories...]'));
       await expectLater(process.stdout, emitsThrough(contains('--overwrite')));
       await expectLater(process.stdout, emitsThrough(contains('--fix')));
-      await expectLater(process.stdout, neverEmits(contains('--set-exit-if-changed')));
+      await expectLater(
+          process.stdout, neverEmits(contains('--set-exit-if-changed')));
       await process.shouldExit(0);
     });
 
@@ -135,7 +136,8 @@ void main() {
           emits('Usage:   dartfmt [options...] [files or directories...]'));
       await expectLater(process.stdout, emitsThrough(contains('--overwrite')));
       await expectLater(process.stdout, emitsThrough(contains('--fix')));
-      await expectLater(process.stdout, emitsThrough(contains('--set-exit-if-changed')));
+      await expectLater(
+          process.stdout, emitsThrough(contains('--set-exit-if-changed')));
       await process.shouldExit(0);
     });
   });

--- a/test/string_compare_test.dart
+++ b/test/string_compare_test.dart
@@ -39,26 +39,26 @@ void main() {
   });
 
   test('test unicode whitespace characters', () {
-    // Dart sources only allow ascii whitespace code points so we
-    // should not consider the following strings equal.
+    // The formatter strips all Unicode whitespace characters from the end of
+    // comment lines, so treat those as whitespace too.
     var whitespaceRunes = [
-      0x00A0,
-      0x1680,
-      0x180E,
+      0x0020,
+      0x0085,
+      0x00a0,
       0x2000,
-      0x200A,
+      0x200a,
       0x2028,
       0x2029,
-      0x202F,
-      0x205F,
+      0x202f,
+      0x205f,
       0x3000,
-      0xFEFF
+      0xfeff
     ];
     for (var rune in whitespaceRunes) {
       expect(
           equalIgnoringWhitespace(
               'foo${String.fromCharCode(rune)}bar', 'foo    bar'),
-          isFalse);
+          isTrue);
     }
   });
 

--- a/test/whitespace/trailing.unit
+++ b/test/whitespace/trailing.unit
@@ -1,0 +1,32 @@
+40 columns                              |
+>>> remove after line comment
+// trailing spaces after here:×20×20×20×20
+<<<
+// trailing spaces after here:
+>>> remove from empty line comment
+//×20×20×20
+<<<
+//
+>>> keep inside block comment lines
+/* one×20×20
+   two×20
+×20×20×20
+   three×20×20×20×20
+*/×20×20
+<<<
+/* one×20×20
+   two×20
+×20×20×20
+   three×20×20×20×20
+*/
+>>> after code
+main() {×20×20
+×20
+  veryLongExpression    +×20×20×20
+  veryLongStatement;×20×20
+}×20×20×20×20
+<<<
+main() {
+  veryLongExpression +
+      veryLongStatement;
+}

--- a/test/whitespace/unicode.unit
+++ b/test/whitespace/unicode.unit
@@ -1,0 +1,65 @@
+40 columns                              |
+>>> preserve unicode whitespace inside comments from trim from the end
+// control middle: ×09 end: ×09 ×09
+// control middle: ×0b end: ×0b ×0b
+// space middle: ×20 end: ×20 ×20
+// control middle: ×85 end: ×85 ×85
+<<<
+// control middle: ×09 end:
+// control middle: ×0b end:
+// space middle: ×20 end:
+// control middle: ×85 end:
+>>> preserve unicode whitespace inside comments from trim from the end
+// no-break space middle: ×a0 end: ×a0 ×a0
+// ogham space mark middle: ×1680 end: ×1680 ×1680
+// en quad middle: ×2000 end: ×2000 ×2000
+// em quad middle: ×2001 end: ×2001 ×2001
+// en space middle: ×2002 end: ×2002 ×2002
+// em space middle: ×2003 end: ×2003 ×2003
+<<<
+// no-break space middle: ×a0 end:
+// ogham space mark middle: ×1680 end:
+// en quad middle: ×2000 end:
+// em quad middle: ×2001 end:
+// en space middle: ×2002 end:
+// em space middle: ×2003 end:
+>>>
+// three-per-em space middle: ×2004 end: ×2004 ×2004
+// four-per-em space middle: ×2005 end: ×2005 ×2005
+// six-per-em space middle: ×2006 end: ×2006 ×2006
+// figure space middle: ×2007 end: ×2007 ×2007
+// punctuation space middle: ×2008 end: ×2008 ×2008
+// thin space middle: ×2009 end: ×2009 ×2009
+// hair space middle: ×200a end: ×200a ×200a
+<<<
+// three-per-em space middle: ×2004 end:
+// four-per-em space middle: ×2005 end:
+// six-per-em space middle: ×2006 end:
+// figure space middle: ×2007 end:
+// punctuation space middle: ×2008 end:
+// thin space middle: ×2009 end:
+// hair space middle: ×200a end:
+>>>
+// line separator middle: ×2028 end: ×2028 ×2028
+// paragraph separator middle: ×2029 end: ×2029 ×2029
+// narrow no-break space middle: ×202f end: ×202f ×202f
+// medium mathematical space middle: ×205f end: ×205f ×205f
+// ideographic space middle: ×3000 end: ×3000 ×3000
+// zero width no-break space middle: ×feff end: ×feff ×feff
+<<<
+// line separator middle: ×2028 end:
+// paragraph separator middle: ×2029 end:
+// narrow no-break space middle: ×202f end:
+// medium mathematical space middle: ×205f end:
+// ideographic space middle: ×3000 end:
+// zero width no-break space middle: ×feff end:
+>>> unicode line endings
+// line feed middle: ×0a // end: ×0a ×0a
+// form feed middle: ×0c // end: ×0c ×0c
+// carriage return middle: ×0d // end: ×0d ×0d
+<<<
+// line feed middle:
+// end:
+
+// form feed middle: ×0c // end:
+// carriage return middle: // end:


### PR DESCRIPTION
* Don't crash when trailing non-ASCII whitespace is trimmed.
* Add tests for trailing whitespace trimming.
* Add tests for other Unicode characters.

Fix #901.