### PR TITLE
Format enhanced enums.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.2.2
 
 * Format named arguments anywhere (#1072).
+* Format enhanced enums (#1075).
 
 # 2.2.1
 

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1171,6 +1171,13 @@ class SourceVisitor extends ThrowingAstVisitor {
     if (arguments != null) {
       builder.nestExpression();
       visit(arguments.typeArguments);
+
+      var constructor = arguments.constructorSelector;
+      if (constructor != null) {
+        token(constructor.period);
+        visit(constructor.name);
+      }
+
       visitArgumentList(arguments.argumentList, nestExpression: false);
       builder.unnest();
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "34.0.0"
+    version: "36.0.0"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.1"
   args:
     dependency: "direct main"
     description:
@@ -70,7 +70,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.0"
   crypto:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   lints:
     dependency: "direct dev"
     description:
@@ -189,7 +189,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   pool:
     dependency: transitive
     description:
@@ -252,7 +252,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -287,7 +287,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.20.0"
+    version: "1.20.1"
   test_api:
     dependency: transitive
     description:
@@ -301,7 +301,7 @@ packages:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.10"
+    version: "0.4.11"
   test_descriptor:
     dependency: "direct dev"
     description:
@@ -329,7 +329,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.5.0"
+    version: "8.2.0"
   watcher:
     dependency: transitive
     description:
@@ -359,4 +359,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  analyzer: ">=3.2.0 <4.0.0"
+  analyzer: ^3.3.1
   args: ">=1.0.0 <3.0.0"
   path: ^1.0.0
   pub_semver: ">=1.4.4 <3.0.0"

--- a/test/comments/enums.unit
+++ b/test/comments/enums.unit
@@ -52,3 +52,24 @@ enum A {
   // comment
   B
 }
+>>> ensure blank line above doc comments
+enum Foo {/// doc
+a,/// doc
+b;/// doc
+var x = 1;
+/// doc
+void y() {}}
+<<<
+enum Foo {
+  /// doc
+  a,
+
+  /// doc
+  b;
+
+  /// doc
+  var x = 1;
+
+  /// doc
+  void y() {}
+}

--- a/test/regression/other/enhanced_enum.unit
+++ b/test/regression/other/enhanced_enum.unit
@@ -1,0 +1,180 @@
+>>> enhanced enum language test
+// Full syntax, with every possible option.
+@EnumAll.v1
+@EnumAll.sConst
+enum EnumAll<S extends num, T extends num>
+    with GenericEnumMixin<T>, ObjectMixin
+    implements Interface, GenericInterface<S> {
+  @v1
+  @v2
+  v1,
+  @EnumAll.v2
+  v2(y: 2),
+  @sConst
+  v3<int, int>(y: 2),
+  v4.named(1, y: 2),
+  v5<int, int>.renamed(1, y: 2),
+  v6.new(),
+  ;
+
+  /// Static members.
+  ///
+  /// Any kind of static variable.
+  static const sConst = v3;
+  static final sFinal = v3;
+  static late final EnumAll sLateFinal;
+  static late final sLateFinalInit = v3;
+  static late EnumAll sLateVar;
+  static late var sLateVarInit = v3;
+  static EnumAll? sVar;
+  static EnumAll sVarInit = v3;
+  /// Static getters, setters and methods
+  static EnumAll<int, int> get staticGetSet => v3;
+  static set staticGetSet(EnumAll<int, int> _) {}
+  static int staticMethod() => 42;
+
+  // Constructors.
+  // Generative, non-redirecting, unnamed.
+  const EnumAll({T? y})
+      : constructor = "unnamed", this.x = 0 as S, y = y ?? (0 as T);
+  // Generative, non-redirecting, named.
+  const EnumAll.named(this.x, {T? y, String? constructor})
+      : constructor = constructor ?? "named", y = y ?? (0 as T);
+  // Generative, redirecting.
+  const EnumAll.renamed(S x, {T? y})
+      : this.named(x, y: y, constructor: "renamed");
+  // Factory, non-redirecting.
+  factory EnumAll.factory(int index) => values[index] as EnumAll<S, T>;
+  // Factory, redirecting (only to other factory constructor).
+  factory EnumAll.refactory(int index) = EnumAll<S, T>.factory;
+
+  // Cannot have factory constructors redirecting to generative constructors.
+  // (Nothing can refer to generative constructors except redirecting generative
+  // constructors and the implicit element creation expressions.)
+  // Cannot have const factory constructor, because they *must* redirect to
+  // generative constructors.
+  // Cannot have `super`-constuctor invocations in initializer lists.
+
+  // Instance members.
+
+  // Instance variables must be final and non-late because of const constructor.
+  final String constructor;
+  final S x;
+  final num y;
+
+  // Getters, setters, methods and operators.
+  S get instanceGetSet => x;
+  set instanceGetSet(S _) {}
+  S instanceMethod() => x;
+  EnumAll<num, num> operator ^(EnumAll<num, num> other) {
+    var newIndex = index ^ other.index;
+    if (newIndex > 4) newIndex = 4;
+    return values[newIndex]; // Can refer to `values`.
+  }
+
+  // Can access `this` and `super` in an instance method.
+  String thisAndSuper() => "${super.toString()}:${this.toString()}";
+
+  // Can be callable.
+  T call<T>(T value) => value;
+
+  // Can have an `index` setter.
+  set index(int value) {}
+
+  // Instance members shadow extensions.
+  String get notExtension => "not extension";
+
+  String toString() => "this";
+}
+<<<
+// Full syntax, with every possible option.
+@EnumAll.v1
+@EnumAll.sConst
+enum EnumAll<S extends num, T extends num>
+    with GenericEnumMixin<T>, ObjectMixin
+    implements Interface, GenericInterface<S> {
+  @v1
+  @v2
+  v1,
+  @EnumAll.v2
+  v2(y: 2),
+  @sConst
+  v3<int, int>(y: 2),
+  v4.named(1, y: 2),
+  v5<int, int>.renamed(1, y: 2),
+  v6.new(),
+  ;
+
+  /// Static members.
+  ///
+  /// Any kind of static variable.
+  static const sConst = v3;
+  static final sFinal = v3;
+  static late final EnumAll sLateFinal;
+  static late final sLateFinalInit = v3;
+  static late EnumAll sLateVar;
+  static late var sLateVarInit = v3;
+  static EnumAll? sVar;
+  static EnumAll sVarInit = v3;
+
+  /// Static getters, setters and methods
+  static EnumAll<int, int> get staticGetSet => v3;
+  static set staticGetSet(EnumAll<int, int> _) {}
+  static int staticMethod() => 42;
+
+  // Constructors.
+  // Generative, non-redirecting, unnamed.
+  const EnumAll({T? y})
+      : constructor = "unnamed",
+        this.x = 0 as S,
+        y = y ?? (0 as T);
+  // Generative, non-redirecting, named.
+  const EnumAll.named(this.x, {T? y, String? constructor})
+      : constructor = constructor ?? "named",
+        y = y ?? (0 as T);
+  // Generative, redirecting.
+  const EnumAll.renamed(S x, {T? y})
+      : this.named(x, y: y, constructor: "renamed");
+  // Factory, non-redirecting.
+  factory EnumAll.factory(int index) => values[index] as EnumAll<S, T>;
+  // Factory, redirecting (only to other factory constructor).
+  factory EnumAll.refactory(int index) = EnumAll<S, T>.factory;
+
+  // Cannot have factory constructors redirecting to generative constructors.
+  // (Nothing can refer to generative constructors except redirecting generative
+  // constructors and the implicit element creation expressions.)
+  // Cannot have const factory constructor, because they *must* redirect to
+  // generative constructors.
+  // Cannot have `super`-constuctor invocations in initializer lists.
+
+  // Instance members.
+
+  // Instance variables must be final and non-late because of const constructor.
+  final String constructor;
+  final S x;
+  final num y;
+
+  // Getters, setters, methods and operators.
+  S get instanceGetSet => x;
+  set instanceGetSet(S _) {}
+  S instanceMethod() => x;
+  EnumAll<num, num> operator ^(EnumAll<num, num> other) {
+    var newIndex = index ^ other.index;
+    if (newIndex > 4) newIndex = 4;
+    return values[newIndex]; // Can refer to `values`.
+  }
+
+  // Can access `this` and `super` in an instance method.
+  String thisAndSuper() => "${super.toString()}:${this.toString()}";
+
+  // Can be callable.
+  T call<T>(T value) => value;
+
+  // Can have an `index` setter.
+  set index(int value) {}
+
+  // Instance members shadow extensions.
+  String get notExtension => "not extension";
+
+  String toString() => "this";
+}

--- a/test/splitting/enums.unit
+++ b/test/splitting/enums.unit
@@ -17,3 +17,29 @@ enum Primate {
   GORILLA,
   ORANGUTAN,
 }
+>>> wrapped argument lists in values
+enum Args {
+firstEnumValue(longArgument,anotherArgument),
+secondEnumValue(longArgument,anotherArgument,aThirdArgument,theLastOne),
+thirdGenericOne<FirstTypeArgument,
+SecondTypeArgument<NestedTypeArgument,AnotherNestedTypeArgument>,
+LastTypeArgument>(namedArgument: firstValue,anotherNamed:argumentValue)
+}
+<<<
+enum Args {
+  firstEnumValue(
+      longArgument, anotherArgument),
+  secondEnumValue(
+      longArgument,
+      anotherArgument,
+      aThirdArgument,
+      theLastOne),
+  thirdGenericOne<
+          FirstTypeArgument,
+          SecondTypeArgument<
+              NestedTypeArgument,
+              AnotherNestedTypeArgument>,
+          LastTypeArgument>(
+      namedArgument: firstValue,
+      anotherNamed: argumentValue)
+}

--- a/test/whitespace/enums.unit
+++ b/test/whitespace/enums.unit
@@ -51,3 +51,232 @@ enum Primate {
 }
 <<<
 enum Primate { bonobo, chimp, gorilla }
+>>> one blank line between values and members
+enum E { a, b, c;
+
+
+
+int x; }
+<<<
+enum E {
+  a,
+  b,
+  c;
+
+  int x;
+}
+>>> always go multiline if there are members
+enum E { a, b, c; int x; }
+<<<
+enum E {
+  a,
+  b,
+  c;
+
+  int x;
+}
+>>> indentation
+enum A { a;
+var z;
+inc(int x) => ++x;
+foo(int x) {
+if (x == 0) {
+return true;
+}}}
+<<<
+enum A {
+  a;
+
+  var z;
+  inc(int x) => ++x;
+  foo(int x) {
+    if (x == 0) {
+      return true;
+    }
+  }
+}
+>>> trailing space inside body
+enum A { a, b
+  }
+<<<
+enum A { a, b }
+>>> leading space before "enum"
+  enum A { a
+}
+<<<
+enum A { a }
+>>>
+enum A  { a;int meaningOfLife() => 42; }
+<<<
+enum A {
+  a;
+
+  int meaningOfLife() => 42;
+}
+>>>
+enum A{a;var z;inc(int x) => ++x;}
+<<<
+enum A {
+  a;
+
+  var z;
+  inc(int x) => ++x;
+}
+>>> insert blank line after non-empty block-bodied members
+enum Foo {
+  x;
+var a = 1; b() {;} c() => null; get d {;} get e => null; set f(value) {;
+} set g(value) => null; var h = 1;}
+<<<
+enum Foo {
+  x;
+
+  var a = 1;
+  b() {
+    ;
+  }
+
+  c() => null;
+  get d {
+    ;
+  }
+
+  get e => null;
+  set f(value) {
+    ;
+  }
+
+  set g(value) => null;
+  var h = 1;
+}
+>>> no required blank line after empty block-bodied members
+enum Foo {x;
+var a = 1; b() {} c() => null; get d {} get e => null; set f(value) {
+} set g(value) => null; var h = 1;}
+<<<
+enum Foo {
+  x;
+
+  var a = 1;
+  b() {}
+  c() => null;
+  get d {}
+  get e => null;
+  set f(value) {}
+  set g(value) => null;
+  var h = 1;
+}
+>>> blank line before and after enum
+var x = 1;
+enum A { a }
+var y = 2;
+<<<
+var x = 1;
+
+enum A { a }
+
+var y = 2;
+>>> semicolon after values but no members
+enum   E { a, b; }
+<<<
+enum E {
+  a,
+  b;
+}
+>>> enhanced with clauses and members
+enum E with M<R, S>, F implements C<T>, D {
+value;
+late final String field;
+static var staticField = initializer;
+int method() { body; }
+static String staticMethod(int x) => body;
+List<int> get getter => 3;
+int operator +(other) => 3;
+const E([String parameter]) : field = parameter;
+const E.named({String parameter});
+}
+<<<
+enum E
+    with M<R, S>, F
+    implements C<T>, D {
+  value;
+
+  late final String field;
+  static var staticField = initializer;
+  int method() {
+    body;
+  }
+
+  static String staticMethod(int x) =>
+      body;
+  List<int> get getter => 3;
+  int operator +(other) => 3;
+  const E([String parameter])
+      : field = parameter;
+  const E.named({String parameter});
+}
+>>> argument lists in values
+enum Args {
+first(),second(a,b,c),
+third(named:1,2,another:3)
+}
+<<<
+enum Args {
+  first(),
+  second(a, b, c),
+  third(named: 1, 2, another: 3)
+}
+>>> generic enum
+enum MagicNumbers< T    extends num   ,   S> {
+  one(1), two(2),pi<double,String>(3.14159)
+}
+<<<
+enum MagicNumbers<T extends num, S> {
+  one(1),
+  two(2),
+  pi<double, String>(3.14159)
+}
+>>> trailing commas in value arguments
+enum Numbers {
+  one(1,),
+  two(1,2,),
+}
+<<<
+enum Numbers {
+  one(
+    1,
+  ),
+  two(
+    1,
+    2,
+  ),
+}
+>>> trailing comma and semicolon after constants
+enum E {a,b,c,;}
+<<<
+enum E {
+  a,
+  b,
+  c,
+  ;
+}
+>>> trailing comma and semicolon after constants with member
+enum E {a,b,c,;var x;}
+<<<
+enum E {
+  a,
+  b,
+  c,
+  ;
+
+  var x;
+}
+>>> trailing comma and semicolon after constant with argument list
+enum E {a,b,c(123),;}
+<<<
+enum E {
+  a,
+  b,
+  c(123),
+  ;
+}


### PR DESCRIPTION
The implementation is straightforward. Most of the new code is copied from similar code for formatting class bodies. (There wasn't enough exact duplication to be worth hoisting it out to something reused.)

I tried to write tests to cover everything I could think of. I also ran this over the enhanced enum language and co19 tests to make sure it could format everything in those.

Fix #1075.