### PR TITLE
Formatting support for named arguments anywhere.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.2
+
+* Format named arguments anywhere (#1072).
+
 # 2.2.1
 
 * Require `package:analyzer` version `2.6.0`.

--- a/lib/src/argument_list_visitor.dart
+++ b/lib/src/argument_list_visitor.dart
@@ -294,11 +294,15 @@ class ArgumentSublist {
   /// The full argument list from the AST.
   final List<Expression> _allArguments;
 
-  /// The leading positional arguments, in order.
+  /// If all positional arguments occur before all named arguments, then this
+  /// contains the positional arguments, in order. Otherwise (there are no
+  /// positional arguments or they are interleaved with named ones), this is
+  /// empty.
   final List<Expression> _positional;
 
-  /// The named arguments, in order, and any positional arguments that follow
-  /// at least one named argument.
+  /// The named arguments, in order. If there are any named arguments that occur
+  /// before positional arguments, then all arguments are treated as named and
+  /// end up in this list.
   final List<Expression> _named;
 
   /// Maps each block argument, excluding functions, to the first token for that

--- a/test/splitting/arguments.stmt
+++ b/test/splitting/arguments.stmt
@@ -216,3 +216,134 @@ fn(
   named: argument,
   another: argument,
 );
+>>> many arguments mixed named
+method(first, name1: second, third, name2: fourth, name3: fifth, sixth,
+seventh, name4: eighth, ninth, tenth);
+<<<
+method(
+    first,
+    name1: second,
+    third,
+    name2: fourth,
+    name3: fifth,
+    sixth,
+    seventh,
+    name4: eighth,
+    ninth,
+    tenth);
+>>> wrap before first argument, named first
+longFunctionIsLoooooooooooooong(name: argument, argument);
+<<<
+longFunctionIsLoooooooooooooong(
+    name: argument, argument);
+>>> named first
+function(name: firstArg * second, third * fourthAndLongest);
+<<<
+function(
+    name: firstArg * second,
+    third * fourthAndLongest);
+>>> arguments, nested
+someFunctionOne(someArgument,
+someFunctionTwo(name1: argument, argument, name2: argument),
+someFunctionTwo(argument, name: argument, argument),
+someArgument, someArgument);
+<<<
+someFunctionOne(
+    someArgument,
+    someFunctionTwo(
+        name1: argument,
+        argument,
+        name2: argument),
+    someFunctionTwo(
+        argument,
+        name: argument,
+        argument),
+    someArgument,
+    someArgument);
+>>> keep mixed positional and named on first line
+foo(arg, foo: arg, 1, bar: 2);
+<<<
+foo(arg, foo: arg, 1, bar: 2);
+>>> treat mixed named and positional as all named
+reallyLongMethod(argument, foo: first, second);
+<<<
+reallyLongMethod(
+    argument, foo: first, second);
+>>>
+reallyLongMethod(argument, argument, foo: first, bar: second, third);
+<<<
+reallyLongMethod(
+    argument,
+    argument,
+    foo: first,
+    bar: second,
+    third);
+>>>
+reallyLongMethod(leadingNamed: first, second, baz: third);
+<<<
+reallyLongMethod(
+    leadingNamed: first,
+    second,
+    baz: third);
+>>> trailing collections are indented in mixed named/positional arguments
+function(argument, a: argument, argument, b: argument,
+[element, element, element, element],
+c: {'key': value, 'other key': value, 'third key': value});
+<<<
+function(
+    argument,
+    a: argument,
+    argument,
+    b: argument,
+    [
+      element,
+      element,
+      element,
+      element
+    ],
+    c: {
+      'key': value,
+      'other key': value,
+      'third key': value
+    });
+>>> all trailing collections
+function([element, element], name: [element, element], {'key': value, 'other key': value, 'third key': value});
+<<<
+function([
+  element,
+  element
+], name: [
+  element,
+  element
+], {
+  'key': value,
+  'other key': value,
+  'third key': value
+});
+>>> non-collection non-preceding argument forces all collections to indent
+function([element, element, element, element], name: argument,
+{'key': value, 'other key': value, 'third key': value}, () {;});
+<<<
+function(
+    [
+      element,
+      element,
+      element,
+      element
+    ],
+    name: argument,
+    {
+      'key': value,
+      'other key': value,
+      'third key': value
+    }, () {
+  ;
+});
+>>> trailing comma with mixed named
+fn(argument,name: argument  ,argument  ,  );
+<<<
+fn(
+  argument,
+  name: argument,
+  argument,
+);

--- a/test/splitting/function_arguments.stmt
+++ b/test/splitting/function_arguments.stmt
@@ -201,6 +201,54 @@ longFunction(
       ;
     },
     c: argument);
+>>> named args anywhere with leading non-function
+{
+  longFunction(argument, b: () {;}, c: () {;});
+  longFunction(a: argument, () {;}, c: () {;});
+  longFunction(a: argument, b: () {;}, () {;});
+}
+<<<
+{
+  longFunction(argument, b: () {
+    ;
+  }, c: () {
+    ;
+  });
+  longFunction(a: argument, () {
+    ;
+  }, c: () {
+    ;
+  });
+  longFunction(a: argument, b: () {
+    ;
+  }, () {
+    ;
+  });
+}
+>>> named args anywhere with trailing non-function
+{
+  longFunction(() {;}, b: () {;}, c: argument);
+  longFunction(a: () {;}, () {;}, c: argument);
+  longFunction(a: () {;}, b: () {;}, argument);
+}
+<<<
+{
+  longFunction(() {
+    ;
+  }, b: () {
+    ;
+  }, c: argument);
+  longFunction(a: () {
+    ;
+  }, () {
+    ;
+  }, c: argument);
+  longFunction(a: () {
+    ;
+  }, b: () {
+    ;
+  }, argument);
+}
 >>> no extra indent for expression function argument with trailing comma
 function(() => P(p,),a: () => [a,],);
 <<<
@@ -229,3 +277,63 @@ function(
     p,
   ),
 );
+>>> unsplit named arguments with trailing positional closure
+function(a: argument, b: argument, () {;});
+<<<
+function(a: argument, b: argument, () {
+  ;
+});
+>>> split named arguments with trailing positional closure
+function(a: argument, b: argument, c: argument, () {;});
+<<<
+function(
+    a: argument,
+    b: argument,
+    c: argument, () {
+  ;
+});
+>>> unsingle split leading positional, named arguments with trailing positional closure
+function(argument, b: argument, () {;});
+<<<
+function(argument, b: argument, () {
+  ;
+});
+>>> single split leading positional, named arguments with trailing positional closure
+function(argument, b: argument, c: argument, () {;});
+<<<
+function(argument,
+    b: argument, c: argument, () {
+  ;
+});
+>>> split leading positional, named arguments with trailing positional closure
+function(argument, argument, argument, argument, argument, b: argument, c: argument, d: argument, () {;});
+<<<
+function(argument, argument, argument,
+    argument, argument,
+    b: argument,
+    c: argument,
+    d: argument, () {
+  ;
+});
+>>> multiple trailing positional closures
+function(argument, b: argument, c: argument, () {;}, () {;});
+<<<
+function(argument,
+    b: argument, c: argument, () {
+  ;
+}, () {
+  ;
+});
+>>> mixed named and positional trailing closures
+function(argument, b: argument, c: argument, () {;}, d: () {;}, () {;}, e: () {;});
+<<<
+function(argument,
+    b: argument, c: argument, () {
+  ;
+}, d: () {
+  ;
+}, () {
+  ;
+}, e: () {
+  ;
+});

--- a/test/splitting/list_arguments.stmt
+++ b/test/splitting/list_arguments.stmt
@@ -233,6 +233,30 @@ method(
       element
     ],
     c: third);
+>>> mixed named and positional forces nesting
+method(a:first,[element, element, element, element],c:third);
+<<<
+method(
+    a: first,
+    [
+      element,
+      element,
+      element,
+      element
+    ],
+    c: third);
+>>> mixed named and positional forces nesting
+method(a:first,b:[element, element, element, element],third);
+<<<
+method(
+    a: first,
+    b: [
+      element,
+      element,
+      element,
+      element
+    ],
+    third);
 >>> nothing but named list args does not nest
 longFunctionName(a: [element, element, element, element],
 b: [element, element, element, element], c: [element, element, element, element]);


### PR DESCRIPTION
I opted to add support for this while being minimally invasive to the
existing style and formatting. All existing code which does not have any
positional arguments after named ones retains its previous formatting.

For new argument lists that use positional arguments after named ones,
I try to mostly follow the existing style rules even though they can be
fairly complex. In particular, it will be pretty aggressive about
applying block-style formatting to function literals inside argument
lists even with named args anywhere. I think that's important to support
the main use case I know of for the feature which is trailing positional
closures like:

```dart
function(named: 1, another: 2, () {
  block...
});
```

In argument lists using named args anywhere that don't have block
functions, it treats all arguments like named ones. That provides nice
simple formatting like:

```dart
function(
    argument1,
    named: argument2,
    argument3,
    another: argument4);
```

I think that does a good job of highlighting which arguments are named,
which is what we want.

Fix #1072.