### PR TITLE
Fix hang when reading from stdin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.3
+
+* Fix hang when reading from stdin (https://github.com/dart-lang/sdk/issues/46600).
+
 # 2.0.2
 
 * Don't unnecessarily split argument lists with `/* */` comments (#837).

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '2.0.2';
+const dartStyleVersion = '2.0.3';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 class FormatterOptions {

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -39,7 +39,6 @@ Future<void> formatStdin(
       var output = formatter.formatSource(source);
       options.afterFile(null, name, output,
           changed: source.text != output.text);
-      return;
     } on FormatterException catch (err) {
       stderr.writeln(err.message());
       exitCode = 65; // sysexits.h: EX_DATAERR

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.0.2
+version: 2.0.3
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
The tests for dart_style do not seem to trigger this bug, and I'm not
sure why not. But I can repro it in dartdev, and I have a test there
that will trigger the bug. So I'm going to push out this fix, roll it
into the SDK, and land the dartdev test with that roll.