### PR TITLE
Refactor Chunk to represent the split preceding the chunk's text.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 2.2.3-dev
+
+* Refactor Chunk to store split before text instead of after. This mostly does
+  not affect the visible behavior of the formatter, but a few edge cases are
+  handled slightly differently. These are all bug fixes where the previous
+  behavior was unintentional. The changes are:
+
+  * Consistently discard blank lines between a `{` or `[` and a subsequent
+    comment. It used to do this before the `{` in type bodies, but not switch
+    bodies, optional parameter sections, or named parameter sections.
+
+  * Don't allow splitting an empty class body.
+
+  * Allow splitting after an inline block comment in some places where it makes
+    sense.
+
+  * Don't allow a line comment in an argument list to cause preceding arguments
+    to be misformatted.
+
+  * Remove blank lines after a line comment at the end of a body.
+
 # 2.2.2
 
 * Format named arguments anywhere (#1072).

--- a/example/format.dart
+++ b/example/format.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+library dart_style.example.format;
+
 import 'dart:io';
 import 'dart:mirrors';
 

--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -220,17 +220,15 @@ class Chunk extends Selection {
 
   @override
   String toString() {
-    var parts = [];
-
-    parts.add('indent:$indent');
-    if (spaceWhenUnsplit) parts.add('space');
-    if (isDouble) parts.add('double');
-    if (flushLeft) parts.add('flush');
-    parts.add('$rule${rule.isHardened ? '!' : ''}');
-
-    if (rule.constrainedRules.isNotEmpty) {
-      parts.add("-> ${rule.constrainedRules.join(' ')}");
-    }
+    var parts = [
+      'indent:$indent',
+      if (spaceWhenUnsplit) 'space',
+      if (isDouble) 'double',
+      if (flushLeft) 'flush',
+      '$rule${rule.isHardened ? '!' : ''}',
+      if (rule.constrainedRules.isNotEmpty)
+        "-> ${rule.constrainedRules.join(' ')}"
+    ];
 
     return '[${parts.join(' ')}] `$text`';
   }

--- a/lib/src/chunk_builder.dart
+++ b/lib/src/chunk_builder.dart
@@ -149,6 +149,17 @@ class ChunkBuilder {
   ///
   /// If we didn't do this here, we'd have to call [nestExpression] after the
   /// first token of practically every grammar production.
+  ///
+  /// If [mergeEmptySplits] is `true`, the default, then any pending split
+  /// information will be combined with a previously created split if no text
+  /// has been written since. This generally comes into play when text is
+  /// written after a comment. The comment may leave some pending split
+  /// information while [SourceVisitor] may have also created a split and we
+  /// want to combine those.
+  ///
+  /// It is only `false` when writing the contents of a multiline string. There,
+  /// we may *want* to have a series of empty chunks because those represent
+  /// empty lines in the multiline string.
   void write(String string, {bool mergeEmptySplits = true}) {
     _emitPendingWhitespace(mergeEmptySplits: mergeEmptySplits);
     _writeText(string);

--- a/lib/src/chunk_builder.dart
+++ b/lib/src/chunk_builder.dart
@@ -53,6 +53,18 @@ class ChunkBuilder {
   /// indentation or nesting.
   Whitespace _pendingWhitespace = Whitespace.none;
 
+  /// Whether a non-breaking space should be written before the next text.
+  bool _pendingSpace = false;
+
+  /// Whether the next chunk should use expression nesting.
+  bool _pendingNested = false;
+
+  /// Whether the next chunk should be flush left.
+  bool _pendingFlushLeft = false;
+
+  /// Whether the most recently written output was a comment.
+  bool _afterComment = false;
+
   /// The nested stack of rules that are currently in use.
   ///
   /// New chunks are implicitly split by the innermost rule when the chunk is
@@ -84,24 +96,6 @@ class ChunkBuilder {
   ///
   /// A block argument's contents will nest at the last level in this stack.
   final _blockArgumentNesting = <NestingLevel>[];
-
-  /// The index of the "current" chunk being written.
-  ///
-  /// If the last chunk is still being appended to, this is its index.
-  /// Otherwise, it is the index of the next chunk which will be created.
-  int get _currentChunkIndex {
-    if (_chunks.isEmpty) return 0;
-    if (_chunks.last.canAddText) return _chunks.length - 1;
-    return _chunks.length;
-  }
-
-  /// Whether or not there was a leading comment that was flush left before any
-  /// other content was written.
-  ///
-  /// This is used when writing child blocks to make the parent chunk have the
-  /// right flush left value when a comment appears immediately inside the
-  /// block.
-  bool _firstFlushLeft = false;
 
   /// The number of calls to [preventSplit()] that have not been ended by a
   /// call to [endPreventSplit()].
@@ -155,45 +149,55 @@ class ChunkBuilder {
   ///
   /// If we didn't do this here, we'd have to call [nestExpression] after the
   /// first token of practically every grammar production.
-  void write(String string) {
-    _emitPendingWhitespace();
+  void write(String string, {bool mergeEmptySplits = true}) {
+    _emitPendingWhitespace(mergeEmptySplits: mergeEmptySplits);
     _writeText(string);
 
     _lazyRules.forEach(_activateRule);
     _lazyRules.clear();
 
     _nesting.commitNesting();
+    _afterComment = false;
   }
 
   /// Writes a [WhitespaceChunk] of [type].
-  void writeWhitespace(Whitespace type) {
+  void writeWhitespace(Whitespace type,
+      {bool flushLeft = false, bool nest = false}) {
     _pendingWhitespace = type;
+    _pendingFlushLeft = flushLeft;
+    _pendingNested = nest;
+  }
+
+  /// Writes a space before the subsequent non-whitespace text.
+  void writeSpace() {
+    _pendingSpace = true;
   }
 
   /// Write a split owned by the current innermost rule.
   ///
-  /// If [flushLeft] is `true`, then forces the next line to start at column
-  /// one regardless of any indentation or nesting.
-  ///
-  /// If [isDouble] is passed, forces the split to either be a single or double
-  /// newline. Otherwise, leaves it indeterminate.
-  ///
   /// If [nest] is `false`, ignores any current expression nesting. Otherwise,
   /// uses the current nesting level. If unsplit, it expands to a space if
   /// [space] is `true`.
-  Chunk split({bool? flushLeft, bool? isDouble, bool? nest, bool? space}) {
-    space ??= false;
-
+  Chunk split({bool nest = true, bool space = false}) {
     // If we are not allowed to split at all, don't. Returning null for the
     // chunk is safe since the rule that uses the chunk will itself get
     // discarded because no chunk references it.
     if (_preventSplitNesting > 0) {
-      if (space) _pendingWhitespace = Whitespace.space;
+      _pendingWhitespace = Whitespace.none;
+      _pendingNested = false;
+
+      if (space) _pendingSpace = true;
       return Chunk.dummy();
     }
 
-    return _writeSplit(_rules.last,
-        flushLeft: flushLeft, isDouble: isDouble, nest: nest, space: space);
+    // If a hard split after a comment is already pending, then prefer that over
+    // a soft split.
+    if (_pendingWhitespace.minimumLines > 0) {
+      return Chunk.dummy();
+    }
+
+    return _writeSplit(
+        isHard: false, isDouble: false, nest: nest, space: space);
   }
 
   /// Outputs the series of [comments] and associated whitespace that appear
@@ -221,11 +225,11 @@ class ChunkBuilder {
     if (_pendingWhitespace == Whitespace.twoNewlines &&
         comments.first.linesBefore < 2) {
       if (linesBeforeToken > 1) {
-        _pendingWhitespace = Whitespace.newline;
+        writeWhitespace(Whitespace.newline);
       } else {
         for (var i = 1; i < comments.length; i++) {
           if (comments[i].linesBefore > 1) {
-            _pendingWhitespace = Whitespace.newline;
+            writeWhitespace(Whitespace.newline);
             break;
           }
         }
@@ -245,9 +249,9 @@ class ChunkBuilder {
     //
     // When that happens, we need to make sure to preserve the split at the end
     // of the first sequence of comments if there is one.
-    if (_pendingWhitespace == Whitespace.afterHardSplit) {
+    if (_afterComment && _pendingWhitespace != Whitespace.none) {
       comments.first.linesBefore = 1;
-      _pendingWhitespace = Whitespace.none;
+      writeWhitespace(Whitespace.none);
     }
 
     // Edge case: if the comments are completely inline (i.e. just a series of
@@ -274,33 +278,39 @@ class ChunkBuilder {
 
       preserveNewlines(comment.linesBefore);
 
-      // Don't emit a space because we'll handle it below. If we emit it here,
-      // we may get a trailing space if the comment needs a line before it.
-      if (_pendingWhitespace == Whitespace.space) {
-        _pendingWhitespace = Whitespace.none;
-      }
-      _emitPendingWhitespace();
-
       // See if the comment should follow text on the current line.
-      if (comment.linesBefore == 0 || comment.type == CommentType.inlineBlock) {
-        // If we're sitting on a split, move the comment before it to adhere it
-        // to the preceding text.
-        if (_shouldMoveCommentBeforeSplit(comment)) {
-          _chunks.last.allowText();
+      var chunk = _chunkForComment(comment, token);
+      if (chunk != null) {
+        // The comment follows other text, so decide if it gets a space before
+        // it.
+        _pendingSpace = _needsSpaceBeforeComment(comment, chunk);
+        if (_pendingSpace && chunk != _chunks.last) {
+          // We've already created a split after the comment, so if it doesn't
+          // split, it should get a space.
+          _chunks.last.updateSplit(space: true);
+        }
+      } else {
+        // Split before the comment if it starts a line.
+        if (_pendingWhitespace == Whitespace.none) {
+          if (comment.linesBefore > 0 &&
+              (_afterComment || comment.type != CommentType.inlineBlock)) {
+            writeWhitespace(
+                _needsBlankLineBeforeComment(comment)
+                    ? Whitespace.twoNewlines
+                    : Whitespace.newline,
+                flushLeft: comment.flushLeft,
+                nest: true);
+          } else if (_chunks.isNotEmpty) {
+            _pendingSpace = _needsSpaceBeforeComment(comment, _chunks.last);
+          }
+        } else {
+          _pendingFlushLeft = comment.flushLeft;
         }
 
-        // The comment follows other text, so we need to decide if it gets a
-        // space before it or not.
-        if (_needsSpaceBeforeComment(comment)) _writeText(' ');
-      } else {
-        // The comment is not inline, so start a new line.
-        _writeHardSplit(
-            flushLeft: comment.flushLeft,
-            isDouble: comment.linesBefore > 1,
-            nest: true);
+        _emitPendingWhitespace(isDouble: _needsBlankLineBeforeComment(comment));
       }
 
-      _writeCommentText(comment);
+      _writeCommentText(comment, chunk);
 
       if (comment.selectionStart != null) {
         startSelectionFromEnd(comment.text.length - comment.selectionStart!);
@@ -329,31 +339,36 @@ class ChunkBuilder {
         }
       }
 
-      if (linesAfter > 0) _writeHardSplit(isDouble: linesAfter > 1, nest: true);
+      if (linesAfter > 0) {
+        writeWhitespace(
+            _pendingWhitespace == Whitespace.twoNewlines || linesAfter > 1
+                ? Whitespace.twoNewlines
+                : Whitespace.newline,
+            nest: true);
+      }
     }
 
     // If the comment has text following it (aside from a grouping character),
     // it needs a trailing space.
-    if (_needsSpaceAfterLastComment(comments, token)) {
-      _pendingWhitespace = Whitespace.space;
-    }
+    _pendingSpace = _needsSpaceAfterComment(comments.last, token);
 
     preserveNewlines(linesBeforeToken);
+    _afterComment = true;
   }
 
   /// Writes the text of [comment].
   ///
   /// If it's a JavaDoc comment that should be fixed to use `///`, fixes it.
-  void _writeCommentText(SourceComment comment) {
+  void _writeCommentText(SourceComment comment, [Chunk? chunk]) {
     if (!_formatter.fixes.contains(StyleFix.docComments)) {
-      _writeText(comment.text);
+      _writeText(comment.text, chunk);
       return;
     }
 
     // See if it's a JavaDoc comment.
     var match = _javaDocComment.firstMatch(comment.text);
     if (match == null) {
-      _writeText(comment.text);
+      _writeText(comment.text, chunk);
       return;
     }
 
@@ -389,49 +404,43 @@ class ChunkBuilder {
     if (lines.isEmpty) lines.add('');
 
     for (var line in lines) {
-      _writeText('///');
+      _writeText('///', chunk);
       if (line.isNotEmpty) {
         // Discard any indentation shared by all lines.
         line = line.substring(leastIndentation);
-        _writeText(' $line');
+        _writeText(' $line', chunk);
       }
-      _pendingWhitespace = Whitespace.newline;
+
+      writeWhitespace(Whitespace.newline);
       _emitPendingWhitespace();
     }
   }
 
   /// If the current pending whitespace allows some source discretion, pins
   /// that down given that the source contains [numLines] newlines at that
-  /// point.
+  /// point and writes any needed split.
   void preserveNewlines(int numLines) {
-    // If we didn't know how many newlines the user authored between the last
-    // token and this one, now we do.
     switch (_pendingWhitespace) {
       case Whitespace.splitOrNewline:
         if (numLines > 0) {
-          _pendingWhitespace = Whitespace.nestedNewline;
+          _writeSplit(nest: true);
         } else {
-          _pendingWhitespace = Whitespace.none;
           split(space: true);
         }
         break;
 
       case Whitespace.splitOrTwoNewlines:
         if (numLines > 1) {
-          _pendingWhitespace = Whitespace.twoNewlines;
+          _writeSplit(isDouble: true, nest: true);
         } else {
-          _pendingWhitespace = Whitespace.none;
           split(space: true);
         }
         break;
 
       case Whitespace.oneOrTwoNewlines:
-        if (numLines > 1) {
-          _pendingWhitespace = Whitespace.twoNewlines;
-        } else {
-          _pendingWhitespace = Whitespace.newline;
-        }
+        _writeSplit(isDouble: numLines > 1, nest: false);
         break;
+
       default:
         break;
     }
@@ -453,7 +462,7 @@ class ChunkBuilder {
   ///
   /// Each call to this needs a later matching call to [endSpan].
   void startSpan([int cost = Cost.normal]) {
-    _openSpans.add(OpenSpan(_currentChunkIndex, cost));
+    _openSpans.add(OpenSpan(_chunks.length, cost));
   }
 
   /// Ends the innermost span.
@@ -461,14 +470,14 @@ class ChunkBuilder {
     var openSpan = _openSpans.removeLast();
 
     // A span that just covers a single chunk can't be split anyway.
-    var end = _currentChunkIndex;
+    var end = _chunks.length;
     if (openSpan.start == end) return;
 
     // Add the span to every chunk that can split it.
     var span = Span(openSpan.cost);
     for (var i = openSpan.start; i < end; i++) {
       var chunk = _chunks[i];
-      if (!chunk.rule!.isHardened) chunk.spans.add(span);
+      if (!chunk.rule.isHardened) chunk.spans.add(span);
     }
   }
 
@@ -574,7 +583,14 @@ class ChunkBuilder {
   /// of text containing the selection has been output.
   void endSelectionFromEnd(int fromEnd) {
     assert(_chunks.isNotEmpty);
-    _chunks.last.endSelectionFromEnd(fromEnd);
+
+    // If the selection marker is right on a split, then put it before the
+    // newline.
+    if (_chunks.last.text.isNotEmpty) {
+      _chunks.last.endSelectionFromEnd(fromEnd);
+    } else {
+      _chunks[_chunks.length - 2].endSelectionFromEnd(fromEnd);
+    }
   }
 
   /// Captures the current nesting level as marking where subsequent block
@@ -590,17 +606,12 @@ class ChunkBuilder {
 
   /// Starts a new block as a child of the current chunk.
   ///
-  /// Nested blocks are handled using their own independent [LineWriter]. If
-  /// [indent] is `false` then the first line of the block will not get a level
-  /// of leading indentation. Otherwise it does.
-  ChunkBuilder startBlock(Chunk? argumentChunk, {bool indent = true}) {
+  /// Nested blocks are handled using their own independent [LineWriter].
+  ChunkBuilder startBlock([Chunk? argumentChunk]) {
     var chunk = _chunks.last;
-    chunk.makeBlock(argumentChunk, indent: indent);
+    chunk.makeBlock(argumentChunk);
 
-    var builder = ChunkBuilder._(this, _formatter, _source, chunk.block.chunks);
-    if (indent) builder.indent();
-
-    return builder;
+    return ChunkBuilder._(this, _formatter, _source, chunk.block.chunks);
   }
 
   /// Ends this [ChunkBuilder], which must have been created by [startBlock()].
@@ -615,6 +626,10 @@ class ChunkBuilder {
   ChunkBuilder endBlock(Rule? ignoredSplit, {required bool forceSplit}) {
     _divideChunks();
 
+    // If the last chunk ends with a comment that wants a newline after it,
+    // then force the block contents to split.
+    forceSplit |= _pendingNested;
+
     // If we don't already know if the block is going to split, see if it
     // contains any hard splits or is longer than a page.
     if (!forceSplit) {
@@ -626,8 +641,11 @@ class ChunkBuilder {
           break;
         }
 
-        if (chunk.rule != null &&
-            chunk.rule!.isHardened &&
+        // If there are any hardened splits in the chunks (aside from the first
+        // one which is always a hard split since it is the beginning of the
+        // code), then force the collection to split.
+        if (chunk != _chunks.first &&
+            chunk.rule.isHardened &&
             chunk.rule != ignoredSplit) {
           forceSplit = true;
           break;
@@ -635,23 +653,26 @@ class ChunkBuilder {
       }
     }
 
-    _parent!._endChildBlock(
-        firstFlushLeft: _firstFlushLeft, forceSplit: forceSplit);
+    if (forceSplit) {
+      forceRules();
+    }
+
+    _parent!._endChildBlock(forceSplit: forceSplit);
     return _parent!;
   }
 
   /// Finishes off the last chunk in a child block of this parent.
-  void _endChildBlock({bool? firstFlushLeft, required bool forceSplit}) {
+  void _endChildBlock({required bool forceSplit}) {
     // If there is a hard newline within the block, force the surrounding rule
     // for it so that we apply that constraint.
     if (forceSplit) forceRules();
 
-    // Write the split for the block contents themselves.
-    var chunk = _chunks.last;
-    chunk.applySplit(rule, _nesting.indentation, _blockArgumentNesting.last,
-        flushLeft: firstFlushLeft);
+    // Start a new chunk for the code after the block contents. The split at
+    // the beginning of this chunk also determines whether the preceding block
+    // splits and, if so, how it is indented.
+    _startChunk(_blockArgumentNesting.last, isHard: false);
 
-    if (chunk.rule!.isHardened) _handleHardSplit();
+    if (rule.isHardened) _handleHardSplit();
   }
 
   /// Finishes writing and returns a [SourceCode] containing the final output
@@ -659,7 +680,6 @@ class ChunkBuilder {
   SourceCode end() {
     assert(_rules.isEmpty);
 
-    _writeHardSplit();
     _divideChunks();
 
     if (debug.traceChunkBuilder) {
@@ -669,8 +689,8 @@ class ChunkBuilder {
     }
 
     var writer = LineWriter(_formatter, _chunks);
-    var result = writer.writeLines(_formatter.indent,
-        isCompilationUnit: _source.isCompilationUnit);
+    var result =
+        writer.writeLines(isCompilationUnit: _source.isCompilationUnit);
 
     int? selectionStart;
     int? selectionLength;
@@ -706,66 +726,60 @@ class ChunkBuilder {
   ///
   /// This should only be called after source lines have been preserved to turn
   /// any ambiguous whitespace into a concrete choice.
-  void _emitPendingWhitespace() {
-    // Output any pending whitespace first now that we know it won't be
-    // trailing.
-    switch (_pendingWhitespace) {
-      case Whitespace.space:
-        _writeText(' ');
-        break;
+  void _emitPendingWhitespace(
+      {bool isDouble = false, bool mergeEmptySplits = true}) {
+    if (_pendingWhitespace == Whitespace.none) return;
 
-      case Whitespace.newline:
-        _writeHardSplit();
-        break;
-
-      case Whitespace.nestedNewline:
-        _writeHardSplit(nest: true);
-        break;
-
-      case Whitespace.newlineFlushLeft:
-        _writeHardSplit(flushLeft: true, nest: true);
-        break;
-
-      case Whitespace.twoNewlines:
-        _writeHardSplit(isDouble: true);
-        break;
-
-      case Whitespace.splitOrNewline:
-      case Whitespace.splitOrTwoNewlines:
-      case Whitespace.oneOrTwoNewlines:
-        // We should have pinned these down before getting here.
-        assert(false);
-        break;
-      default:
-        break;
-    }
-
-    _pendingWhitespace = Whitespace.none;
+    if (_pendingWhitespace == Whitespace.twoNewlines) isDouble = true;
+    _writeSplit(
+        isDouble: isDouble,
+        nest: _pendingNested,
+        mergeEmptySplits: mergeEmptySplits);
   }
 
-  /// Returns `true` if the last chunk is a split that should be moved after the
-  /// comment that is about to be written.
-  bool _shouldMoveCommentBeforeSplit(SourceComment comment) {
+  /// Tries to find an existing chunk to append [comment] to.
+  ///
+  /// If [comment] should be appending to an existing line (in other words,
+  /// should be moved before a split), then this returns that [Chunk].
+  /// Otherwise, returns `null`.
+  Chunk? _chunkForComment(SourceComment comment, String token) {
     // Not if there is nothing before it.
-    if (_chunks.isEmpty) return false;
+    if (_chunks.isEmpty) return null;
 
     // Don't move a comment to a preceding line.
-    if (comment.linesBefore != 0) return false;
+    if (comment.linesBefore != 0) return null;
 
     // Multi-line comments are always pushed to the next line.
-    if (comment.type == CommentType.doc) return false;
-    if (comment.type == CommentType.block) return false;
+    if (comment.type == CommentType.doc) return null;
+    if (comment.type == CommentType.block) return null;
 
-    var text = _chunks.last.text;
+    var chunk = _chunks.last;
+
+    // We may have started a split for a new chunk but not written any text yet.
+    // In that case, the comment may get written to the previous chunk. Keep a
+    // generic method comment before '(' with the '(', so don't move it before
+    // the split.
+    if (chunk.text.isEmpty &&
+        _chunks.length > 1 &&
+        (!_isGenericMethodComment(comment) || token != '(')) {
+      chunk = _chunks[_chunks.length - 2];
+    }
 
     // A block comment following a comma probably refers to the following item.
+    var text = chunk.text;
     if (text.endsWith(',') && comment.type == CommentType.inlineBlock) {
-      return false;
+      return null;
     }
 
     // If the text before the split is an open grouping character, it looks
     // better to keep it with the elements than with the bracket itself.
-    return !text.endsWith('(') && !text.endsWith('[') && !text.endsWith('{');
+    if (text.endsWith('(') ||
+        text.endsWith('[') ||
+        (text.endsWith('{') && !text.endsWith('\${'))) {
+      return null;
+    }
+
+    return chunk;
   }
 
   /// Returns `true` if [comment] appears to be a magic generic method comment.
@@ -789,18 +803,15 @@ class ChunkBuilder {
   /// *   The comment is a block comment immediately following a grouping
   ///     character (`(`, `[`, or `{`). This is to allow `foo(/* comment */)`,
   ///     et. al.
-  bool _needsSpaceBeforeComment(SourceComment comment) {
-    // Not at the start of the file.
-    if (_chunks.isEmpty) return false;
-
-    // Not at the start of a line.
-    if (!_chunks.last.canAddText) return false;
+  bool _needsSpaceBeforeComment(SourceComment comment, Chunk chunk) {
+    // Not at the beginning of a line.
+    var text = chunk.text;
+    if (text.isEmpty) return false;
 
     // Always put a space before line comments.
     if (comment.type == CommentType.line) return true;
 
     // Magic generic method comments like "Foo/*<T>*/" don't get spaces.
-    var text = _chunks.last.text;
     if (_isGenericMethodComment(comment) &&
         _trailingIdentifierChar.hasMatch(text)) {
       return false;
@@ -812,15 +823,14 @@ class ChunkBuilder {
 
   /// Returns `true` if a space should be output after the last comment which
   /// was just written and the token that will be written.
-  bool _needsSpaceAfterLastComment(List<SourceComment> comments, String token) {
-    // Not if there are no comments.
-    if (comments.isEmpty) return false;
-
+  bool _needsSpaceAfterComment(SourceComment comment, String token) {
     // Not at the beginning of a line.
-    if (!_chunks.last.canAddText) return false;
+    if (_chunks.last.text.isEmpty) return false;
+
+    if (_pendingWhitespace != Whitespace.none) return false;
 
     // Magic generic method comments like "Foo/*<T>*/" don't get spaces.
-    if (_isGenericMethodComment(comments.last) && token == '(') {
+    if (_isGenericMethodComment(comment) && token == '(') {
       return false;
     }
 
@@ -834,63 +844,103 @@ class ChunkBuilder {
         token != '';
   }
 
-  /// Appends a hard split with the current indentation and nesting (the latter
-  /// only if [nest] is `true`).
-  ///
-  /// If [double] is `true` or `false`, forces a single or double line to be
-  /// output. Otherwise, it is left indeterminate.
-  ///
-  /// If [flushLeft] is `true`, then the split will always cause the next line
-  /// to be at column zero. Otherwise, it uses the normal indentation and
-  /// nesting behavior.
-  void _writeHardSplit({bool? isDouble, bool? flushLeft, bool nest = false}) {
-    // A hard split overrides any other whitespace.
-    _pendingWhitespace = Whitespace.afterHardSplit;
-    _writeSplit(Rule.hard(),
-        flushLeft: flushLeft, isDouble: isDouble, nest: nest);
+  bool _needsBlankLineBeforeComment(SourceComment comment) {
+    // Only if the source code has a blank line.
+    if (comment.linesBefore < 2) return false;
+
+    // Don't allow blank lines at the beginning of a block.
+    if (_chunks.isEmpty) return false;
+
+    // Don't allow blank lines at the beginning of a child block.
+    var text = _chunks.last.text;
+    if (text.endsWith('{') || text.endsWith('[')) return false;
+
+    return true;
   }
 
-  /// Ends the current chunk (if any) with the given split information.
+  /// Starts a new chunk with the given split information.
   ///
   /// Returns the chunk.
-  Chunk _writeSplit(Rule rule,
-      {bool? flushLeft, bool? isDouble, bool? nest, bool? space}) {
-    nest ??= true;
-    space ??= false;
+  Chunk _writeSplit(
+      {bool isHard = true,
+      bool isDouble = false,
+      required bool nest,
+      bool space = false,
+      bool mergeEmptySplits = true}) {
+    Chunk chunk;
+    // If we've already just created a split (i.e. we have a new chunk but it's
+    // still empty) then update that split with the new information. This avoids
+    // duplicate splits when line comments occur in places where SourceVisitor
+    // also inserts splits.
+    if (mergeEmptySplits && _chunks.isNotEmpty && _chunks.last.text.isEmpty) {
+      chunk = _chunks.last;
 
-    if (_chunks.isEmpty) {
-      if (flushLeft != null) _firstFlushLeft = flushLeft;
-      return Chunk.dummy();
+      // Don't allow a blank newline at the top of a block.
+      if (isDouble) {
+        if (_chunks.length > 1 &&
+            _chunks[_chunks.length - 2].text.endsWith('{')) {
+          isDouble = false;
+        }
+      }
+
+      // Must split before it so that there is a newline after the line comment.
+      chunk.rule.harden();
+
+      chunk.updateSplit(flushLeft: _pendingFlushLeft, isDouble: isDouble);
+    } else {
+      chunk = _startChunk(nest ? _nesting.nesting : NestingLevel(),
+          isHard: isHard, isDouble: isDouble, space: space);
     }
 
-    _chunks.last.applySplit(
-        rule, _nesting.indentation, nest ? _nesting.nesting : NestingLevel(),
-        flushLeft: flushLeft, isDouble: isDouble, space: space);
+    _pendingWhitespace = Whitespace.none;
+    _pendingNested = false;
 
-    if (_chunks.last.rule!.isHardened) _handleHardSplit();
-    return _chunks.last;
+    if (chunk.rule.isHardened) _handleHardSplit();
+    return chunk;
   }
 
   /// Writes [text] to either the current chunk or a new one if the current
   /// chunk is complete.
-  void _writeText(String text) {
-    if (_chunks.isNotEmpty && _chunks.last.canAddText) {
-      _chunks.last.appendText(text);
-    } else {
-      _chunks.add(Chunk(text));
+  void _writeText(String text, [Chunk? chunk]) {
+    if (chunk == null) {
+      if (_chunks.isEmpty) {
+        _startChunk(NestingLevel(), isHard: true);
+      }
+
+      chunk = _chunks.last;
     }
+
+    if (_pendingSpace && chunk.text.isNotEmpty) chunk.appendText(' ');
+    _pendingSpace = false;
+
+    chunk.appendText(text);
+  }
+
+  Chunk _startChunk(NestingLevel nesting,
+      {required bool isHard, bool isDouble = false, bool space = false}) {
+    var rule = isHard ? Rule.hard() : _rules.last;
+
+    var chunk = Chunk(rule, _nesting.indentation, nesting,
+        space: space, flushLeft: _pendingFlushLeft, isDouble: isDouble);
+    _chunks.add(chunk);
+
+    _pendingFlushLeft = false;
+    return chunk;
   }
 
   /// Returns true if we can divide the chunks at [index] and line split the
   /// ones before and after that separately.
   bool _canDivideAt(int i) {
-    // Don't divide after the last chunk.
-    if (i == _chunks.length - 1) return false;
+    // Don't divide at the first chunk.
+    if (i == 0) return false;
 
     var chunk = _chunks[i];
-    if (!chunk.rule!.isHardened) return false;
-    if (chunk.nesting!.isNested) return false;
-    if (chunk.isBlock) return false;
+    if (!chunk.rule.isHardened) return false;
+    if (chunk.nesting.isNested) return false;
+
+    // If the previous chunk is a block, then this chunk determines whether the
+    // block contents split, so don't separate it from the block.
+    if (i > 0 && _chunks[i - 1].isBlock) return false;
 
     return true;
   }
@@ -954,7 +1004,7 @@ class ChunkBuilder {
     // Discard spans in hardened chunks since we know for certain they will
     // split anyway.
     for (var chunk in _chunks) {
-      if (chunk.rule != null && chunk.rule!.isHardened) {
+      if (chunk.rule.isHardened) {
         chunk.spans.clear();
       }
     }

--- a/lib/src/line_splitting/line_splitter.dart
+++ b/lib/src/line_splitting/line_splitter.dart
@@ -61,7 +61,7 @@ const _maxAttempts = 5000;
 /// We start off with a [SolveState] where all rules are unbound (which
 /// implicitly treats them as unsplit). For a given solve state, we can produce
 /// a set of expanded states that takes some of the rules in the first long
-/// line and bind them to split values. This always produces new solve states
+/// line and binds them to split values. This always produces new solve states
 /// with higher cost (but often fewer overflow characters) than the parent
 /// state.
 ///
@@ -108,9 +108,6 @@ class LineSplitter {
   /// column based on where the block appears.
   final int blockIndentation;
 
-  /// The starting column of the first line.
-  final int firstLineIndent;
-
   /// The queue of solve states to explore further.
   ///
   /// This is sorted lowest-cost first. This ensures that as soon as we find a
@@ -120,16 +117,13 @@ class LineSplitter {
 
   /// Creates a new splitter for [_writer] that tries to fit [chunks] into the
   /// page width.
-  LineSplitter(
-      this.writer, this.chunks, this.blockIndentation, int firstLineIndent,
-      {bool flushLeft = false})
+  LineSplitter(this.writer, this.chunks, this.blockIndentation)
       : // Collect the set of rules that we need to select values for.
         rules = chunks
             .map((chunk) => chunk.rule)
             .whereType<Rule>()
             .toSet()
-            .toList(growable: false),
-        firstLineIndent = flushLeft ? 0 : firstLineIndent + blockIndentation {
+            .toList(growable: false) {
     _queue.bindSplitter(this);
 
     // Store the rule's index in the rule so we can get from a chunk to a rule
@@ -150,9 +144,6 @@ class LineSplitter {
   ///
   /// Returns a [SplitSet] that defines where each split occurs and the
   /// indentation of each line.
-  ///
-  /// [firstLineIndent] is the number of characters of whitespace to prefix the
-  /// first line of output with.
   SplitSet apply() {
     // Start with a completely unbound, unsplit solution.
     _queue.add(SolveState(this, RuleSet(rules.length)));
@@ -174,7 +165,7 @@ class LineSplitter {
       if (debug.traceSplitter) {
         var best = state == bestSolution ? ' (best)' : '';
         debug.log('$state$best');
-        debug.dumpLines(chunks, firstLineIndent, state.splits);
+        debug.dumpLines(chunks, state.splits);
         debug.log();
       }
 
@@ -186,7 +177,7 @@ class LineSplitter {
 
     if (debug.traceSplitter) {
       debug.log('$bestSolution (winner)');
-      debug.dumpLines(chunks, firstLineIndent, bestSolution!.splits);
+      debug.dumpLines(chunks, bestSolution!.splits);
       debug.log();
     }
 

--- a/lib/src/line_splitting/rule_set.dart
+++ b/lib/src/line_splitting/rule_set.dart
@@ -134,9 +134,9 @@ class SplitSet {
   late final int _cost;
 
   /// Creates a new empty split set for a line with [numChunks].
-  SplitSet(int numChunks) : _columns = List.filled(numChunks - 1, -1);
+  SplitSet(int numChunks) : _columns = List.filled(numChunks, -1);
 
-  /// Marks the line after chunk [index] as starting at [column].
+  /// Marks the chunk at [index] as starting at [column].
   void add(int index, int column) {
     _columns[index] = column;
   }

--- a/lib/src/rule/rule.dart
+++ b/lib/src/rule/rule.dart
@@ -8,6 +8,9 @@ import '../fast_hash.dart';
 /// A constraint that determines the different ways a related set of chunks may
 /// be split.
 class Rule extends FastHash {
+  /// The rule used for dummy chunks.
+  static final Rule dummy = Rule.hard();
+
   /// Rule value that splits no chunks.
   ///
   /// Every rule is required to treat this value as fully unsplit.

--- a/lib/src/whitespace.dart
+++ b/lib/src/whitespace.dart
@@ -28,21 +28,8 @@ class Whitespace {
   /// No whitespace.
   static const none = Whitespace._('none');
 
-  /// A single non-breaking space.
-  static const space = Whitespace._('space');
-
   /// A single newline.
   static const newline = Whitespace._('newline');
-
-  /// A single newline that takes into account the current expression nesting
-  /// for the next line.
-  static const nestedNewline = Whitespace._('nestedNewline');
-
-  /// A single newline with all indentation eliminated at the beginning of the
-  /// next line.
-  ///
-  /// Used for subsequent lines in a multiline string.
-  static const newlineFlushLeft = Whitespace._('newlineFlushLeft');
 
   /// Two newlines, a single blank line of separation.
   static const twoNewlines = Whitespace._('twoNewlines');
@@ -71,18 +58,12 @@ class Whitespace {
   /// less prescriptive over the user's whitespace.
   static const oneOrTwoNewlines = Whitespace._('oneOrTwoNewlines');
 
-  /// A hard split was just written whose whitespace takes precedence over any
-  /// previous pending whitespace.
-  static const afterHardSplit = Whitespace._('afterHardSplit');
-
   final String name;
 
   /// Gets the minimum number of newlines contained in this whitespace.
   int get minimumLines {
     switch (this) {
       case Whitespace.newline:
-      case Whitespace.nestedNewline:
-      case Whitespace.newlineFlushLeft:
       case Whitespace.oneOrTwoNewlines:
         return 1;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.2.2
+version: 2.2.3-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/comments/classes.unit
+++ b/test/comments/classes.unit
@@ -142,6 +142,18 @@ class Foo {
 // flush
   }
 }
+>>> flush left after member
+class Foo {
+  var x = 1;
+// comment
+  var y = 2;
+}
+<<<
+class Foo {
+  var x = 1;
+// comment
+  var y = 2;
+}
 >>> force doc comment between classes to have two newlines before
 class Foo {} /**
 */
@@ -162,3 +174,12 @@ class Foo {}
 /**
 */
 class Bar {}
+>>> inline before type parameter
+class Foo</* comment */T> {}
+<<<
+class Foo< /* comment */ T> {}
+>>> TODO(rnystrom): Ideally, would split before the comment, not after.
+class Foo< /* comment */TypeParameter> {}
+<<<
+class Foo< /* comment */
+    TypeParameter> {}

--- a/test/comments/enums.unit
+++ b/test/comments/enums.unit
@@ -73,3 +73,13 @@ enum Foo {
   /// doc
   void y() {}
 }
+>>> line comment after last
+enum Foo {
+  a,
+  b // comment
+}
+<<<
+enum Foo {
+  a,
+  b // comment
+}

--- a/test/comments/expressions.stmt
+++ b/test/comments/expressions.stmt
@@ -95,3 +95,9 @@ function(
     argument,
     named: argument,
     another: argument);
+>>> block comment with newline before
+someVeryLongFunctionName(argumentName: true
+/* comment */);
+<<<
+someVeryLongFunctionName(
+    argumentName: true /* comment */);

--- a/test/comments/functions.unit
+++ b/test/comments/functions.unit
@@ -176,3 +176,51 @@ function(/* comment */ int a, int b,
     int c, int d) {
   ;
 }
+>>> blank line before comment at beginning of optional parameters
+function([
+
+  // comment
+  a]) {;}
+<<<
+function(
+    [
+    // comment
+    a]) {
+  ;
+}
+>>> blank line before comment at beginning of named parameters
+function({
+
+  // comment
+  a}) {;}
+<<<
+function(
+    {
+    // comment
+    a}) {
+  ;
+}
+>>> blank line before comment at beginning of trailing comma optional parameters
+function([
+
+  // comment
+  a,]) {;}
+<<<
+function([
+  // comment
+  a,
+]) {
+  ;
+}
+>>> blank line before comment at beginning of trailing comma named parameters
+function({
+
+  // comment
+  a,}) {;}
+<<<
+function({
+  // comment
+  a,
+}) {
+  ;
+}

--- a/test/comments/statements.stmt
+++ b/test/comments/statements.stmt
@@ -84,3 +84,40 @@ main() {
 main() {
   while (b) /*unreachable*/ {}
 }
+>>> blank lines before comments in switch
+main() {
+  switch (n) {
+
+
+    // comment
+    case 0:
+
+
+
+    // comment
+
+
+
+    case 1:
+      ;
+
+
+    // comment
+
+
+  }
+}
+<<<
+main() {
+  switch (n) {
+    // comment
+    case 0:
+
+    // comment
+
+    case 1:
+      ;
+
+    // comment
+  }
+}

--- a/test/fixes/function_typedefs.unit
+++ b/test/fixes/function_typedefs.unit
@@ -227,7 +227,8 @@ typedef/*0*/void/*1*/Foo/*2*/<T>/*3*/(/*4*/T/*5*/foo(/*6*/x));
 typedef /*1*/ Foo /*2*/ <T>
     = /*0*/ void Function /*3*/ (
         /*4*/ T Function(
-            /*6*/ dynamic x) /*5*/ foo);
+                /*6*/ dynamic x) /*5*/
+            foo);
 >>> eol comments in typedef
 typedef//0
 void//1

--- a/test/fixes/optional_new.stmt
+++ b/test/fixes/optional_new.stmt
@@ -39,6 +39,14 @@ A();
 // a
 // b
 A();
+>>>
+var x = // 1
+new // 2
+Foo();
+<<<
+var x = // 1
+    // 2
+    Foo();
 >>> merge surrounding comments
 {
   /* a */ new /* b */ A();

--- a/test/regression/other/chunk_refactor.unit
+++ b/test/regression/other/chunk_refactor.unit
@@ -1,0 +1,380 @@
+>>> preserve flush left comment
+class TestName {
+  static const String realtimePresenceSubscribe = 'realtimePresenceSubscribe';
+// TODO(tiholic) handle realtimeHistoryWithAuthCallback
+
+  // This is not a test, but a way to retrieve
+  // more information of failures from any of the tests cases
+  static const String getFlutterErrors = 'getFlutterErrors';
+}
+<<<
+class TestName {
+  static const String realtimePresenceSubscribe = 'realtimePresenceSubscribe';
+// TODO(tiholic) handle realtimeHistoryWithAuthCallback
+
+  // This is not a test, but a way to retrieve
+  // more information of failures from any of the tests cases
+  static const String getFlutterErrors = 'getFlutterErrors';
+}
+>>> preserve flush left comment
+class BusStationResult {
+  BusStationResult.ios(BusStationResult_iOS result) {
+    pageCount = result.count;
+//    searchSuggestionCities = result.suggestion.cities?.map((city) {
+//      return SuggestionCity(
+//        cityName: city.city,
+//        cityCode: city.citycode,
+//        adCode: city.adcode,
+//        suggestionNum: city.num,
+//        districts: city.districts?.map((district) {
+//          return District(
+//
+//          );
+//        });
+//      );
+//    });
+    searchSuggestionKeywords = result.suggestion.keywords;
+  }
+}
+<<<
+class BusStationResult {
+  BusStationResult.ios(BusStationResult_iOS result) {
+    pageCount = result.count;
+//    searchSuggestionCities = result.suggestion.cities?.map((city) {
+//      return SuggestionCity(
+//        cityName: city.city,
+//        cityCode: city.citycode,
+//        adCode: city.adcode,
+//        suggestionNum: city.num,
+//        districts: city.districts?.map((district) {
+//          return District(
+//
+//          );
+//        });
+//      );
+//    });
+    searchSuggestionKeywords = result.suggestion.keywords;
+  }
+}
+>>> preserve flush left comment
+class Semester {
+  String get code => '$year$value';
+
+//  String get cacheSaveTag => '${Helper.username}_$code';
+
+  Semester({
+    this.year,
+    this.value,
+    this.text,
+  });
+}
+<<<
+class Semester {
+  String get code => '$year$value';
+
+//  String get cacheSaveTag => '${Helper.username}_$code';
+
+  Semester({
+    this.year,
+    this.value,
+    this.text,
+  });
+}
+>>> space before inline block comment
+class _MyAppState extends State<MyApp> {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SafeArea(
+          child: SingleChildScrollView(
+            child: Padding(
+              child: Column(
+                children: <Widget>[
+                  _assetsAudioPlayer.builderCurrent(
+                      builder: (context, Playing? playing) {
+                    return Column(
+                      children: <Widget>[
+                        _assetsAudioPlayer.builderLoopMode(
+                          builder: (context, loopMode) {
+                            return PlayerBuilder.isPlaying(
+                                builder: (context, isPlaying) {
+                                  return PlayingControls(
+                                    onNext: () {
+                                      _assetsAudioPlayer.next(keepLoopMode: true
+                                          /*keepLoopMode: false*/);
+                                    },
+                                    onPrevious: () {
+                                      _assetsAudioPlayer.previous(
+                                          /*keepLoopMode: false*/);
+                                    },
+                                  );
+                                });
+                          },
+                        ),
+                      ],
+                    );
+                  }),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+<<<
+class _MyAppState extends State<MyApp> {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SafeArea(
+          child: SingleChildScrollView(
+            child: Padding(
+              child: Column(
+                children: <Widget>[
+                  _assetsAudioPlayer.builderCurrent(
+                      builder: (context, Playing? playing) {
+                    return Column(
+                      children: <Widget>[
+                        _assetsAudioPlayer.builderLoopMode(
+                          builder: (context, loopMode) {
+                            return PlayerBuilder.isPlaying(
+                                builder: (context, isPlaying) {
+                              return PlayingControls(
+                                onNext: () {
+                                  _assetsAudioPlayer.next(
+                                      keepLoopMode:
+                                          true /*keepLoopMode: false*/);
+                                },
+                                onPrevious: () {
+                                  _assetsAudioPlayer.previous(
+                                      /*keepLoopMode: false*/);
+                                },
+                              );
+                            });
+                          },
+                        ),
+                      ],
+                    );
+                  }),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+>>> remove blank line before comment before first case
+class Sizing {
+  double heightOf({weight: sizingWeight}) {
+    switch (weight) {
+
+      //MINIMUM HEIGHT OF ITEM - 5%
+      case sizingWeight.w0:
+        screenWeightedHeight = logicalHeight() * 0.05;
+        break;
+
+      //10% of screen height
+      case sizingWeight.w1:
+        screenWeightedHeight = logicalHeight() * 0.1;
+        break;
+
+      //20% of screen height
+      case sizingWeight.w2:
+        screenWeightedHeight = logicalHeight() * 0.2;
+        break;
+
+      //30% of screen height
+      case sizingWeight.w3:
+        screenWeightedHeight = logicalHeight() * 0.3;
+        break;
+    }
+  }
+}
+<<<
+class Sizing {
+  double heightOf({weight: sizingWeight}) {
+    switch (weight) {
+      //MINIMUM HEIGHT OF ITEM - 5%
+      case sizingWeight.w0:
+        screenWeightedHeight = logicalHeight() * 0.05;
+        break;
+
+      //10% of screen height
+      case sizingWeight.w1:
+        screenWeightedHeight = logicalHeight() * 0.1;
+        break;
+
+      //20% of screen height
+      case sizingWeight.w2:
+        screenWeightedHeight = logicalHeight() * 0.2;
+        break;
+
+      //30% of screen height
+      case sizingWeight.w3:
+        screenWeightedHeight = logicalHeight() * 0.3;
+        break;
+    }
+  }
+}
+>>>
+class CloudWatchLogStack {
+  void fixMessage(List<int> bytes, int time, String msg) {
+    switch (largeMessageBehavior) {
+
+      /// Truncate message by replacing middle with "..."
+      case CloudWatchLargeMessages.truncate:
+        addToStack(time, truncate(bytes));
+        return;
+
+      /// Split up large message into multiple smaller ones
+      case CloudWatchLargeMessages.split:
+        split(bytes).forEach((splitMessage) {
+          addToStack(time, splitMessage);
+        });
+        return;
+    }
+  }
+}
+<<<
+class CloudWatchLogStack {
+  void fixMessage(List<int> bytes, int time, String msg) {
+    switch (largeMessageBehavior) {
+      /// Truncate message by replacing middle with "..."
+      case CloudWatchLargeMessages.truncate:
+        addToStack(time, truncate(bytes));
+        return;
+
+      /// Split up large message into multiple smaller ones
+      case CloudWatchLargeMessages.split:
+        split(bytes).forEach((splitMessage) {
+          addToStack(time, splitMessage);
+        });
+        return;
+    }
+  }
+}
+>>> don't split empty class body
+class _BeagleImageDownloaderMock extends Mock implements BeagleImageDownloader {}
+<<<
+class _BeagleImageDownloaderMock extends Mock
+    implements BeagleImageDownloader {}
+>>> don't split empty class body
+abstract class ParentRepoExternal extends CRUDRepositoryExternal<ParentEntity> {
+}
+<<<
+abstract class ParentRepoExternal
+    extends CRUDRepositoryExternal<ParentEntity> {}
+>>> adjacent strings inside string interpolation
+class _ImageNetworkState extends State<ImageNetwork> {
+  String _imagePage() {
+    return """<!DOCTYPE html>
+            <html>
+              <head>
+                <style  type="text/css" rel="stylesheet">
+                  body {
+                    margin: 0px;
+                    height: 100%;
+                    width: 100%;
+                    overflow: hidden;
+                   }
+                    #myImg {
+                      cursor: ${pointer ? "pointer" : ""};
+                      transition: 0.3s;
+                      width: ${fullScreen ? "100%" : "$width" "px"};
+                      height: ${fullScreen ? "100%" : "$height" "px"};
+                      object-fit: ${fitWeb.name(fitWeb as Fit)};
+                    }
+                    #myImg:hover {opacity: ${pointer ? "0.7" : ""}};}
+                </style>
+                <meta charset="utf-8"
+                <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0">
+                <meta http-equiv="Content-Security-Policy"
+                content="default-src * gap:; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src *;
+                img-src * data: blob: android-webview-video-poster:; style-src * 'unsafe-inline';">
+             </head>
+             <body>
+                <img id="myImg" src="$image" frameborder="0" allow="fullscreen"  allowfullscreen onclick= onClick() onerror= onError(this)>
+                <script>
+                  window.onload = function onLoad(){ callbackLoad(true);}
+                </script>
+             </body>
+            <script>
+                function onClick() { callback() }
+                function onError(source) {
+                  source.src = "https://scaffoldtecnologia.com.br/wp-content/uploads/2021/12/transparente.png";
+                  source.onerror = "";
+                  callbackError(true);
+                  return true;
+                 }
+            </script>
+        </html>
+    """;
+  }
+}
+<<<
+class _ImageNetworkState extends State<ImageNetwork> {
+  String _imagePage() {
+    return """<!DOCTYPE html>
+            <html>
+              <head>
+                <style  type="text/css" rel="stylesheet">
+                  body {
+                    margin: 0px;
+                    height: 100%;
+                    width: 100%;
+                    overflow: hidden;
+                   }
+                    #myImg {
+                      cursor: ${pointer ? "pointer" : ""};
+                      transition: 0.3s;
+                      width: ${fullScreen ? "100%" : "$width" "px"};
+                      height: ${fullScreen ? "100%" : "$height" "px"};
+                      object-fit: ${fitWeb.name(fitWeb as Fit)};
+                    }
+                    #myImg:hover {opacity: ${pointer ? "0.7" : ""}};}
+                </style>
+                <meta charset="utf-8"
+                <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0">
+                <meta http-equiv="Content-Security-Policy"
+                content="default-src * gap:; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src *;
+                img-src * data: blob: android-webview-video-poster:; style-src * 'unsafe-inline';">
+             </head>
+             <body>
+                <img id="myImg" src="$image" frameborder="0" allow="fullscreen"  allowfullscreen onclick= onClick() onerror= onError(this)>
+                <script>
+                  window.onload = function onLoad(){ callbackLoad(true);}
+                </script>
+             </body>
+            <script>
+                function onClick() { callback() }
+                function onError(source) {
+                  source.src = "https://scaffoldtecnologia.com.br/wp-content/uploads/2021/12/transparente.png";
+                  source.onerror = "";
+                  callbackError(true);
+                  return true;
+                 }
+            </script>
+        </html>
+    """;
+  }
+}
+>>>
+class _Action< /*JsonSerializable*/ T> {}
+<<<
+class _Action< /*JsonSerializable*/ T> {}
+>>>
+enum RenovationBackend {
+  frappe,
+  firebase // To be implemented
+}
+<<<
+enum RenovationBackend {
+  frappe,
+  firebase // To be implemented
+}

--- a/test/splitting/classes.unit
+++ b/test/splitting/classes.unit
@@ -129,3 +129,8 @@ class SomeVeryLongClass extends A with Mixin implements Interface {}
 class SomeVeryLongClass extends A
     with Mixin
     implements Interface {}
+>>> don't split empty body
+class TooLongClassName extends Another {}
+<<<
+class TooLongClassName
+    extends Another {}

--- a/test/splitting/list_arguments.stmt
+++ b/test/splitting/list_arguments.stmt
@@ -455,7 +455,8 @@ function(
 function(argument, // comment
 [[element]]);
 <<<
-function(argument, // comment
+function(
+    argument, // comment
     [
       [element]
     ]);

--- a/test/whitespace/adjacent_strings.stmt
+++ b/test/whitespace/adjacent_strings.stmt
@@ -256,3 +256,7 @@ function(
       "string"
       "more",
 );
+>>> inside interpolation
+var x = '${"a" "b"}';
+<<<
+var x = '${"a" "b"}';

--- a/test/whitespace/strings.stmt
+++ b/test/whitespace/strings.stmt
@@ -7,3 +7,29 @@
 """""" '''''';
 <<<
 """""" '''''';
+>>> blank lines in multi-line string
+'''
+
+
+two before
+
+one
+
+
+two
+
+
+''';
+<<<
+'''
+
+
+two before
+
+one
+
+
+two
+
+
+''';


### PR DESCRIPTION
The internal representation that the formatter users is a series of
chunks of code that can't contain any internal line breaks separated by
information describing the split between each one:

        .----. .-----. .----. .-----. .----. .-----.
    ... |text| |split| |text| |split| |text| |split| ...
        '----' '-----' '----' '-----' '----' '-----'

To have a homogeneous list of objects, each text/split pair is wrapped
into a single Chunk class. For historical reasons, they were paired up
so that each  Chunk has the text and the split that follows it:

        .--------------. .--------------. .--------------.
        |    Chunk     | |    Chunk     | |    Chunk     |
        |.----. .-----.| |.----. .-----.| |.----. .-----.|
    ... ||text| |split|| ||text| |split|| ||text| |split|| ...
        |'----' '-----'| |'----' '-----'| |'----' '-----'|
        '--------------' '--------------' '--------------'

When all we had was a flat list of chunks, this mostly didn't matter.
However, in order to improve the performance of line-splitting large
expressions containing nested function expressions and collection
literals, I moved to a more tree-like representation where some Chunks
contain a list of child Chunks.

This made having each Chunk terminate with a split more annoying to work
with because now the first child Chunk doesn't actually contain the
information to describe where it begins on its own line.

In order to be able to format child blocks independently and cache them,
it makes more sense if each Chunk describes an independent line: the
leading indentation followed by the text.

        .--------------. .--------------. .--------------.
        |    Chunk     | |    Chunk     | |    Chunk     |
        |.-----. .----.| |.-----. .----.| |.-----. .----.|
    ... ||split| |text|| ||split| |text|| ||split| |text|| ...
        |'-----' '----'| |'-----' '----'| |'-----' '----'|
        '--------------' '--------------' '--------------'

I have tried this refactoring several times in the past, but it causes
an unbelievable amount of off-by-one errors and other problems. I
finally pushed through and got everything working again.

This change doesn't actually simplify the codebase very much right now.
My goal was to get the Chunk representation changed with as little
changes to the rest of the formatter as possible. My hope is that this
will enable future refactoring and simplifications.

The external behavior is almost completely unchanged. On a corpus of
2,000 Pub packages (10+MLOC), there were <100 differences compared to
the previous formatter behavior. All of those differences were actually
(very rare) bugs, which this refactoring incidentally fixes.