### PR TITLE
add a type annotation to defineOptions()

### DIFF
--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -5,7 +5,8 @@ import 'package:args/args.dart';
 
 import '../style_fix.dart';
 
-void defineOptions(ArgParser parser, {bool oldCli = false, verbose = false}) {
+void defineOptions(ArgParser parser,
+    {bool oldCli = false, bool verbose = false}) {
   if (oldCli) {
     // The Command class implicitly adds "--help", so we only need to manually
     // add it for the old CLI.


### PR DESCRIPTION
- add a type annotation to `defineOptions()`

This was missing a type annotation (but was likely intended to be `bool`) - you might consider adding the `type_annotate_public_apis` lint to the analysis options file.
