### PR TITLE
Don't indent nested ternaries

### DIFF
--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -821,7 +821,10 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   @override
   void visitConditionalExpression(ConditionalExpression node) {
-    builder.nestExpression();
+    // Don't nest if this expression is the else leg of another ternary
+    final shouldNest = !(node.parent is ConditionalExpression &&
+        (node.parent as ConditionalExpression).elseExpression == node);
+    if (shouldNest) builder.nestExpression();
 
     // Start lazily so we don't force the operator to split if a line comment
     // appears before the first operand. If we split after one clause in a
@@ -856,7 +859,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     builder.endRule();
     builder.endSpan();
     builder.endBlockArgumentNesting();
-    builder.unnest();
+    if (shouldNest) builder.unnest();
   }
 
   @override

--- a/test/regression/0400/0407.unit
+++ b/test/regression/0400/0407.unit
@@ -12,22 +12,22 @@ void main() {
       ..tags = (new Account_Tags()
         ..accountHotlist.add(new Hotlist()..hotlistId = new Int64(10))));
 }
->>> (indent 4)
+>>> (indent 6)
 main() {
 receiver
       ..formattedTotal = _total == 0
           ? ""
           : _chartType == "PieChart"
-              ? _formatter.formatAsPercent(item.value / _total, fractionDigits: 1)
-              : _formatter.formatValue(item.value, item.valueType);
+          ? _formatter.formatAsPercent(item.value / _total, fractionDigits: 1)
+          : _formatter.formatValue(item.value, item.valueType);
 }
 <<<
-    main() {
-      receiver
-        ..formattedTotal = _total == 0
-            ? ""
-            : _chartType == "PieChart"
-                ? _formatter.formatAsPercent(item.value / _total,
-                    fractionDigits: 1)
-                : _formatter.formatValue(item.value, item.valueType);
-    }
+      main() {
+        receiver
+          ..formattedTotal = _total == 0
+              ? ""
+              : _chartType == "PieChart"
+              ? _formatter.formatAsPercent(item.value / _total,
+                  fractionDigits: 1)
+              : _formatter.formatValue(item.value, item.valueType);
+      }

--- a/test/regression/0900/0927.unit
+++ b/test/regression/0900/0927.unit
@@ -7,6 +7,6 @@ class C {
   int get currentAngleDigits => _currentSunAngleDeg < 0
       ? 1
       : _currentSunAngleDeg < 10
-          ? 2
-          : 3;
+      ? 2
+      : 3;
 }

--- a/test/splitting/expressions.stmt
+++ b/test/splitting/expressions.stmt
@@ -84,8 +84,8 @@ var kind = a ? b : c ? d : e;
 var kind = a
     ? b
     : c
-        ? d
-        : e;
+    ? d
+    : e;
 >>> don't split conditionals when indirectly nested
 var kind = a ? b : (c ? d : e);
 <<<
@@ -132,8 +132,8 @@ identifier
         ? someParticularlyLongOperand
         : someParticularlyLongOperand
     : identifier
-        ? someParticularlyLongOperand
-        : someParticularlyLongOperand;
+    ? someParticularlyLongOperand
+    : someParticularlyLongOperand;
 >>> index expressions can split after "["
 verylongIdentifier[someParticularlyLongArgument];
 <<<


### PR DESCRIPTION
Fixes #722

Don't indent ternary expressions that are in the else leg of another ternary. This change makes nested ternaries used as a series of `else if` statements much more readable.

This
```
String type = status == 'OK'
      ? 'notices'
      : status == 'NO'
      ? 'warnings'
      : status == 'BAD'
      ? 'errors'
      : '';
```
instead of 
```
String type = status == 'OK'
      ? 'notices'
      : status == 'NO'
        ? 'warnings'
        : status == 'BAD'
          ? 'errors'
          : '';
```