### PR TITLE
Format generic function references and constructor tear-offs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.0.4-dev
+# 2.1.0-dev
 
 * Support generic function references and constructor tear-offs (#1028).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.4-dev
+
+* Support generic function references and constructor tear-offs (#1028).
+
 # 2.0.3
 
 * Fix hang when reading from stdin (https://github.com/dart-lang/sdk/issues/46600).

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -89,6 +89,7 @@ class DartFormatter {
     var featureSet = FeatureSet.fromEnableFlags2(
         sdkLanguageVersion: Version(2, 13, 0),
         flags: [
+          'constructor-tearoffs',
           'generic-metadata',
           'nonfunction-type-aliases',
           'triple-shift'

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1806,6 +1806,12 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
+  void visitFunctionReference(FunctionReference node) {
+    visit(node.function);
+    visit(node.typeArguments);
+  }
+
+  @override
   void visitFunctionTypeAlias(FunctionTypeAlias node) {
     visitMetadata(node.metadata);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.0.3
+version: 2.0.4-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.0.4-dev
+version: 2.1.0-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/splitting/mixed.stmt
+++ b/test/splitting/mixed.stmt
@@ -223,3 +223,11 @@ var longVariableName = identifierSoLongItWraps is SomeClassName;
 var longVariableName =
     identifierSoLongItWraps
         is SomeClassName;
+>>> generic function reference nested inside expression
+veryLongFunction(argument, ConstructorTearOff<First, Second, Third, Fourth>, argument);
+<<<
+veryLongFunction(
+    argument,
+    ConstructorTearOff<First, Second,
+        Third, Fourth>,
+    argument);

--- a/test/splitting/type_arguments.stmt
+++ b/test/splitting/type_arguments.stmt
@@ -95,3 +95,42 @@ new SomeClass<
     sixth,
     seventh,
     eighth);
+>>> generic instantiation all fit on one line
+Foo<A,B,C,D>;
+<<<
+Foo<A, B, C, D>;
+>>> generic instantiation split between args
+LongClassName<First, Second, Third, Fourth>;
+<<<
+LongClassName<First, Second, Third,
+    Fourth>;
+>>> generic instantiation split before first if needed
+LongClassName<FirstTypeArgumentIsTooLong, Second>;
+<<<
+LongClassName<
+    FirstTypeArgumentIsTooLong, Second>;
+>>> generic instantiation split in middle if fit in two lines
+LongClassName<First, Second, Third, Fourth, Fifth, Sixth, Seventh>;
+<<<
+LongClassName<First, Second, Third,
+    Fourth, Fifth, Sixth, Seventh>;
+>>> generic instantiation split one per line if they don't fit in two lines
+LongClassName<First, Second, Third, Fourth, Fifth, Sixth, Seventh, Eighth>;
+<<<
+LongClassName<
+    First,
+    Second,
+    Third,
+    Fourth,
+    Fifth,
+    Sixth,
+    Seventh,
+    Eighth>;
+>>> generic instantiation indent nested type arguments
+LongClassName<First, Inner<Second, Third, Fourth, Fifth, Sixth, Seventh>, Eighth>;
+<<<
+LongClassName<
+    First,
+    Inner<Second, Third, Fourth, Fifth,
+        Sixth, Seventh>,
+    Eighth>;

--- a/test/whitespace/expressions.stmt
+++ b/test/whitespace/expressions.stmt
@@ -171,3 +171,19 @@ obj?[foo];
 var generic = < T,S >(){};
 <<<
 var generic = <T, S>() {};
+>>> generic method instantiation
+void main() => id  < int   > ;
+<<<
+void main() => id<int>;
+>>> generic method instantiation
+void main() => id  < int , String  , bool   > ;
+<<<
+void main() => id<int, String, bool>;
+>>> generic constructor tear-off
+var x = Class  < int  >;
+<<<
+var x = Class<int>;
+>>> generic name constructor tear-off
+var x = Class  < int  > . named;
+<<<
+var x = Class<int>.named;


### PR DESCRIPTION
Fix #1028.