### PR TITLE
Remove outdated references to "dartfmt".

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,17 +99,9 @@ If you need to run a different version of the formatter, you can
 [globally activate][] the package from the dart_style package on
 pub.dev:
 
-    $ pub global activate dart_style
-    $ dartfmt ...
-
-For this to work, you need to put pub's bin directory on your PATH before the
-Dart SDK directory. Otherwise, the SDK's dartfmt will shadow this one.
-
 [globally activate]: https://dart.dev/tools/pub/cmd/pub-global
 
-If you don't want pub to put `dartfmt` on your PATH, you can run it explicitly:
-
-    $ pub global activate dart_style --no-executables
+    $ pub global activate dart_style
     $ pub global run dart_style:format ...
 
 ## Using the dart_style API

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2284,8 +2284,8 @@ class SourceVisitor extends ThrowingAstVisitor {
     //
     // That ensures that the way some code is formatted is not affected by the
     // presence or absence of `new`/`const`. In particular, it means that if
-    // they run `dartfmt --fix`, and then run `dartfmt` *again*, the second run
-    // will not produce any additional changes.
+    // they run `dart format --fix`, and then run `dart format` *again*, the
+    // second run will not produce any additional changes.
     if (node.target == null || looksLikeStaticCall(node)) {
       // Try to keep the entire method invocation one line.
       builder.nestExpression();

--- a/lib/src/string_compare.dart
+++ b/lib/src/string_compare.dart
@@ -1,8 +1,8 @@
 /// Returns `true` if [c] represents a whitespace code unit allowed in Dart
 /// source code.
 ///
-/// This follows the same rules as `String.trim()` because that's what dartfmt
-/// uses to trim trailing whitespace.
+/// This follows the same rules as `String.trim()` because that's what
+/// dart_style uses to trim trailing whitespace.
 bool _isWhitespace(int c) {
   // Not using a set or something more elegant because this code is on the hot
   // path and this large expression is significantly faster than a set lookup.

--- a/test/fixes/doc_comments.stmt
+++ b/test/fixes/doc_comments.stmt
@@ -166,7 +166,7 @@ This is an ugly dartdoc comment that contains a code block.
       Foo(this.x);
     }
 
-The formatting gets messed up by `dartfmt --fix-doc-comments`.
+The formatting gets messed up by `dart format --fix-doc-comments`.
 */
 m() {}
 <<<
@@ -177,7 +177,7 @@ m() {}
 ///       Foo(this.x);
 ///     }
 ///
-/// The formatting gets messed up by `dartfmt --fix-doc-comments`.
+/// The formatting gets messed up by `dart format --fix-doc-comments`.
 m() {}
 >>> strip leading indentation shared by all lines
 /**    4

--- a/test/whitespace/methods.unit
+++ b/test/whitespace/methods.unit
@@ -49,7 +49,7 @@ class A {
   named({covariant int a, covariant b});
   fn(covariant int f(bool b));
 }
->>> covariant in initializing formal (not valid, but dartfmt should accept)
+>>> covariant in initializing formal (not valid, but dart format should accept)
 class A {
   A(   covariant   this.foo);
 }

--- a/tool/command_shell.dart
+++ b/tool/command_shell.dart
@@ -12,8 +12,8 @@ import 'package:dart_style/src/cli/format_command.dart';
 /// This enables tests to spawn this executable in order to verify the output
 /// it prints.
 void main(List<String> arguments) async {
-  var runner =
-      CommandRunner<int>('dartfmt', 'Idiomatically format Dart source code.');
+  var runner = CommandRunner<int>(
+      'command_shell', 'Idiomatically format Dart source code.');
   runner.argParser.addFlag('verbose',
       abbr: 'v', negatable: false, help: 'Show verbose help.');
   runner.addCommand(FormatCommand(


### PR DESCRIPTION
There are still a few in the repo, but they are in code that exists to
implement or test the legacy CLI. Those will go away when support for
that is fully removed from the package in a future change.