### PR TITLE
Fix a metadata test to not have whitespace before the "(".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 * Format unnamed libraries.
 * Require Dart 2.18.
 * Use typed `_visitFunctionOrMethodDeclaration` instead of dynamically typed.
+* Fix metadata test to not fail when record syntax makes whitespace between
+  metadata annotation names and `(` significant ([sdk#50769][]).
+
+[sdk#50769]: https://github.com/dart-lang/sdk/issues/50769
 
 # 2.2.4
 

--- a/test/whitespace/metadata.unit
+++ b/test/whitespace/metadata.unit
@@ -280,7 +280,7 @@ class A {
 @foo
 typedef Fn = Function();
 >>> metadata on non-function typedef
-@foo typedef Hash< @a  K, @b  (  1  )  V  >  =  Map < K ,  V >   ;
+@foo typedef Hash< @a  K, @b(  1  )  V  >  =  Map < K ,  V >   ;
 <<<
 @foo
 typedef Hash<@a K, @b(1) V> = Map<K, V>;


### PR DESCRIPTION
With records coming, we use whitespace there to disambiguate metadata annotation arguments from a subsequent record type annotation. There was a metadata formatting test whose before code had whitespace there and now will be interpreted differently (and erroneously) by the language. This fixes that test.

Note that there are no changes to the formatter itself. It's just a formatting test whose "before" code is a little too wild with the whitespace. :)

cc @jensjoha 