### PR TITLE
Better grammar

### DIFF
--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -66,7 +66,7 @@ class UnexpectedOutputException implements Exception {
   String toString() {
     return '''The formatter produced unexpected output. Input was:
 $_input
-Which formatted to:
+Which was formatted to:
 $_output''';
   }
 }


### PR DESCRIPTION
I guess it is better to say `which was formatted to`, instead of `which formatted to`.