### PR TITLE
Simplify and unify how delimited bodies are handled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 2.2.4-dev
 
+* Unify how brace-delimited syntax is formatted. This is mostly an internal
+  refactoring, but slightly changes how a type body containing only an inline
+  block comment is formatted.
+
 * Refactor Chunk to store split before text instead of after. This mostly does
   not affect the visible behavior of the formatter, but a few edge cases are
   handled slightly differently. These are all bug fixes where the previous

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -22,6 +22,22 @@ extension AstNodeExtensions on AstNode {
   /// Whether there is a comma token immediately following this.
   bool get hasCommaAfter => commaAfter != null;
 
+  /// Whether this node is a statement or member with a braced body that isn't
+  /// empty.
+  ///
+  /// Used to determine if a blank line should be inserted after the node.
+  bool get hasNonEmptyBody {
+    AstNode? body;
+    var node = this;
+    if (node is MethodDeclaration) {
+      body = node.body;
+    } else if (node is FunctionDeclarationStatement) {
+      body = node.functionDeclaration.functionExpression.body;
+    }
+
+    return body is BlockFunctionBody && body.block.statements.isNotEmpty;
+  }
+
   bool get isControlFlowElement => this is IfElement || this is ForElement;
 
   /// Whether this is immediately contained within an anonymous

--- a/test/comments/classes.unit
+++ b/test/comments/classes.unit
@@ -33,7 +33,9 @@ class A {
 class A {
   /* comment */}
 <<<
-class A {/* comment */}
+class A {
+  /* comment */
+}
 >>> inline block comment
 class A {  /* comment */  }
 <<<

--- a/test/comments/extensions.unit
+++ b/test/comments/extensions.unit
@@ -33,7 +33,9 @@ extension A on B {
 extension A on B {
   /* comment */}
 <<<
-extension A on B {/* comment */}
+extension A on B {
+  /* comment */
+}
 >>> inline block comment
 extension A on B {  /* comment */  }
 <<<


### PR DESCRIPTION
For mostly historical reasons, SourceVisitor used to create a flat list
of Chunks for some brace-delimited bodies like block statements and
switch bodies while using nested BlockChunks for function expression
bodies.

This now uniformly uses nested blocks for all of them. The visible
behavior is mostly unchanged except in a rare corner case with type
bodies containing only inline block comments where the old formatter
would arbitrarily split in one case but not the other. Now its behavior
is more consistent.