### PR TITLE
Require the latest version of pkg:lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,9 +3,4 @@ linter:
   rules:
     - avoid_dynamic_calls
     - directives_ordering
-    - prefer_equal_for_default_values
-    - prefer_generic_function_type_aliases
-    - slash_for_doc_comments
     - unawaited_futures
-    - unnecessary_const
-    - unnecessary_new

--- a/example/format.dart
+++ b/example/format.dart
@@ -100,12 +100,12 @@ void runTest(String path, int line) {
 
     var input = '';
     while (!lines[i].startsWith('<<<')) {
-      input += lines[i++] + '\n';
+      input += '${lines[i++]}\n';
     }
 
     var expectedOutput = '';
     while (++i < lines.length && !lines[i].startsWith('>>>')) {
-      expectedOutput += lines[i] + '\n';
+      expectedOutput += '${lines[i]}\n';
     }
 
     if (line != startLine) continue;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,7 +133,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   frontend_server_client:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   # TODO(rnystrom): Disabled for now because node_preamble is not migrated yet
   # and publishing to npm hasn't been used in a while.
   #  node_preamble: ^1.0.0
-  lints: ^1.0.0
+  lints: ^2.0.0
   test: ^1.16.8
   test_descriptor: ^2.0.0
   test_process: ^2.0.0

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -216,12 +216,12 @@ void _testFile(String name, String path, Iterable<StyleFix>? baseFixes) {
 
       var input = '';
       while (!lines[i].startsWith('<<<')) {
-        input += lines[i++] + '\n';
+        input += '${lines[i++]}\n';
       }
 
       var expectedOutput = '';
       while (++i < lines.length && !lines[i].startsWith('>>>')) {
-        expectedOutput += lines[i] + '\n';
+        expectedOutput += '${lines[i]}\n';
       }
 
       // Unescape special Unicode escape markers.


### PR DESCRIPTION
Fix new lints
Remove explicit lints that are added to lints v2
