### PR TITLE
Remove non-working constraint between metadata and parameters.

### DIFF
--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1326,7 +1326,6 @@ class SourceVisitor extends ThrowingAstVisitor {
     PositionalRule? rule;
     if (requiredParams.isNotEmpty) {
       rule = PositionalRule(null, argumentCount: requiredParams.length);
-      _metadataRules.last.constrainWhenFullySplit(rule);
 
       builder.startRule(rule);
       if (node.isFunctionExpressionBody) {
@@ -1354,7 +1353,6 @@ class SourceVisitor extends ThrowingAstVisitor {
 
     if (optionalParams.isNotEmpty) {
       var namedRule = NamedRule(null, 0, 0);
-      _metadataRules.last.constrainWhenFullySplit(namedRule);
       if (rule != null) rule.addNamedArgsConstraints(namedRule);
 
       builder.startRule(namedRule);


### PR DESCRIPTION
I believe the *intent* of these constraints is that if a parameter list splits then the metadata before each parameters split too. With these, instead of:

```dart
   function(
       @anno param,
       @anno param,
       @anno param) {
```

Where the parameters can split while leaving the annotations alone, the annotations are forced to split too:

```dart
   function(
       @anno
       param,
       @anno
       param,
       @anno param) {
```

But...

1. These constraints don't appear to do that.

2. There are no tests that they would do that. In fact, all the tests pass with these lines removed.

3. And when I format a large corpus with these lines removed, there are no differences versus when them included. They don't appear to do anything.

4. Most importantly, it seems that the current style is to allow a parameter list to split while keeping annotations. So even if I were to fix this code so that it does what (I think) it was supposed to, it's probably not what people want.

So just removing it.