### PR TITLE
Remove unused dart:async import

### DIFF
--- a/test/utils.dart
+++ b/test/utils.dart
@@ -4,7 +4,6 @@
 
 library dart_style.test.utils;
 
-import 'dart:async';
 import 'dart:io';
 import 'dart:mirrors';
 


### PR DESCRIPTION
No longer needed since Dart 2.1 added Future/Stream to dart:core exports