### PR TITLE
Hide the --line-length option

### DIFF
--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -85,7 +85,10 @@ void defineOptions(ArgParser parser,
   if (verbose) parser.addSeparator('Other options:');
 
   parser.addOption('line-length',
-      abbr: 'l', help: 'Wrap lines longer than this.', defaultsTo: '80');
+      abbr: 'l',
+      help: 'Wrap lines longer than this.',
+      defaultsTo: '80',
+      hide: true);
   parser.addOption('indent',
       abbr: 'i',
       help: 'Add this many spaces of leading indentation.',


### PR DESCRIPTION
Towards #1115

This is option is not intended to be user facing. It is not ergonomic, and it causes confusion in the current state. The option is not removed because it is used for tests, and we don't want to break scripts which are passing the option today.