### PR TITLE
Fix uses of deprecated APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.11
+
+* Remove use of deprecated analyzer API and List constructor.
+
 # 1.3.10
 
 * Allow analyzer version 0.41.x.

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -14,6 +14,7 @@ import 'package:analyzer/error/error.dart';
 import 'package:analyzer/src/dart/scanner/scanner.dart';
 import 'package:analyzer/src/generated/parser.dart';
 import 'package:analyzer/src/string_source.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 import 'exceptions.dart';
 import 'source_code.dart';
@@ -89,10 +90,8 @@ class DartFormatter {
     // version.
     // TODO(paulberry): consider plumbing in experiment enable flags from the
     // command line.
-    var featureSet = FeatureSet.fromEnableFlags([
-      'extension-methods',
-      'non-nullable',
-    ]);
+    var featureSet = FeatureSet.fromEnableFlags2(
+        sdkLanguageVersion: Version(2, 10, 0), flags: ['non-nullable']);
 
     var inputOffset = 0;
     var text = source.text;

--- a/lib/src/line_splitting/rule_set.dart
+++ b/lib/src/line_splitting/rule_set.dart
@@ -18,7 +18,7 @@ import '../rule/rule.dart';
 class RuleSet {
   List<int> _values;
 
-  RuleSet(int numRules) : this._(List(numRules));
+  RuleSet(int numRules) : this._(List.filled(numRules, null));
 
   RuleSet._(this._values);
 
@@ -138,7 +138,7 @@ class SplitSet {
   int _cost;
 
   /// Creates a new empty split set for a line with [numChunks].
-  SplitSet(int numChunks) : _columns = List(numChunks - 1);
+  SplitSet(int numChunks) : _columns = List.filled(numChunks - 1, null);
 
   /// Marks the line after chunk [index] as starting at [column].
   void add(int index, int column) {

--- a/lib/src/line_splitting/solve_state_queue.dart
+++ b/lib/src/line_splitting/solve_state_queue.dart
@@ -20,12 +20,12 @@ class SolveStateQueue {
   /// Initial capacity of a queue when created, or when added to after a [clear].
   /// Number can be any positive value. Picking a size that gives a whole
   /// number of "tree levels" in the heap is only done for aesthetic reasons.
-  static const int _INITIAL_CAPACITY = 7;
+  static const int _initialCapacity = 7;
 
   LineSplitter _splitter;
 
   /// List implementation of a heap.
-  List<SolveState> _queue = List<SolveState>(_INITIAL_CAPACITY);
+  List<SolveState> _queue = List<SolveState>.filled(_initialCapacity, null);
 
   /// Number of elements in queue.
   /// The heap is implemented in the first [_length] entries of [_queue].
@@ -48,9 +48,9 @@ class SolveStateQueue {
 
     if (_length == _queue.length) {
       var newCapacity = _queue.length * 2 + 1;
-      if (newCapacity < _INITIAL_CAPACITY) newCapacity = _INITIAL_CAPACITY;
+      if (newCapacity < _initialCapacity) newCapacity = _initialCapacity;
 
-      var newQueue = List<SolveState>(newCapacity);
+      var newQueue = List<SolveState>.filled(newCapacity, null);
       newQueue.setRange(0, _length, _queue);
       _queue = newQueue;
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "13.0.0"
+    version: "14.0.0"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.41.0"
+    version: "0.41.1"
   archive:
     dependency: transitive
     description:
@@ -85,6 +85,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.5"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.2.1"
   glob:
     dependency: transitive
     description:
@@ -113,6 +120,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.16.1"
   io:
     dependency: transitive
     description:
@@ -161,14 +175,14 @@ packages:
       name: node_interop
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   node_io:
     dependency: transitive
     description:
       name: node_io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   node_preamble:
     dependency: "direct dev"
     description:
@@ -205,7 +219,7 @@ packages:
     source: hosted
     version: "1.5.0-nullsafety.3"
   pub_semver:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
@@ -231,7 +245,7 @@ packages:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "0.2.9+1"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -294,7 +308,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.10"
+    version: "1.16.0-nullsafety.13"
   test_api:
     dependency: transitive
     description:
@@ -308,7 +322,7 @@ packages:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.10"
+    version: "0.3.12-nullsafety.12"
   test_descriptor:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.3.10
+version: 1.3.11-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.
@@ -10,9 +10,10 @@ environment:
   sdk: '>=2.9.0 <3.0.0'
 
 dependencies:
-  analyzer: ">=0.40.0 <0.42.0"
+  analyzer: ">=0.41.1 <0.42.0"
   args: ^1.0.0
   path: ^1.0.0
+  pub_semver: ^1.4.4
   source_span: ^1.4.0
 
 dev_dependencies:
@@ -20,7 +21,6 @@ dev_dependencies:
   js: ^0.6.0
   node_preamble: ^1.0.0
   pedantic: ^1.0.0
-  pub_semver: ^1.2.3
   test: ^1.16.0-nullsafety.2
   test_descriptor: ^1.0.0
   test_process: ^1.0.0


### PR DESCRIPTION
- Use FeatureSet.fromEnableFlags2() and pass in an explicit language
  version. Hard-coding the language version is a little dubious, but
  probably practically correct since dart_style is generally not
  forward compatible with language changes.

- Stop using the deprecated List() constructor. This change technically
  isn't needed until the null safety migration, but this addresses the
  deprecate lint errors.