### PR TITLE
Don't duplicate comments on chained if elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.9
+
+* Don't duplicate comments on chained if elements (#966).
+
 # 1.3.8
 
 * Preserve `?` in initializing formal function-typed parameters (#960).

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '1.3.8+1';
+const dartStyleVersion = '1.3.9';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 class FormatterOptions {

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1931,7 +1931,7 @@ class SourceVisitor extends ThrowingAstVisitor {
           split();
         }
 
-        token(node.elseKeyword);
+        token(element.elseKeyword);
 
         // If there is another if element in the chain, put a space between
         // it and this "else".

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.3.8+1
+version: 1.3.9-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.3.9-dev
+version: 1.3.9
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/regression/0900/0966.stmt
+++ b/test/regression/0900/0966.stmt
@@ -1,0 +1,24 @@
+>>>
+return [
+      for (final x in exampleList)
+        if (conditionA)
+          ItemConstructorA()
+       // Sample multi-line comment
+      // which broke the formatter
+        else if (conditionB)
+           ItemConstructorB()
+     else
+       ItemConstructorC()
+];
+<<<
+return [
+  for (final x in exampleList)
+    if (conditionA)
+      ItemConstructorA()
+    // Sample multi-line comment
+    // which broke the formatter
+    else if (conditionB)
+      ItemConstructorB()
+    else
+      ItemConstructorC()
+];


### PR DESCRIPTION
There was a bug where every "else" in a chained if element used the
first element's "else" token instead of its own. This had the
unfortunate side effect of duplicating any comment that appeared before
the first one (and discarding comments on the later ones).

Fix #966.