### PR TITLE
Preliminary support for generic annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.14
+
+* Add support for generic annotations.
+
 # 1.3.13
 
 - Allow the latest version of `package:analyzer`.

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -91,7 +91,8 @@ class DartFormatter {
     // TODO(paulberry): consider plumbing in experiment enable flags from the
     // command line.
     var featureSet = FeatureSet.fromEnableFlags2(
-        sdkLanguageVersion: Version(2, 10, 0), flags: ['non-nullable']);
+        sdkLanguageVersion: Version(2, 10, 0),
+        flags: ['non-nullable', 'generic-metadata']);
 
     var inputOffset = 0;
     var text = source.text;

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -297,14 +297,20 @@ class SourceVisitor extends ThrowingAstVisitor {
   void visitAnnotation(Annotation node) {
     token(node.atSign);
     visit(node.name);
+
+    builder.nestExpression();
     visit(node.typeArguments);
     token(node.period);
     visit(node.constructorName);
 
-    // Metadata annotations are always const contexts.
-    _constNesting++;
-    visit(node.arguments);
-    _constNesting--;
+    if (node.arguments != null) {
+      // Metadata annotations are always const contexts.
+      _constNesting++;
+      visitArgumentList(node.arguments, nestExpression: false);
+      _constNesting--;
+    }
+
+    builder.unnest();
   }
 
   /// Visits an argument list.

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -297,6 +297,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   void visitAnnotation(Annotation node) {
     token(node.atSign);
     visit(node.name);
+    visit(node.typeArguments);
     token(node.period);
     visit(node.constructorName);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.3.13
+version: 1.3.14-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/splitting/annotations.unit
+++ b/test/splitting/annotations.unit
@@ -1,0 +1,9 @@
+40 columns                              |
+>>> blet
+@veryLongPrefix.VeryLongClassName<VeryLongTypeArgument, OtherVeryLongTypeArgument>(veryLongArgument, otherVeryLongArgument, thirdVeryLongArgument) int i = 0;
+<<<
+@veryLongPrefix.VeryLongClassName<VeryLongTypeArgument, OtherVeryLongTypeArgument>(
+    veryLongArgument,
+    otherVeryLongArgument,
+    thirdVeryLongArgument)
+int i = 0;

--- a/test/splitting/annotations.unit
+++ b/test/splitting/annotations.unit
@@ -1,9 +1,95 @@
 40 columns                              |
->>> blet
-@veryLongPrefix.VeryLongClassName<VeryLongTypeArgument, OtherVeryLongTypeArgument>(veryLongArgument, otherVeryLongArgument, thirdVeryLongArgument) int i = 0;
+>>> complex annotation that all fits on one line
+@a.B<C,D>(e,f,g) int i = 0;
 <<<
-@veryLongPrefix.VeryLongClassName<VeryLongTypeArgument, OtherVeryLongTypeArgument>(
+@a.B<C, D>(e, f, g)
+int i = 0;
+>>> prefer to split between args even when they all fit on next line
+@BigLongClassName<First, Second, Third>() int i = 0;
+<<<
+@BigLongClassName<First, Second,
+    Third>()
+int i = 0;
+>>> split before first if needed
+@BigLongClassName<FirstTypeArgumentIsLong, Second>() int i = 0;
+<<<
+@BigLongClassName<
+    FirstTypeArgumentIsLong, Second>()
+int i = 0;
+>>> split in middle if fit in two lines
+@BigLongClassName<First, Second, Third, Fourth, Fifth, Sixth, Seventh>() int i = 0;
+<<<
+@BigLongClassName<First, Second, Third,
+    Fourth, Fifth, Sixth, Seventh>()
+int i = 0;
+>>> split one per line if they don't fit in two lines
+@BigLongClassName<First, Second, Third, Fourth, Fifth, Sixth, Seventh, Eighth>() int i = 0;
+<<<
+@BigLongClassName<
+    First,
+    Second,
+    Third,
+    Fourth,
+    Fifth,
+    Sixth,
+    Seventh,
+    Eighth>()
+int i = 0;
+>>> prefers to not split at type arguments
+@SomeBigClass<
+    TypeArgument>(valueArgument)
+int i = 0;
+<<<
+@SomeBigClass<TypeArgument>(
+    valueArgument)
+int i = 0;
+>>> split both type and value arguments
+@SomeBigClass<First, Second, Third, Fourth, Fifth, Sixth, Seventh, Eighth>(first, second, third, fourth, fifth, sixth, seventh, eighth) int i = 0;
+<<<
+@SomeBigClass<
+        First,
+        Second,
+        Third,
+        Fourth,
+        Fifth,
+        Sixth,
+        Seventh,
+        Eighth>(
+    first,
+    second,
+    third,
+    fourth,
+    fifth,
+    sixth,
+    seventh,
+    eighth)
+int i = 0;
+>>> prefer to split at arguments rather than prefix
+@veryLongPrefix.VeryLongClassName<VeryLongTypeArgument,OtherVeryLongTypeArgument>(veryLongArgument,otherVeryLongArgument,thirdVeryLongArgument) int i = 0;
+<<<
+@veryLongPrefix.VeryLongClassName<
+        VeryLongTypeArgument,
+        OtherVeryLongTypeArgument>(
     veryLongArgument,
     otherVeryLongArgument,
     thirdVeryLongArgument)
+int i = 0;
+>>> nested type arguments, no splitting required
+@A<B<C,D>,E<F,G>>() int i = 0;
+<<<
+@A<B<C, D>, E<F, G>>()
+int i = 0;
+>>> nested type arguments, split at outer level when possible
+@Aaaa<Bbbb<Cccc,Dddd>,Eeee<Ffff,Gggg>>() int i = 0;
+<<<
+@Aaaa<Bbbb<Cccc, Dddd>,
+    Eeee<Ffff, Gggg>>()
+int i = 0;
+>>> nested type arguments, split at inner level when necessary
+@Aaaaaaaaa<Bbbbbbbbbbb<Ccccccccccc,Ddddddddddd>,Eeeeeeeee<Fffffffff,Ggggggggg>>() int i = 0;
+<<<
+@Aaaaaaaaa<
+    Bbbbbbbbbbb<Ccccccccccc,
+        Ddddddddddd>,
+    Eeeeeeeee<Fffffffff, Ggggggggg>>()
 int i = 0;

--- a/test/whitespace/metadata.unit
+++ b/test/whitespace/metadata.unit
@@ -381,3 +381,23 @@ class C {
   @meta
   abstract var x;
 }
+>>> annotation with type arguments
+@A<int,String>()int x;
+<<<
+@A<int, String>()
+int x;
+>>>
+@prefix.A<int,String>()int x;
+<<<
+@prefix.A<int, String>()
+int x;
+>>>
+@A<int,String>.constructor()int x;
+<<<
+@A<int, String>.constructor()
+int x;
+>>>
+@prefix.A<int,String>.constructor()int x;
+<<<
+@prefix.A<int, String>.constructor()
+int x;


### PR DESCRIPTION
This change provides enough support to avoid a crash and ensure that
generic annotations are preserved by the formatter.

We don't yet insert as many line breaks as we arguably should (see the
example in test/splitting/annotations.unit); we can improve that in a
future change.