### PR TITLE
Bump to 1.3.14.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 1.3.14-dev
+version: 1.3.14
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
I'm going to publish this as a separate release so that users (like
dartdoc) who just want the latest analyzer and generic annotation
support can get it without having to deal with a major version bump to
2.0.0.