### PR TITLE
Republish dart_style 2.0.3 as 2.1.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * Republish 2.0.3 as 2.1.1 in order to avoid users getting 2.1.0, which has a
   bad dependency constraint (#1051).
 
+# 2.1.0
+
+* Support generic function references and constructor tear-offs (#1028).
+
 # 2.0.3
 
 * Fix hang when reading from stdin (https://github.com/dart-lang/sdk/issues/46600).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.1
+
+* Republish 2.0.3 as 2.1.1 in order to avoid users getting 2.1.0, which has a
+  bad dependency constraint (#1051).
+
 # 2.0.3
 
 * Fix hang when reading from stdin (https://github.com/dart-lang/sdk/issues/46600).

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '2.0.3';
+const dartStyleVersion = '2.1.1';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 class FormatterOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.0.3
+version: 2.1.1
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
This enables pub to avoid selecting 2.1.0, which has a bad constraint
on analyzer.

Fix #1051.