### PR TITLE
Correctly bump versions this time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.14
+
+- Correctly bump versions and allow a wider range of SDKs/analyzer versions.
+
 # 1.3.13
 
 - Allow the latest version of `package:analyzer`.

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '1.3.12';
+const dartStyleVersion = '1.3.14';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 class FormatterOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.3.13
+version: 1.3.14
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.
 repository: https://github.com/dart-lang/dart_style
 
 environment:
-  sdk: '>=2.11.99 <3.0.0'
+  sdk: '>=2.9.0 <3.0.0'
 
 dependencies:
-  analyzer: ^1.0.0
+  analyzer: ">=0.41.1 <=1.1.0"
   args: '>=1.0.0 <3.0.0'
   path: ^1.0.0
   pub_semver: '>=1.4.4 <3.0.0'


### PR DESCRIPTION
Fixes problem with 1.3.13 where it will report the wrong version number, and relaxes some constraints per @kevmoo.