### PR TITLE
Update to latest version of analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.13
+
+- Allow the latest version of `package:analyzer`.
+
 # 1.3.12
 
 - Allow the latest versions of `package:args` and `package:pub_semver`.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "14.0.0"
+    version: "16.0.0"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.41.2"
+    version: "1.0.0"
   args:
     dependency: "direct main"
     description:
@@ -50,13 +50,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
-  clock:
-    dependency: transitive
-    description:
-      name: clock
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   collection:
     dependency: transitive
     description:
@@ -91,21 +84,21 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.1"
+    version: "6.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   grinder:
     dependency: "direct dev"
     description:
       name: grinder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.6"
+    version: "0.9.0-nullsafety.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -120,13 +113,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.17.0"
   io:
     dependency: transitive
     description:
@@ -169,20 +155,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
   node_preamble:
     dependency: "direct dev"
     description:
@@ -196,7 +168,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "2.0.0"
   path:
     dependency: "direct main"
     description:
@@ -308,7 +280,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.16.2"
   test_api:
     dependency: transitive
     description:
@@ -322,7 +294,7 @@ packages:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12"
+    version: "0.3.13"
   test_descriptor:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,27 +1,27 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.3.12
+version: 1.3.13
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.
 repository: https://github.com/dart-lang/dart_style
 
 environment:
-  sdk: '>=2.9.0 <3.0.0'
+  sdk: '>=2.11.99 <3.0.0'
 
 dependencies:
-  analyzer: ">=0.41.1 <0.42.0"
+  analyzer: ^1.0.0
   args: '>=1.0.0 <3.0.0'
   path: ^1.0.0
   pub_semver: '>=1.4.4 <3.0.0'
   source_span: ^1.4.0
 
 dev_dependencies:
-  grinder: ^0.8.0
+  grinder: ^0.9.0-nullsafety.0
   js: ^0.6.0
   node_preamble: ^1.0.0
   pedantic: ^1.0.0
-  test: ^1.16.0-nullsafety.2
+  test: ^1.16.0
   test_descriptor: ^1.0.0
   test_process: ^1.0.0
   yaml: '>=2.0.0 <4.0.0'


### PR DESCRIPTION
This is required to unblock some elements of the ecosystem (namely, build and packages using it), allowing them to use new language features implemented only in analyzer 1.0.0 even if they aren't fully ported to null safety yet.