### PR TITLE
Format records and record type annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2.2.5-dev
 
+* Format record expressions and record type annotations.
+* Better indentation of multiline function types inside type argument lists. 
 * Require `package:analyzer` `^5.1.0`.
 * Format unnamed libraries.
 * Require Dart 2.18.

--- a/lib/src/argument_list_visitor.dart
+++ b/lib/src/argument_list_visitor.dart
@@ -453,13 +453,18 @@ class ArgumentSublist {
 
       // Tell it to use the rule we've already created.
       visitor.beforeBlock(argumentBlock, blockRule, previousSplit);
-    } else if (_allArguments.length > 1) {
+    } else if (_allArguments.length > 1 ||
+        _allArguments.first is RecordLiteral) {
       // Edge case: Only bump the nesting if there are multiple arguments. This
       // lets us avoid spurious indentation in cases like:
       //
       //     function(function(() {
       //       body;
       //     }));
+      //
+      // Do bump the nesting if the single argument is a record because records
+      // are formatted like regular values when they appear in argument lists
+      // even though they internally get block-like formatting.
       visitor.builder.startBlockArgumentNesting();
     } else if (argument is! NamedExpression) {
       // Edge case: Likewise, don't force the argument to split if there is
@@ -478,7 +483,8 @@ class ArgumentSublist {
 
     if (argumentBlock != null) {
       rule.enableSplitOnInnerRules();
-    } else if (_allArguments.length > 1) {
+    } else if (_allArguments.length > 1 ||
+        _allArguments.first is RecordLiteral) {
       visitor.builder.endBlockArgumentNesting();
     } else if (argument is! NamedExpression) {
       rule.enableSplitOnInnerRules();

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -100,8 +100,8 @@ extension ExpressionExtensions on Expression {
   ///     ]..addAll(numbers);
   bool get isCollectionLike {
     var expression = this;
-    if (expression is ListLiteral) return false;
-    if (expression is SetOrMapLiteral) return false;
+    if (expression is ListLiteral) return true;
+    if (expression is SetOrMapLiteral) return true;
 
     // If the target is a call with a trailing comma in the argument list,
     // treat it like a collection literal.
@@ -119,7 +119,7 @@ extension ExpressionExtensions on Expression {
     //       element
     //     ])..cascade();
 
-    return arguments == null || !arguments.arguments.hasCommaAfter;
+    return arguments != null && arguments.arguments.hasCommaAfter;
   }
 
   /// Whether this is an argument in an argument list with a trailing comma.

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -90,6 +90,7 @@ class DartFormatter {
     var featureSet = FeatureSet.fromEnableFlags2(
       sdkLanguageVersion: Version(2, 19, 0),
       flags: [
+        'records',
         'unnamed-libraries',
       ],
     );

--- a/lib/src/line_writer.dart
+++ b/lib/src/line_writer.dart
@@ -180,10 +180,11 @@ class LineWriter {
   void _writeChunksUnsplit(BlockChunk block) {
     for (var chunk in block.children) {
       if (chunk.spaceWhenUnsplit) _buffer.write(' ');
-      _writeChunk(chunk);
 
       // Recurse into the block.
       if (chunk is BlockChunk) _writeChunksUnsplit(chunk);
+
+      _writeChunk(chunk);
     }
   }
 

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -3127,9 +3127,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     // Unlike other collections, records don't force outer ones to split.
     if (node is! RecordLiteral) {
       // Force all of the surrounding collections to split.
-      for (var i = 0; i < _collectionSplits.length; i++) {
-        _collectionSplits[i] = true;
-      }
+      _collectionSplits.fillRange(0, _collectionSplits.length, true);
 
       // Add this collection to the stack.
       _collectionSplits.add(false);

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -451,7 +451,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     //     ]
     //       ..add(more);
     var splitIfOperandsSplit =
-        node.cascadeSections.length > 1 || node.target.isCollectionLike;
+        node.cascadeSections.length > 1 || !node.target.isCollectionLike;
     if (splitIfOperandsSplit) {
       builder.startLazyRule(node.allowInline ? Rule() : Rule.hard());
     }
@@ -1280,7 +1280,8 @@ class SourceVisitor extends ThrowingAstVisitor {
     visitParameterMetadata(node.metadata, () {
       _beginFormalParameter(node);
       token(node.keyword, after: space);
-      visit(node.type, after: split);
+      visit(node.type);
+      _separatorBetweenTypeAndVariable(node.type);
       token(node.thisKeyword);
       token(node.period);
       token(node.name);
@@ -1339,6 +1340,8 @@ class SourceVisitor extends ThrowingAstVisitor {
         rule.beforeArgument(zeroSplit());
       }
 
+      // Make sure record and function type parameter lists are indented.
+      builder.startBlockArgumentNesting();
       builder.startSpan();
 
       for (var param in requiredParams) {
@@ -1348,6 +1351,7 @@ class SourceVisitor extends ThrowingAstVisitor {
         if (param != requiredParams.last) rule.beforeArgument(split());
       }
 
+      builder.endBlockArgumentNesting();
       builder.endSpan();
       builder.endRule();
     }
@@ -1359,7 +1363,8 @@ class SourceVisitor extends ThrowingAstVisitor {
 
       builder.startRule(namedRule);
 
-      // Make sure multi-line default values are indented.
+      // Make sure multi-line default values, record types, and inner function
+      // types are indented.
       builder.startBlockArgumentNesting();
 
       namedRule.beforeArgument(builder.split(space: requiredParams.isNotEmpty));
@@ -2296,6 +2301,110 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
+  void visitRecordLiteral(RecordLiteral node) {
+    modifier(node.constKeyword);
+    _visitCollectionLiteral(
+        node, node.leftParenthesis, node.fields, node.rightParenthesis);
+  }
+
+  @override
+  void visitRecordTypeAnnotation(RecordTypeAnnotation node) {
+    var namedFields = node.namedFields;
+
+    // Handle empty record types specially.
+    if (node.positionalFields.isEmpty && namedFields == null) {
+      token(node.leftParenthesis);
+
+      // If there is a comment inside the parens, do allow splitting before it.
+      if (node.rightParenthesis.precedingComments != null) soloZeroSplit();
+
+      token(node.rightParenthesis);
+      return;
+    }
+
+    _metadataRules.add(Rule());
+    token(node.leftParenthesis);
+    builder.startRule();
+
+    // If all parameters are named, put the "{" right after "(".
+    if (node.positionalFields.isEmpty) {
+      token(namedFields!.leftBracket);
+    }
+
+    // Process the parameters as a separate set of chunks.
+    builder = builder.startBlock();
+
+    // Write the positional fields.
+    for (var field in node.positionalFields) {
+      builder.split(nest: false, space: field != node.positionalFields.first);
+      visit(field);
+      _writeCommaAfter(field);
+    }
+
+    // Then the named fields.
+    var firstClosingDelimiter = node.rightParenthesis;
+    if (namedFields != null) {
+      if (node.positionalFields.isNotEmpty) {
+        space();
+        token(namedFields.leftBracket);
+      }
+
+      for (var field in namedFields.fields) {
+        builder.split(nest: false, space: field != namedFields.fields.first);
+        visit(field);
+        _writeCommaAfter(field);
+      }
+
+      firstClosingDelimiter = namedFields.rightBracket;
+    }
+
+    // Put comments before the closing ")" or "}" inside the block.
+    if (firstClosingDelimiter.precedingComments != null) {
+      newline();
+      writePrecedingCommentsAndNewlines(firstClosingDelimiter);
+    }
+
+    // If there is a trailing comma, then force the record type to split. But
+    // don't force if there is only a single positional element because then
+    // the trailing comma is actually mandatory.
+    bool force;
+    if (namedFields == null) {
+      force = node.positionalFields.length > 1 &&
+          node.positionalFields.last.hasCommaAfter;
+    } else {
+      force = namedFields.fields.last.hasCommaAfter;
+    }
+
+    builder = builder.endBlock(forceSplit: force);
+    builder.endRule();
+    _metadataRules.removeLast();
+
+    // Now write the delimiter(s) themselves.
+    _writeText(firstClosingDelimiter.lexeme, firstClosingDelimiter);
+    if (namedFields != null) token(node.rightParenthesis);
+
+    token(node.question);
+  }
+
+  @override
+  void visitRecordTypeAnnotationNamedField(
+      RecordTypeAnnotationNamedField node) {
+    visitParameterMetadata(node.metadata, () {
+      visit(node.type);
+      token(node.name, before: space);
+    });
+  }
+
+  @override
+  void visitRecordTypeAnnotationPositionalField(
+      RecordTypeAnnotationPositionalField node) {
+    visitParameterMetadata(node.metadata, () {
+      visit(node.type);
+      token(node.name, before: space);
+    });
+  }
+
+  @override
   void visitRethrowExpression(RethrowExpression node) {
     token(node.rethrowKeyword);
   }
@@ -2334,8 +2443,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     visitParameterMetadata(node.metadata, () {
       _beginFormalParameter(node);
 
-      var hasType = node.type != null;
-      if (_insideNewTypedefFix && !hasType) {
+      if (_insideNewTypedefFix && node.type == null) {
         // Parameters can use "var" instead of "dynamic". Since we are inserting
         // "dynamic" in that case, remove the "var".
         if (node.keyword != null) {
@@ -2358,10 +2466,9 @@ class SourceVisitor extends ThrowingAstVisitor {
         });
       } else {
         modifier(node.keyword);
+
         visit(node.type);
-
-        if (hasType && node.name != null) split();
-
+        if (node.name != null) _separatorBetweenTypeAndVariable(node.type);
         token(node.name);
       }
 
@@ -2574,7 +2681,8 @@ class SourceVisitor extends ThrowingAstVisitor {
 
     modifier(node.lateKeyword);
     modifier(node.keyword);
-    visit(node.type, after: soloSplit);
+    visit(node.type);
+    _separatorBetweenTypeAndVariable(node.type, isSolo: true);
 
     builder.endSpan();
 
@@ -2777,18 +2885,30 @@ class SourceVisitor extends ThrowingAstVisitor {
     token(leftBracket);
     rule.beforeArgument(zeroSplit());
 
+    // Set the block nesting in case an argument is a function type with a
+    // trailing comma or a record type.
+    builder.startBlockArgumentNesting();
+
     for (var node in nodes) {
       visit(node);
 
-      // Write the trailing comma.
+      // Write the comma separator.
       if (node != nodes.last) {
-        token(node.endToken.next);
+        var comma = node.endToken.next;
+
+        // TODO(rnystrom): There is a bug in analyzer where the end token of a
+        // nullable record type is the ")" and not the "?". This works around
+        // that. Remove that's fixed.
+        if (comma?.lexeme == '?') comma = comma?.next;
+
+        token(comma);
         rule.beforeArgument(split());
       }
     }
 
     token(rightBracket);
 
+    builder.endBlockArgumentNesting();
     builder.unnest();
     builder.endSpan();
     builder.endRule();
@@ -2981,10 +3101,10 @@ class SourceVisitor extends ThrowingAstVisitor {
   ///
   /// This is also used for argument lists with a trailing comma which are
   /// considered "collection-like". In that case, [node] is `null`.
-  void _visitCollectionLiteral(TypedLiteral? node, Token leftBracket,
+  void _visitCollectionLiteral(Literal? node, Token leftBracket,
       List<AstNode> elements, Token rightBracket,
       [int? cost]) {
-    if (node != null) {
+    if (node is TypedLiteral) {
       // See if `const` should be removed.
       if (node.constKeyword != null &&
           _constNesting > 0 &&
@@ -3004,16 +3124,19 @@ class SourceVisitor extends ThrowingAstVisitor {
       return;
     }
 
-    // Force all of the surrounding collections to split.
-    for (var i = 0; i < _collectionSplits.length; i++) {
-      _collectionSplits[i] = true;
+    // Unlike other collections, records don't force outer ones to split.
+    if (node is! RecordLiteral) {
+      // Force all of the surrounding collections to split.
+      for (var i = 0; i < _collectionSplits.length; i++) {
+        _collectionSplits[i] = true;
+      }
+
+      // Add this collection to the stack.
+      _collectionSplits.add(false);
     }
 
-    // Add this collection to the stack.
-    _collectionSplits.add(false);
-
     _beginBody(leftBracket);
-    if (node != null) _startPossibleConstContext(node.constKeyword);
+    if (node is TypedLiteral) _startPossibleConstContext(node.constKeyword);
 
     // If a collection contains a line comment, we assume it's a big complex
     // blob of data with some documented structure. In that case, the user
@@ -3053,13 +3176,20 @@ class SourceVisitor extends ThrowingAstVisitor {
       }
     }
 
+    var force = false;
+
     // If there is a collection inside this one, it forces this one to split.
-    var force = _collectionSplits.removeLast();
+    if (node is! RecordLiteral) {
+      force = _collectionSplits.removeLast();
+    }
 
     // If the collection has a trailing comma, the user must want it to split.
-    if (elements.hasCommaAfter) force = true;
+    // (Unless it's a single-element record literal, in which case the trailing
+    // comma is required for disambiguation.)
+    var isSingleElementRecord = node is RecordLiteral && elements.length == 1;
+    if (elements.hasCommaAfter && !isSingleElementRecord) force = true;
 
-    if (node != null) _endPossibleConstContext(node.constKeyword);
+    if (node is TypedLiteral) _endPossibleConstContext(node.constKeyword);
     _endBody(rightBracket, forceSplit: force);
   }
 
@@ -3202,6 +3332,39 @@ class SourceVisitor extends ThrowingAstVisitor {
     }
 
     builder.endRule();
+  }
+
+  /// Writes the separator between a type annotation and a variable or
+  /// parameter. If the preceding type annotation ends in a delimited list of
+  /// elements that have block formatting, then we don't split between the
+  /// type annotation and parameter name, as in:
+  ///
+  ///     Function(
+  ///       int,
+  ///     ) variable;
+  ///
+  /// Otherwise, we can.
+  void _separatorBetweenTypeAndVariable(TypeAnnotation? type,
+      {bool isSolo = false}) {
+    if (type == null) return;
+
+    var isBlockType = false;
+    if (type is GenericFunctionType) {
+      // Function types get block-like formatting if they have a trailing comma.
+      isBlockType = type.parameters.parameters.isNotEmpty &&
+          type.parameters.parameters.last.hasCommaAfter;
+    } else if (type is RecordTypeAnnotation) {
+      // Record types always have block-like formatting.
+      isBlockType = true;
+    }
+
+    if (isBlockType) {
+      space();
+    } else if (isSolo) {
+      soloSplit();
+    } else {
+      split();
+    }
   }
 
   /// Whether [node] should be forced to split even if completely empty.

--- a/test/comments/records.stmt
+++ b/test/comments/records.stmt
@@ -1,0 +1,72 @@
+40 columns                              |
+>>> empty record block comment
+var record = (  /* comment */  );
+<<<
+var record = (/* comment */);
+>>> empty record line comment
+var record = (  // comment
+);
+<<<
+var record = (
+  // comment
+);
+>>> single-element record block comment
+var record = ( element , /* comment */  );
+<<<
+var record = (element, /* comment */);
+>>> single-element record block comment
+var record = ( element /* comment */ , );
+<<<
+var record = (element /* comment */,);
+>>> long single-element record block comment
+var record = ( element /* very long adhered to element */ , );
+<<<
+var record = (
+  element /* very long adhered to element */,
+);
+>>> long single-element record block comment
+var record = ( element, /* very long adhered to element */ );
+<<<
+var record = (
+  element, /* very long adhered to element */
+);
+>>> single-element record line comment
+var record = ( element , // comment
+);
+<<<
+var record = (
+  element, // comment
+);
+>>> single-element record line comment
+var record = ( element // comment
+,);
+<<<
+var record = (
+  element // comment
+  ,
+);
+>>> multi-element record block comment
+var record = ( 1 /* comment */ , 2  );
+<<<
+var record = (1 /* comment */, 2);
+>>> multi-element record block comment
+var record = ( 1 , /* comment */ 2  );
+<<<
+var record = (1, /* comment */ 2);
+>>> multi-element record line comment
+var record = ( 1 // comment
+, 2  );
+<<<
+var record = (
+  1 // comment
+  ,
+  2
+);
+>>> multi-element record line comment
+var record = ( 1, // comment
+2  );
+<<<
+var record = (
+  1, // comment
+  2
+);

--- a/test/regression/other/analyzer.unit
+++ b/test/regression/other/analyzer.unit
@@ -1,0 +1,4 @@
+>>> work around bug in record type annotation end token
+var x = foo<(int, int)?, int>();
+<<<
+var x = foo<(int, int)?, int>();

--- a/test/splitting/annotations.unit
+++ b/test/splitting/annotations.unit
@@ -93,3 +93,27 @@ int i = 0;
         Ddddddddddd>,
     Eeeeeeeee<Fffffffff, Ggggggggg>>()
 int i = 0;
+>>> on unsplit function type parameters
+Function(@a @b int c, int d) func;
+<<<
+Function(@a @b int c, int d) func;
+>>> on split function type parameters
+Function(@annotation int param1, int param2, @annotation int param3, int param4) func;
+<<<
+Function(
+    @annotation int param1,
+    int param2,
+    @annotation int param3,
+    int param4) func;
+>>> on unsplit record type field
+(@a int, {@a double d}) record;
+<<<
+(@a int, {@a double d}) record;
+>>> on split record type field
+(@anno @tation int, @annotation String s, {@annotation double d}) record;
+<<<
+(
+  @anno @tation int,
+  @annotation String s, {
+  @annotation double d
+}) record;

--- a/test/splitting/function_types.unit
+++ b/test/splitting/function_types.unit
@@ -96,3 +96,95 @@ Function<Argument>(String)
             Function<Argument>(int)
         Function<Argument>(bool)
     longVariable;
+>>> trailing comma
+Function(first, second,) f;
+<<<
+Function(
+  first,
+  second,
+) f;
+>>> split inside type argument
+GenericClass<Function(first, second, third, fourth, fifth)> f;
+<<<
+GenericClass<
+    Function(first, second, third,
+        fourth, fifth)> f;
+>>> trailing comma split inside type argumennt
+GenericClass<Function(first, second,)> f;
+<<<
+GenericClass<
+    Function(
+      first,
+      second,
+    )> f;
+>>> inside parameter list
+outer(Function(first, second, third, fourth, fifth) fn) {;}
+<<<
+outer(
+    Function(first, second, third,
+            fourth, fifth)
+        fn) {
+  ;
+}
+>>> trailing comma inside parameter list
+outer(Function(first,) fn) {;}
+<<<
+outer(
+    Function(
+      first,
+    ) fn) {
+  ;
+}
+>>> optional parameter trailing comma inside parameter list
+outer(Function([first,]) fn) {;}
+<<<
+outer(
+    Function([
+      first,
+    ]) fn) {
+  ;
+}
+>>> named parameter trailing comma inside parameter list
+outer(Function({int first,}) fn) {;}
+<<<
+outer(
+    Function({
+      int first,
+    }) fn) {
+  ;
+}
+>>> field formal parameter trailing comma inside parameter list
+class C { C(Function(first,) this.fn) {;} }
+<<<
+class C {
+  C(
+      Function(
+        first,
+      ) this.fn) {
+    ;
+  }
+}
+>>> inside trailing comma parameter list
+outer(Function(first, second, third, fourth, fifth) fn,) {;}
+<<<
+outer(
+  Function(first, second, third, fourth,
+          fifth)
+      fn,
+) {
+  ;
+}
+>>> trailing comma inside trailing comma parameter list
+outer(Function(first, second, third, fourth, fifth,) fn,) {;}
+<<<
+outer(
+  Function(
+    first,
+    second,
+    third,
+    fourth,
+    fifth,
+  ) fn,
+) {
+  ;
+}

--- a/test/splitting/record_types.unit
+++ b/test/splitting/record_types.unit
@@ -1,0 +1,181 @@
+40 columns                              |
+>>> empty record types don't split
+someLongFunctionName__________________(() x) {}
+<<<
+someLongFunctionName__________________(
+    () x) {}
+>>> unsplit short single positional field
+(TypeName,) x;
+<<<
+(TypeName,) x;
+>>> unsplit single positional field
+function((VeryLongTypeName____________,) x) {;}
+<<<
+function(
+    (VeryLongTypeName____________,) x) {
+  ;
+}
+>>> split single positional field
+function((VeryLongTypeName___________________,) param) {;}
+<<<
+function(
+    (
+      VeryLongTypeName___________________,
+    ) param) {
+  ;
+}
+>>> prefer to split between type and variable
+(LongTypeName, LongTypeName) longVariableName;
+<<<
+(
+  LongTypeName,
+  LongTypeName
+) longVariableName;
+>>> split positional
+(TypeName,TypeName,TypeName,TypeName) x;
+<<<
+(
+  TypeName,
+  TypeName,
+  TypeName,
+  TypeName
+) x;
+>>> split positional
+(TypeName,TypeName,TypeName,TypeName,TypeName) x;
+<<<
+(
+  TypeName,
+  TypeName,
+  TypeName,
+  TypeName,
+  TypeName
+) x;
+>>> split named
+({TypeName a,TypeName b,TypeName c,TypeName d}) x;
+<<<
+({
+  TypeName a,
+  TypeName b,
+  TypeName c,
+  TypeName d
+}) x;
+>>> split named if positional splits
+(TypeName,TypeName,TypeName,TypeName,{TypeName a,TypeName b}) x;
+<<<
+(
+  TypeName,
+  TypeName,
+  TypeName,
+  TypeName, {
+  TypeName a,
+  TypeName b
+}) x;
+>>> split positional if named splits
+(TypeName,TypeName,{TypeName a,TypeName b,TypeName c,TypeName d}) x;
+<<<
+(
+  TypeName,
+  TypeName, {
+  TypeName a,
+  TypeName b,
+  TypeName c,
+  TypeName d
+}) x;
+>>> always split named with trailing comma
+({int n,}) x;
+<<<
+({
+  int n,
+}) x;
+>>> split positional with trailing comma if more than one
+(int m, int n,) x;
+<<<
+(
+  int m,
+  int n,
+) x;
+>>> split outer record if inner record splits
+((TypeName,TypeName,TypeName,TypeName),TypeName) x;
+<<<
+(
+  (
+    TypeName,
+    TypeName,
+    TypeName,
+    TypeName
+  ),
+  TypeName
+) x;
+>>> split outer type argument list if inner record splits
+Map<String, (TypeName,TypeName,TypeName,TypeName)> map;
+<<<
+Map<
+    String,
+    (
+      TypeName,
+      TypeName,
+      TypeName,
+      TypeName
+    )> map;
+>>> inside parameter list
+function((TypeName, TypeName, TypeName, TypeName, TypeName) record) {;}
+<<<
+function(
+    (
+      TypeName,
+      TypeName,
+      TypeName,
+      TypeName,
+      TypeName
+    ) record) {
+  ;
+}
+>>> single positional trailing comma inside parameter list
+function((TypeName,) record) {;}
+<<<
+function((TypeName,) record) {
+  ;
+}
+>>> named parameter trailing comma inside parameter list
+function(({TypeName param,}) record) {;}
+<<<
+function(
+    ({
+      TypeName param,
+    }) record) {
+  ;
+}
+>>> field formal parameter trailing comma inside parameter list
+class C { C((TypeName,TypeName,) this.record) {;} }
+<<<
+class C {
+  C(
+      (
+        TypeName,
+        TypeName,
+      ) this.record) {
+    ;
+  }
+}
+>>> inside trailing comma parameter list
+function((TypeName,TypeName,) record,) {;}
+<<<
+function(
+  (
+    TypeName,
+    TypeName,
+  ) record,
+) {
+  ;
+}
+>>> trailing comma inside trailing comma parameter list
+function((TypeName,TypeName,) record,) {;}
+<<<
+function(
+  (
+    TypeName,
+    TypeName,
+  ) record,
+) {
+  ;
+}

--- a/test/splitting/records.stmt
+++ b/test/splitting/records.stmt
@@ -1,0 +1,173 @@
+40 columns                              |
+>>> empty records don't split
+var longVariableName_______________ = ();
+<<<
+var longVariableName_______________ =
+    ();
+>>> single-element record
+var record = (veryLongRecordField________________,);
+<<<
+var record = (
+  veryLongRecordField________________,
+);
+>>> single-element named record
+var record = (longFieldName: longRecordFieldValue);
+<<<
+var record = (
+  longFieldName: longRecordFieldValue
+);
+>>> single-element named record splits at name
+var record = (longFieldName: veryLongRecordFieldValue);
+<<<
+var record = (
+  longFieldName:
+      veryLongRecordFieldValue
+);
+>>> exactly 40 characters
+(first, second, third, fourth, seventh);
+<<<
+(first, second, third, fourth, seventh);
+>>>
+(first, second, third, fourth, fifth, sixth);
+<<<
+(
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+  sixth
+);
+>>> don't force outer record to split
+((first,), (second, third));
+<<<
+((first,), (second, third));
+>>> don't force outer list to split
+[(first,), (second, third)];
+<<<
+[(first,), (second, third)];
+>>> inner list doesn't force split
+([first], [second, third]);
+<<<
+([first], [second, third]);
+>>> nested split record
+(first, (second, third, fourth), fifth, (sixth, seventh, eighth, nine, tenth,
+    eleventh));
+<<<
+(
+  first,
+  (second, third, fourth),
+  fifth,
+  (
+    sixth,
+    seventh,
+    eighth,
+    nine,
+    tenth,
+    eleventh
+  )
+);
+>>> force multi-line because of contained block
+(first, () {"fn";},third,fourth);
+<<<
+(
+  first,
+  () {
+    "fn";
+  },
+  third,
+  fourth
+);
+>>> trailing comma in single-element does not split
+(1,);
+<<<
+(1,);
+>>> trailing comma in multi-element does force split
+(1,2,);
+<<<
+(
+  1,
+  2,
+);
+>>> preserve newlines in records containing a line comment
+(
+  // yeah
+  a,b,c,
+  d,e,f,
+);
+<<<
+(
+  // yeah
+  a, b, c,
+  d, e, f,
+);
+>>> wrap between elements even when newlines are preserved
+(
+  // yes
+  longElement,longElement,longElement,longElement,
+  longElement,longElement,longElement,longElement,longElement,longElement,
+);
+<<<
+(
+  // yes
+  longElement, longElement, longElement,
+  longElement,
+  longElement, longElement, longElement,
+  longElement, longElement, longElement,
+);
+>>> ignore line comment after the "]"
+(
+  a,b,c,
+  d
+) // comment
+;
+<<<
+(a, b, c, d) // comment
+    ;
+>>> preserves one blank line between elements
+(
+
+
+  element,
+
+
+
+  // comment
+  element,
+
+
+
+  element
+
+
+);
+<<<
+(
+  element,
+
+  // comment
+  element,
+
+  element
+);
+>>> unlike collections, records do not do block-like formatting in arguments
+longFunctionName((element, element), (element, element, element, element));
+<<<
+longFunctionName(
+    (element, element),
+    (
+      element,
+      element,
+      element,
+      element
+    ));
+>>> unlike collections, records do not do block-like formatting in arguments
+longFunctionName((element, element, element, element));
+<<<
+longFunctionName(
+    (
+      element,
+      element,
+      element,
+      element
+    ));

--- a/test/whitespace/expressions.stmt
+++ b/test/whitespace/expressions.stmt
@@ -187,3 +187,23 @@ var x = Class<int>;
 var x = Class  < int  > . named;
 <<<
 var x = Class<int>.named;
+>>> empty record
+var record = (   );
+<<<
+var record = ();
+>>> single-element records don't split after ","
+var record = (   value  ,  );
+<<<
+var record = (value,);
+>>> multi-element record
+var record = (   first  ,  second  ,  third  );
+<<<
+var record = (first, second, third);
+>>> named record fields
+var record = (   first  :  1  ,  2 ,  third : 3 );
+<<<
+var record = (first: 1, 2, third: 3);
+>>> const record
+var record = const   (  1 ,   2 );
+<<<
+var record = const (1, 2);

--- a/test/whitespace/record_types.unit
+++ b/test/whitespace/record_types.unit
@@ -1,0 +1,50 @@
+40 columns                              |
+>>> empty
+(   )  x;
+<<<
+() x;
+>>> single positional field
+(  int  , ) x;
+<<<
+(int,) x;
+>>> single named field
+( { int  n  }  )  x;
+<<<
+({int n}) x;
+>>> named positional fields
+( int  value  ,  String  label) x;
+<<<
+(int value, String label) x;
+>>> unnamed positional fields
+( int    ,  String   ) x;
+<<<
+(int, String) x;
+>>> named fields
+(  {  int  value  ,  String  label  } ) x;
+<<<
+({int value, String label}) x;
+>>> named positional field trailing comma
+( int  value  ,  String  label  , ) x;
+<<<
+(
+  int value,
+  String label,
+) x;
+>>> unnamed positional fields trailing comma
+( int    ,  String   ,  ) x;
+<<<
+(
+  int,
+  String,
+) x;
+>>> named fields trailing comma
+(  {  int  value  ,  String  label  ,  } ) x;
+<<<
+({
+  int value,
+  String label,
+}) x;
+>>> nullable record type
+(  int  ,   bool  )   ?  x;
+<<<
+(int, bool)? x;

--- a/test/whitespace/type_arguments.stmt
+++ b/test/whitespace/type_arguments.stmt
@@ -23,3 +23,7 @@ C<int, float>.named(42);
 Map<  int  ?  , List<String  ?  > ? >();
 <<<
 Map<int?, List<String?>?>();
+>>> record type type argument
+Set < ( int  x  ,  String  ,  {  bool   b,  int  i  } )>();
+<<<
+Set<(int x, String, {bool b, int i})>();


### PR DESCRIPTION
In the process of working on this, I discovered that multi-line function types with trailing commas are pretty busted looking. (I guess no one puts trailing commas there.) I fixed those too, since they are structurally similar to record types in many ways.

(If you don't have time to review this, @natebosch, feel free to bounce it to someone else.)