### PR TITLE
Bump to analyzer 5.1.0 and handle deprecations

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [2.17.0, dev]
+        sdk: [2.18.0, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0
@@ -50,7 +50,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.17.0, dev]
+        sdk: [2.18.0, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.5-dev
+
+* Require `package:analyzer` `^5.1.0`.
+
 # 2.2.4
 
 * Unify how brace-delimited syntax is formatted. This is mostly an internal

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -11,7 +11,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '2.2.4';
+const dartStyleVersion = '2.2.5-dev';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 class FormatterOptions {

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -598,7 +598,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     modifier(node.abstractKeyword);
     token(node.classKeyword);
     space();
-    token(node.name2);
+    token(node.name);
     visit(node.typeParameters);
     visit(node.extendsClause);
     _visitClauses(node.withClause, node.implementsClause);
@@ -617,7 +617,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       modifier(node.abstractKeyword);
       token(node.typedefKeyword);
       space();
-      token(node.name2);
+      token(node.name);
       visit(node.typeParameters);
       space();
       token(node.equals);
@@ -764,7 +764,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     modifier(node.factoryKeyword);
     visit(node.returnType);
     token(node.period);
-    token(node.name2);
+    token(node.name);
 
     // Make the rule for the ":" span both the preceding parameter list and
     // the entire initialization list. This ensures that we split before the
@@ -981,7 +981,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   @override
   void visitEnumConstantDeclaration(EnumConstantDeclaration node) {
     visitMetadata(node.metadata);
-    token(node.name2);
+    token(node.name);
 
     var arguments = node.arguments;
     if (arguments != null) {
@@ -1006,7 +1006,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     builder.nestExpression();
     token(node.enumKeyword);
     space();
-    token(node.name2);
+    token(node.name);
     visit(node.typeParameters);
     _visitClauses(node.withClause, node.implementsClause);
     space();
@@ -1250,9 +1250,9 @@ class SourceVisitor extends ThrowingAstVisitor {
 
     // Don't put a space after `extension` if the extension is unnamed. That
     // way, generic unnamed extensions format like `extension<T> on ...`.
-    if (node.name2 != null) {
+    if (node.name != null) {
       space();
-      token(node.name2);
+      token(node.name);
     }
 
     visit(node.typeParameters);
@@ -1607,17 +1607,17 @@ class SourceVisitor extends ThrowingAstVisitor {
         // Inlined visitGenericTypeAlias
         _visitGenericTypeAliasHeader(
             node.typedefKeyword,
-            node.name2,
+            node.name,
             node.typeParameters,
             null,
-            node.returnType?.beginToken ?? node.name2);
+            node.returnType?.beginToken ?? node.name);
 
         space();
 
         // Recursively convert function-arguments to Function syntax.
         _insideNewTypedefFix = true;
         _visitGenericFunctionType(
-            node.returnType, null, node.name2, null, node.parameters);
+            node.returnType, null, node.name, null, node.parameters);
         _insideNewTypedefFix = false;
       });
       return;
@@ -1627,7 +1627,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       token(node.typedefKeyword);
       space();
       visit(node.returnType, after: space);
-      token(node.name2);
+      token(node.name);
       visit(node.typeParameters);
       visit(node.parameters);
     });
@@ -1669,7 +1669,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   void visitGenericTypeAlias(GenericTypeAlias node) {
     visitNodes(node.metadata, between: newline, after: newline);
     _simpleStatement(node, () {
-      _visitGenericTypeAliasHeader(node.typedefKeyword, node.name2,
+      _visitGenericTypeAliasHeader(node.typedefKeyword, node.name,
           node.typeParameters, node.equals, null);
 
       space();
@@ -2022,7 +2022,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     _simpleStatement(node, () {
       token(node.libraryKeyword);
       space();
-      visit(node.name);
+      visit(node.name2);
     });
   }
 
@@ -2121,7 +2121,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     builder.nestExpression();
     token(node.mixinKeyword);
     space();
-    token(node.name2);
+    token(node.name);
     visit(node.typeParameters);
 
     // If there is only a single superclass constraint, format it like an
@@ -2504,7 +2504,7 @@ class SourceVisitor extends ThrowingAstVisitor {
   @override
   void visitTypeParameter(TypeParameter node) {
     visitParameterMetadata(node.metadata, () {
-      token(node.name2);
+      token(node.name);
       token(node.extendsKeyword, before: space, after: space);
       visit(node.bound);
     });
@@ -2521,7 +2521,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   @override
   void visitVariableDeclaration(VariableDeclaration node) {
-    token(node.name2);
+    token(node.name);
     if (node.initializer == null) return;
 
     // If there are multiple variables being declared, we want to nest the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=4.4.0 <6.0.0'
+  analyzer: '^5.1.0'
   args: ">=1.0.0 <3.0.0"
   path: ^1.0.0
   pub_semver: ">=1.4.4 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.2.4
+version: 2.2.5-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
Since one of the deprecations is moving `.name2` _back_ to `.name`, I think it's necessary to bump the lower bound. In analyzer 4.4.0, `.name` may have meant a different thing...

In any case, analyzer 5.1.0 is the first release to allow unnamed libraries, so I think it is necessary for the follow up PR which adds such support in dart_style.