### PR TITLE
Refactor how child chunks are stored.

### DIFF
--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -89,16 +89,6 @@ class Chunk extends Selection {
   ///             argument));
   final NestingLevel nesting;
 
-  /// If this chunk marks the beginning of a block, this contains the child
-  /// chunks and other data about that nested block.
-  ///
-  /// This should only be accessed when [isBlock] is `true`.
-  ChunkBlock get block => _block!;
-  ChunkBlock? _block;
-
-  /// Whether this chunk has a [block].
-  bool get isBlock => _block != null;
-
   /// The [Rule] that controls when a split should occur before this chunk.
   ///
   /// Multiple splits may share a [Rule].
@@ -136,16 +126,7 @@ class Chunk extends Selection {
   ///
   /// Does not include this chunk's own length, just the length of its child
   /// block chunks (recursively).
-  int get unsplitBlockLength {
-    if (!isBlock) return 0;
-
-    var length = 0;
-    for (var chunk in block.chunks) {
-      length += chunk.length + chunk.unsplitBlockLength;
-    }
-
-    return length;
-  }
+  int get unsplitBlockLength => 0;
 
   /// The [Span]s that contain this chunk.
   final spans = <Span>[];
@@ -189,29 +170,9 @@ class Chunk extends Selection {
     if (space != null) _spaceWhenUnsplit = space;
   }
 
-  /// Turns this chunk into one that can contain a block of child chunks.
-  void makeBlock(Chunk? blockArgument) {
-    assert(_block == null);
-    _block = ChunkBlock(blockArgument);
-  }
-
-  /// Returns `true` if the block body owned by this chunk should be expression
-  /// indented given a set of rule values provided by [getValue].
-  bool indentBlock(int Function(Rule) getValue) {
-    if (!isBlock) return false;
-
-    var argument = block.argument;
-    if (argument == null) return false;
-
-    var rule = argument.rule;
-
-    // There may be no rule if the block occurs inside a string interpolation.
-    // In that case, it's not clear if anything will look particularly nice, but
-    // expression nesting is probably marginally better.
-    if (rule == Rule.dummy) return true;
-
-    return rule.isSplit(getValue(rule), argument);
-  }
+  /// Returns `true` if this chunk is a block whose children should be
+  /// expression indented given a set of rule values provided by [getValue].
+  bool indentBlock(int Function(Rule) getValue) => false;
 
   // Mark whether this chunk can divide the range of chunks.
   void markDivide(bool canDivide) {
@@ -234,9 +195,33 @@ class Chunk extends Selection {
   }
 }
 
-/// The child chunks owned by a chunk that begins a "block" -- an actual block
-/// statement, function expression, or collection literal.
-class ChunkBlock {
+/// A [Chunk] containing a list of nested "child" chunks that are formatted
+/// independently of the surrounding chunks.
+///
+/// This is used for blocks, function expressions, collection literals, etc.
+/// Basically, anywhere we have a delimited body of code whose formatting
+/// doesn't depend on how the surrounding code is formatted except to determine
+/// indentation.
+///
+/// This chunk's own text is the closing delimiter of the block, so its
+/// children come before itself. For example, given this code:
+///
+///     main() {
+///       var list = [
+///         element,
+///       ];
+///     }
+///
+/// It is organized into a tree of chunks like so:
+///
+///    - Chunk           "main() {"
+///    - BlockChunk
+///      |- Chunk          "var list = ["
+///      |- BlockChunk
+///      |  |- Chunk         "element,"
+///      |  '- (text)      "];"
+///      '- (text)       "}"
+class BlockChunk extends Chunk {
   /// If this block is for a collection literal in an argument list, this will
   /// be the chunk preceding this literal argument.
   ///
@@ -245,9 +230,41 @@ class ChunkBlock {
   final Chunk? argument;
 
   /// The child chunks in this block.
-  final List<Chunk> chunks = [];
+  final List<Chunk> children = [];
 
-  ChunkBlock(this.argument);
+  BlockChunk(this.argument, super.rule, super.indent, super.nesting,
+      {required super.space, required super.flushLeft})
+      : super(isDouble: false);
+
+  /// The unsplit length of all of this chunk's block contents.
+  ///
+  /// Does not include this chunk's own length, just the length of its child
+  /// block chunks (recursively).
+  @override
+  int get unsplitBlockLength {
+    var length = 0;
+    for (var chunk in children) {
+      length += chunk.length + chunk.unsplitBlockLength;
+    }
+
+    return length;
+  }
+
+  /// Returns `true` if the block body owned by this chunk should be expression
+  /// indented given a set of rule values provided by [getValue].
+  @override
+  bool indentBlock(int Function(Rule) getValue) {
+    var argument = this.argument;
+    if (argument == null) return false;
+
+    // There may be no rule if the block occurs inside a string interpolation.
+    // In that case, it's not clear if anything will look particularly nice, but
+    // expression nesting is probably marginally better.
+    var rule = argument.rule;
+    if (rule == Rule.dummy) return true;
+
+    return rule.isSplit(getValue(rule), argument);
+  }
 }
 
 /// The in-progress state for a [Span] that has been started but has not yet

--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -172,6 +172,9 @@ class Chunk extends Selection {
 
   /// Returns `true` if this chunk is a block whose children should be
   /// expression indented given a set of rule values provided by [getValue].
+  ///
+  /// [getValue] takes a [Rule] and returns the chosen split state value for
+  /// that [Rule].
   bool indentBlock(int Function(Rule) getValue) => false;
 
   // Mark whether this chunk can divide the range of chunks.
@@ -250,8 +253,6 @@ class BlockChunk extends Chunk {
     return length;
   }
 
-  /// Returns `true` if the block body owned by this chunk should be expression
-  /// indented given a set of rule values provided by [getValue].
   @override
   bool indentBlock(int Function(Rule) getValue) {
     var argument = this.argument;

--- a/lib/src/line_splitting/solve_state.dart
+++ b/lib/src/line_splitting/solve_state.dart
@@ -297,7 +297,7 @@ class SolveState {
           // And any expression nesting.
           indent += chunk.nesting.totalUsedIndent;
 
-          if (i > 0 && _splitter.chunks[i - 1].indentBlock(getValue)) {
+          if (_splitter.chunks[i].indentBlock(getValue)) {
             indent += Indent.expression;
           }
         }
@@ -389,19 +389,18 @@ class SolveState {
         if (chunk.spaceWhenUnsplit) length++;
       }
 
-      length += chunk.text.length;
-
-      if (chunk.isBlock) {
-        if (_splits.shouldSplitAt(i + 1)) {
+      if (chunk is BlockChunk) {
+        if (_splits.shouldSplitAt(i)) {
           // Include the cost of the nested block.
-          cost += _splitter.writer
-              .formatBlock(chunk, _splits.getColumn(i + 1))
-              .cost;
+          cost +=
+              _splitter.writer.formatBlock(chunk, _splits.getColumn(i)).cost;
         } else {
           // Include the nested block inline, if any.
           length += chunk.unsplitBlockLength;
         }
       }
+
+      length += chunk.text.length;
     }
 
     // Add the costs for the rules that have any splits.

--- a/test/comments/classes.unit
+++ b/test/comments/classes.unit
@@ -107,12 +107,23 @@ class Foo {
   /// doc
   var b = 2;
 }
->>> remove blank line before beginning of body
+>>> remove blank lines before beginning of body
 class A {
 
 
 
   // comment
+}
+<<<
+class A {
+  // comment
+}
+>>> remove blank lines after end of body
+class A {
+  // comment
+
+
+
 }
 <<<
 class A {

--- a/test/comments/enums.unit
+++ b/test/comments/enums.unit
@@ -39,7 +39,7 @@ enum A {
 
   /* comment */
 }
->>> remove blank line before beginning of body
+>>> remove blank lines before beginning of body
 enum A {
 
 
@@ -51,6 +51,19 @@ enum A {
 enum A {
   // comment
   B
+}
+>>> remove blank lines after end of body
+enum A {
+  B
+  // comment
+
+
+
+}
+<<<
+enum A {
+  B
+  // comment
 }
 >>> ensure blank line above doc comments
 enum Foo {/// doc

--- a/test/comments/extensions.unit
+++ b/test/comments/extensions.unit
@@ -126,12 +126,23 @@ extension A on B {
   /// doc
   b() => 2;
 }
->>> remove blank line before beginning of body
+>>> remove blank lines before beginning of body
 extension A on B {
 
 
 
   // comment
+}
+<<<
+extension A on B {
+  // comment
+}
+>>> remove blank lines after end of body
+extension A on B {
+  // comment
+
+
+
 }
 <<<
 extension A on B {

--- a/test/comments/functions.unit
+++ b/test/comments/functions.unit
@@ -116,12 +116,23 @@ longFunction(/* a very long block comment */) {}
 <<<
 longFunction(
     /* a very long block comment */) {}
->>> remove blank line before beginning of body
+>>> remove blank lines before beginning of body
 main() {
 
 
 
   // comment
+}
+<<<
+main() {
+  // comment
+}
+>>> remove blank lines after end of body
+main() {
+  // comment
+
+
+
 }
 <<<
 main() {

--- a/test/comments/lists.stmt
+++ b/test/comments/lists.stmt
@@ -89,12 +89,23 @@ var list = [
 var list = [1,/* a */ 2 /* b */  , 3];
 <<<
 var list = [1, /* a */ 2 /* b */, 3];
->>> remove blank line before beginning of body
+>>> remove blank lines before beginning of body
 var list = [
 
 
 
   // comment
+];
+<<<
+var list = [
+  // comment
+];
+>>> remove blank lines after end of body
+var list = [
+  // comment
+
+
+
 ];
 <<<
 var list = [

--- a/test/comments/maps.stmt
+++ b/test/comments/maps.stmt
@@ -94,12 +94,23 @@ var map = {
   // comment
   'foo': 1
 };
->>> remove blank line before beginning of body
+>>> remove blank lines before beginning of body
 var map = {
 
 
 
   // comment
+};
+<<<
+var map = {
+  // comment
+};
+>>> remove blank lines after end of body
+var map = {
+  // comment
+
+
+
 };
 <<<
 var map = {

--- a/test/comments/sets.stmt
+++ b/test/comments/sets.stmt
@@ -107,3 +107,14 @@ var set = <int>{
 var set = <int>{
   // comment
 };
+>>> remove blank lines after end of body
+var set = <int>{
+  // comment
+
+
+
+};
+<<<
+var set = <int>{
+  // comment
+};

--- a/test/comments/statements.stmt
+++ b/test/comments/statements.stmt
@@ -44,12 +44,23 @@ do // comment
 /*
 */
 var i = value;
->>> remove blank line before beginning of block
+>>> remove blank lines before beginning of block
 while (true) {
 
 
 
   // comment
+}
+<<<
+while (true) {
+  // comment
+}
+>>> remove blank lines after end of block
+while (true) {
+  // comment
+
+
+
 }
 <<<
 while (true) {

--- a/test/whitespace/classes.unit
+++ b/test/whitespace/classes.unit
@@ -157,3 +157,16 @@ class Foo {
   abstract final int c;
   abstract int i;
 }
+>>> discard trailing newlines in body
+class Foo {
+  bar() {}
+
+
+
+
+
+}
+<<<
+class Foo {
+  bar() {}
+}

--- a/test/whitespace/enums.unit
+++ b/test/whitespace/enums.unit
@@ -280,3 +280,35 @@ enum E {
   c(123),
   ;
 }
+>>> discard trailing newlines in body
+enum E {
+  a,
+
+
+
+
+
+}
+<<<
+enum E {
+  a,
+}
+>>> discard trailing newlines in body
+enum E {
+  a;
+
+
+
+  bar() {}
+
+
+
+
+
+}
+<<<
+enum E {
+  a;
+
+  bar() {}
+}

--- a/test/whitespace/extensions.unit
+++ b/test/whitespace/extensions.unit
@@ -118,3 +118,16 @@ extension on B {}
 extension   <  T  ,  S  >    on   B{}
 <<<
 extension<T, S> on B {}
+>>> discard trailing newlines in body
+extension A on B {
+  bar() {}
+
+
+
+
+
+}
+<<<
+extension A on B {
+  bar() {}
+}

--- a/test/whitespace/methods.unit
+++ b/test/whitespace/methods.unit
@@ -57,3 +57,19 @@ class A {
 class A {
   A(covariant this.foo);
 }
+>>> discard trailing newlines in method body
+class Foo {
+  bar() {
+    baz();
+
+
+
+
+  }
+}
+<<<
+class Foo {
+  bar() {
+    baz();
+  }
+}


### PR DESCRIPTION
Given a piece of code like:

    main() {
      a();
      b();
    }

There are top level chunks for `main() }` and `}`, and the chunks for
`a()` and `b()` are children.

Previously, the code stored those child chunks in the preceding parent
chunk (so `main() {` here). But it's the subsequent chunk (`}`) that
determines whether the block contents are actually split, so that
doesn't make a lot of sense and leads to weird `+ 1` and `- 1` when
working with nested chunks.

This refactors the code so that child chunks are stored on the same
chunk that determines whether or not they split. This means that chunks
are now written in a post-order traversal: a block chunk's children come
before its own text.

Since we now know that a chunk will have children at the moment that
it's created, removed the old ChunkBlock class and replaced it with a
BlockChunk subclass of Chunk.

Also added a bunch of tests around trailing whitespace in blocks. When I
was testing this change on a corpus of code, I thought it inadvertently
changed some behavior, but it turns out that it was the previous
refactoring (which did deliberately change block formatting) and not
this one. These tests help pin that behavior down.

This commit here has zero changes on the formatter's visible behavior.