### PR TITLE
Return correct exit code from FormatCommand when formatting stdin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.0.2-dev
 
 * Don't unnecessarily split argument lists with `/* */` comments (#837).
+* Return correct exit code from `FormatCommand` when formatting stdin (#1035).
 
 # 2.0.1
 

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -12,7 +12,7 @@ import 'package:dart_style/src/cli/summary.dart';
 import 'package:dart_style/src/io.dart';
 import 'package:dart_style/src/style_fix.dart';
 
-void main(List<String> args) {
+void main(List<String> args) async {
   var parser = ArgParser(allowTrailingOptions: true);
 
   defineOptions(parser,
@@ -135,7 +135,7 @@ void main(List<String> args) {
       setExitIfChanged: setExitIfChanged);
 
   if (argResults.rest.isEmpty) {
-    formatStdin(options, selection, argResults['stdin-name'] as String);
+    await formatStdin(options, selection, argResults['stdin-name'] as String);
   } else {
     formatPaths(options, argResults.rest);
   }

--- a/lib/src/cli/format_command.dart
+++ b/lib/src/cli/format_command.dart
@@ -152,7 +152,7 @@ class FormatCommand extends Command<int> {
         setExitIfChanged: setExitIfChanged);
 
     if (argResults.rest.isEmpty) {
-      formatStdin(options, selection, stdinName);
+      await formatStdin(options, selection, stdinName);
     } else {
       formatPaths(options, argResults.rest);
       options.summary.show();

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -1,9 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
-library dart_style.src.io;
-
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -15,7 +13,7 @@ import 'exceptions.dart';
 import 'source_code.dart';
 
 /// Reads and formats input from stdin until closed.
-void formatStdin(FormatterOptions options, List<int>? selection, String name) {
+Future<void> formatStdin(FormatterOptions options, List<int>? selection, String name) async {
   var selectionStart = 0;
   var selectionLength = 0;
 
@@ -24,6 +22,7 @@ void formatStdin(FormatterOptions options, List<int>? selection, String name) {
     selectionLength = selection[1];
   }
 
+  var completer = Completer<void>();
   var input = StringBuffer();
   stdin.transform(Utf8Decoder()).listen(input.write, onDone: () {
     var formatter = DartFormatter(
@@ -50,7 +49,11 @@ $err
 $stack''');
       exitCode = 70; // sysexits.h: EX_SOFTWARE
     }
+
+    completer.complete();
   });
+
+  return completer.future;
 }
 
 /// Formats all of the files and directories given by [paths].

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -13,7 +13,8 @@ import 'exceptions.dart';
 import 'source_code.dart';
 
 /// Reads and formats input from stdin until closed.
-Future<void> formatStdin(FormatterOptions options, List<int>? selection, String name) async {
+Future<void> formatStdin(
+    FormatterOptions options, List<int>? selection, String name) async {
   var selectionStart = 0;
   var selectionLength = 0;
 


### PR DESCRIPTION
It reads from stdin asynchronously. Before this fix, the FormatCommand
did not wait for that to complete before returning the exit code, so it
would return before stdin had been formatted and any parse error
detected.

Fix #1035.