### PR TITLE
Fix a couple of crashes I found when testing the migration on a corpus.

### DIFF
--- a/lib/src/call_chain_visitor.dart
+++ b/lib/src/call_chain_visitor.dart
@@ -558,7 +558,7 @@ Expression _unwrapTarget(Expression node, List<_Selector> calls) {
   }
 
   // Postfix expressions.
-  if (node is IndexExpression) {
+  if (node is IndexExpression && node.target != null) {
     return _unwrapPostfix(node, node.target!, calls);
   }
 

--- a/lib/src/chunk_builder.dart
+++ b/lib/src/chunk_builder.dart
@@ -181,7 +181,7 @@ class ChunkBuilder {
   /// If [nest] is `false`, ignores any current expression nesting. Otherwise,
   /// uses the current nesting level. If unsplit, it expands to a space if
   /// [space] is `true`.
-  Chunk? split({bool? flushLeft, bool? isDouble, bool? nest, bool? space}) {
+  Chunk split({bool? flushLeft, bool? isDouble, bool? nest, bool? space}) {
     space ??= false;
 
     // If we are not allowed to split at all, don't. Returning null for the
@@ -189,7 +189,7 @@ class ChunkBuilder {
     // discarded because no chunk references it.
     if (_preventSplitNesting > 0) {
       if (space) _pendingWhitespace = Whitespace.space;
-      return null;
+      return Chunk.dummy();
     }
 
     return _writeSplit(_rules.last,
@@ -847,15 +847,14 @@ class ChunkBuilder {
   /// Ends the current chunk (if any) with the given split information.
   ///
   /// Returns the chunk.
-  Chunk? _writeSplit(Rule rule,
+  Chunk _writeSplit(Rule rule,
       {bool? flushLeft, bool? isDouble, bool? nest, bool? space}) {
     nest ??= true;
     space ??= false;
 
     if (_chunks.isEmpty) {
       if (flushLeft != null) _firstFlushLeft = flushLeft;
-
-      return null;
+      return Chunk.dummy();
     }
 
     _chunks.last.applySplit(
@@ -884,7 +883,7 @@ class ChunkBuilder {
 
     var chunk = _chunks[i];
     if (!chunk.rule!.isHardened) return false;
-    if (chunk.nesting.isNested) return false;
+    if (chunk.nesting!.isNested) return false;
     if (chunk.isBlock) return false;
 
     return true;

--- a/lib/src/debug.dart
+++ b/lib/src/debug.dart
@@ -146,7 +146,7 @@ void dumpChunks(int start, List<Chunk> chunks) {
     writeIf(chunk.indent != null && chunk.indent != 0,
         () => 'indent ${chunk.indent}');
 
-    writeIf(chunk.nesting.indent != 0, () => 'nest ${chunk.nesting}');
+    writeIf(chunk.nesting?.indent != 0, () => 'nest ${chunk.nesting}');
 
     writeIf(chunk.flushLeft, () => 'flush');
 

--- a/lib/src/line_splitting/solve_state.dart
+++ b/lib/src/line_splitting/solve_state.dart
@@ -279,8 +279,8 @@ class SolveState {
     for (var i = 0; i < _splitter.chunks.length - 1; i++) {
       var chunk = _splitter.chunks[i];
       if (chunk.rule!.isSplit(getValue(chunk.rule!), chunk)) {
-        usedNestingLevels.add(chunk.nesting);
-        chunk.nesting.clearTotalUsedIndent();
+        usedNestingLevels.add(chunk.nesting!);
+        chunk.nesting!.clearTotalUsedIndent();
       }
     }
 
@@ -298,7 +298,7 @@ class SolveState {
           indent = _splitter.blockIndentation + chunk.indent!;
 
           // And any expression nesting.
-          indent += chunk.nesting.totalUsedIndent;
+          indent += chunk.nesting!.totalUsedIndent;
 
           if (chunk.indentBlock(getValue)) indent += Indent.expression;
         }
@@ -385,9 +385,10 @@ class SolveState {
         // But there are a couple of squirrely cases where it's hard to prevent
         // by construction. Instead, this outlaws it by penalizing it very
         // heavily if it happens to get this far.
+        var totalIndent = chunk.nesting!.totalUsedIndent;
         if (previousNesting != null &&
-            chunk.nesting.totalUsedIndent != 0 &&
-            chunk.nesting.totalUsedIndent == previousNesting.totalUsedIndent &&
+            totalIndent != 0 &&
+            totalIndent == previousNesting.totalUsedIndent &&
             !identical(chunk.nesting, previousNesting)) {
           _overflowChars += 10000;
         }

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2879,7 +2879,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     builder.nestExpression();
 
     token(leftBracket);
-    rule.beforeArgument(zeroSplit()!);
+    rule.beforeArgument(zeroSplit());
 
     for (var node in nodes) {
       visit(node);
@@ -2887,7 +2887,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       // Write the trailing comma.
       if (node != nodes.last) {
         token(node.endToken.next);
-        rule.beforeArgument(split()!);
+        rule.beforeArgument(split());
       }
     }
 
@@ -3493,13 +3493,13 @@ class SourceVisitor extends ThrowingAstVisitor {
   void _visitCombinator(Token keyword, Iterable<AstNode> nodes) {
     // Allow splitting before the keyword.
     var rule = builder.rule as CombinatorRule;
-    rule.addCombinator(split()!);
+    rule.addCombinator(split());
 
     builder.nestExpression();
     token(keyword);
 
-    rule.addName(split()!);
-    visitCommaSeparatedNodes(nodes, between: () => rule.addName(split()!));
+    rule.addName(split());
+    visitCommaSeparatedNodes(nodes, between: () => rule.addName(split()));
 
     builder.unnest();
   }
@@ -3665,12 +3665,12 @@ class SourceVisitor extends ThrowingAstVisitor {
   /// Writes a single space split owned by the current rule.
   ///
   /// Returns the chunk the split was applied to.
-  Chunk? split() => builder.split(space: true);
+  Chunk split() => builder.split(space: true);
 
   /// Writes a zero-space split owned by the current rule.
   ///
   /// Returns the chunk the split was applied to.
-  Chunk? zeroSplit() => builder.split();
+  Chunk zeroSplit() => builder.split();
 
   /// Writes a single space split with its own rule.
   Rule soloSplit([int? cost]) {

--- a/test/regression/other/null_safety.unit
+++ b/test/regression/other/null_safety.unit
@@ -1,0 +1,20 @@
+>>> issues found when migrating to null safety
+void main() => print('first: ${first<int>([1, 2, 3])}');
+<<<
+void main() => print('first: ${first<int>([1, 2, 3])}');
+>>>
+var x = '${jsonEncode([
+  1,
+])}';
+<<<
+var x = '${jsonEncode([
+      1,
+    ])}';
+>>>
+main() {
+  patch..[entityId].removeWhere();
+}
+<<<
+main() {
+  patch..[entityId].removeWhere();
+}

--- a/test/splitting/invocations.stmt
+++ b/test/splitting/invocations.stmt
@@ -159,6 +159,20 @@ object
     .method()
       ..x = 1
       ..y = 2;
+>>> cascade index
+object..[index]..method()..[index]=value;
+<<<
+object
+  ..[index]
+  ..method()
+  ..[index] = value;
+>>> null-aware cascade index
+object?..[index]..method()..[index]=value;
+<<<
+object
+  ?..[index]
+  ..method()
+  ..[index] = value;
 >>> conditional invocation
 object?.method().method()?.method().method();
 <<<


### PR DESCRIPTION
There are basically three issues here:

- The debug library, which isn't part of the public API, could crash
  when logging a chunk that wasn't fully initialized. Turned
  NestingLevel from late back to nullable to fix this. This doesn't
  affect users.

- The null safety migration introduced a crash when formatting blocks
  inside string interpolation (why would someone do that?!). To fix
  that, instead of returning null chunks, changed ChunkBuilder to
  return dummy chunks. They end up getting discarded anyway.

- Cascaded index operators always crash. I need to investigate more, but
  I think this bug may exist in the previous version of dart_style,
  which is in the SDK. I'll look into that next.