### PR TITLE
Revert the change to flatten nested conditionals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 * Support triple-shift `>>>` and `>>>=` operators (#992).
 * Support non-function type aliases (#993).
-* Less indentation on nested `?:` (#713, #722).
 * Correct constructor initializer indentation after `required` (#1010).
 
 # 2.0.0

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -821,10 +821,14 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   @override
   void visitConditionalExpression(ConditionalExpression node) {
+    // TODO(rnystrom): Consider revisiting whether users prefer this after 2.13.
+    /*
     // Flatten else-if style chained conditionals.
     var shouldNest = node.parent is! ConditionalExpression ||
         (node.parent as ConditionalExpression).elseExpression != node;
     if (shouldNest) builder.nestExpression();
+    */
+    builder.nestExpression();
 
     // Start lazily so we don't force the operator to split if a line comment
     // appears before the first operand. If we split after one clause in a
@@ -859,7 +863,12 @@ class SourceVisitor extends ThrowingAstVisitor {
     builder.endRule();
     builder.endSpan();
     builder.endBlockArgumentNesting();
+
+    // TODO(rnystrom): Consider revisiting whether users prefer this after 2.13.
+    /*
     if (shouldNest) builder.unnest();
+    */
+    builder.unnest();
   }
 
   @override

--- a/test/regression/0400/0407.unit
+++ b/test/regression/0400/0407.unit
@@ -27,8 +27,9 @@ receiver
         ..formattedTotal = _total == 0
             ? ""
             : _chartType == "PieChart"
-            ? _formatter.formatAsPercent(item.value / _total, fractionDigits: 1)
-            : _formatter.formatValue(item.value, item.valueType);
+                ? _formatter.formatAsPercent(item.value / _total,
+                    fractionDigits: 1)
+                : _formatter.formatValue(item.value, item.valueType);
     }
 >>> (indent 6)
 main() {
@@ -36,8 +37,8 @@ receiver
       ..formattedTotal = _total == 0
           ? ""
           : _chartType == "PieChart"
-          ? _formatter.formatAsPercent(item.value / _total, fractionDigits: 1)
-          : _formatter.formatValue(item.value, item.valueType);
+              ? _formatter.formatAsPercent(item.value / _total, fractionDigits: 1)
+              : _formatter.formatValue(item.value, item.valueType);
 }
 <<<
       main() {
@@ -45,7 +46,7 @@ receiver
           ..formattedTotal = _total == 0
               ? ""
               : _chartType == "PieChart"
-              ? _formatter.formatAsPercent(item.value / _total,
-                  fractionDigits: 1)
-              : _formatter.formatValue(item.value, item.valueType);
+                  ? _formatter.formatAsPercent(item.value / _total,
+                      fractionDigits: 1)
+                  : _formatter.formatValue(item.value, item.valueType);
       }

--- a/test/regression/0700/0713.stmt
+++ b/test/regression/0700/0713.stmt
@@ -6,7 +6,7 @@ String type = status == 'OK'
 String type = status == 'OK'
     ? 'notices'
     : status == 'NO'
-    ? 'warnings'
-    : status == 'BAD'
-    ? 'errors'
-    : '';
+        ? 'warnings'
+        : status == 'BAD'
+            ? 'errors'
+            : '';

--- a/test/regression/0700/0722.stmt
+++ b/test/regression/0700/0722.stmt
@@ -20,15 +20,15 @@ Widget(
   child: project.locked
       ? Icon(Icons.lock)
       : project.fav
-      ? Icon(Icons.star)
-      : project.taps == null
-      ? Icon(Icons.notifications)
-      : Text(
-          suffixNumber(project.taps),
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            fontSize: 18.0,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
+          ? Icon(Icons.star)
+          : project.taps == null
+              ? Icon(Icons.notifications)
+              : Text(
+                  suffixNumber(project.taps),
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 18.0,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
 );

--- a/test/regression/0900/0927.unit
+++ b/test/regression/0900/0927.unit
@@ -7,6 +7,6 @@ class C {
   int get currentAngleDigits => _currentSunAngleDeg < 0
       ? 1
       : _currentSunAngleDeg < 10
-      ? 2
-      : 3;
+          ? 2
+          : 3;
 }

--- a/test/splitting/expressions.stmt
+++ b/test/splitting/expressions.stmt
@@ -84,8 +84,8 @@ var kind = a ? b : c ? d : e;
 var kind = a
     ? b
     : c
-    ? d
-    : e;
+        ? d
+        : e;
 >>> don't split conditionals when indirectly nested
 var kind = a ? b : (c ? d : e);
 <<<
@@ -132,8 +132,8 @@ identifier
         ? someParticularlyLongOperand
         : someParticularlyLongOperand
     : identifier
-    ? someParticularlyLongOperand
-    : someParticularlyLongOperand;
+        ? someParticularlyLongOperand
+        : someParticularlyLongOperand;
 >>> index expressions can split after "["
 verylongIdentifier[someParticularlyLongArgument];
 <<<


### PR DESCRIPTION
This leaves the tests and commented out implementation in place in case
we decide to re-enable the change later, but it's too close to Dart 2.13
and I've heard too much negative feedback to push it out right now.

Fortunately, I haven't actually published 2.0.1 yet (I was waiting for it to roll smoothly into google3), so I've just made this part of that version.