### PR TITLE
Use typed _visitFunctionOrMethodDeclaration(), stop using 'name2'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Require `package:analyzer` `^5.1.0`.
 * Format unnamed libraries.
 * Require Dart 2.18.
+* Use typed `_visitFunctionOrMethodDeclaration` instead of dynamically typed.
 
 # 2.2.4
 


### PR DESCRIPTION
Using `dynamic` did not report using `name2`, so my attempt to pull `dart_style` into SDK and remove the deprecated methods failed. To prevent this in the future, I think it is better to use more types.