### PR TITLE
Stop using 'astFactory', use specialized internal API.

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "32.0.0"
+    version: "34.0.0"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.0"
   args:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  analyzer: ">=2.6.0 <4.0.0"
+  analyzer: ">=3.2.0 <4.0.0"
   args: ">=1.0.0 <3.0.0"
   path: ^1.0.0
   pub_semver: ">=1.4.4 <3.0.0"


### PR DESCRIPTION
Clients should not build AST manually like this. There is one right way to do this - parse.

I was able to move almost all clients off the `AstFactory`, and `dart_style` is the last one. Unfortunately I was not able to find any better solution than to provide such specialized internal API for it.