### PR TITLE
Add flutter tool cli flag

### DIFF
--- a/lib/src/cli/format_command.dart
+++ b/lib/src/cli/format_command.dart
@@ -122,9 +122,9 @@ class FormatCommand extends Command<int> {
     var followLinks = argResults['follow-links'];
     var setExitIfChanged = argResults['set-exit-if-changed'] as bool;
 
-    // If stdin isn't connected to a pipe, then the user is not passing
+    // If stdin isn't connected to a pipe (or invoked from the flutter-tool), then the user is not passing
     // anything to stdin, so let them know they made a mistake.
-    if (argResults.rest.isEmpty && stdin.hasTerminal) {
+    if (argResults.rest.isEmpty && (stdin.hasTerminal || argResults['flutter-tool-cli'] as bool)) {
       usageException('Missing paths to code to format.');
     }
 

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -75,6 +75,7 @@ void defineOptions(ArgParser parser,
 
   if (verbose) parser.addSeparator('Non-whitespace fixes (off by default):');
   parser.addFlag('fix', negatable: false, help: 'Apply all style fixes.');
+  parser.addFlag('flutter-tool-cli', negatable: false, help: 'Sent when used inside the flutter-tool.');
 
   for (var fix in StyleFix.all) {
     // TODO(rnystrom): Allow negating this if used in concert with "--fix"?

--- a/test/command_line_test.dart
+++ b/test/command_line_test.dart
@@ -65,6 +65,11 @@ void main() {
     await process.shouldExit(64);
   });
 
+  test('command line argument error from flutter tool', () async {
+    var process = await runFormatter(['--fix', '--flutter-tool-cli']);
+    await process.shouldExit(64);
+  });
+
   test('exits with 65 on a parse error', () async {
     await d.dir('code', [d.file('a.dart', 'herp derp i are a dart')]).create();
 


### PR DESCRIPTION
When `dart format --fix` is called inside the flutter tool it gets stuck because it waits on the stdin a work around is to add a flag to the command that tells it is invoked from the flutter tool. Let me know if this is reasonable. 
Flutter issue: https://github.com/flutter/flutter/issues/109553