### PR TITLE
Start formatting patterns and other related syntax.

### DIFF
--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -90,6 +90,10 @@ class DartFormatter {
     var featureSet = FeatureSet.fromEnableFlags2(
       sdkLanguageVersion: Version(2, 19, 0),
       flags: [
+        // TODO(rnystrom): This breaks existing switch cases containing constant
+        // expressions that aren't valid patterns. See:
+        // https://github.com/dart-lang/dart_style/issues/1164
+        'patterns',
         'records',
         'unnamed-libraries',
       ],

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -796,6 +796,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     visit(node.uri);
   }
 
+  @override
   void visitConstantPattern(ConstantPattern node) {
     token(node.constKeyword, after: space);
     visit(node.expression);
@@ -2448,6 +2449,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     });
   }
 
+  @override
   void visitRelationalPattern(RelationalPattern node) {
     token(node.operator);
     space();
@@ -2787,6 +2789,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     });
   }
 
+  @override
   void visitWhenClause(WhenClause node) {
     builder.startRule();
     split();

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -359,11 +359,10 @@ class SourceVisitor extends ThrowingAstVisitor {
     // appears before the first operand.
     builder.startLazyRule();
 
-    // Flatten out a tree/chain of the same precedence. If we split on this
-    // precedence level, we will break all of them.
+    // Flatten out a tree/chain of the same precedence. If we need to split on
+    // any of them, we split on all of them.
     var precedence = node.operator.type.precedence;
 
-    @override
     void traverse(Expression e) {
       if (e is BinaryExpression && e.operator.type.precedence == precedence) {
         traverse(e.leftOperand);
@@ -400,11 +399,10 @@ class SourceVisitor extends ThrowingAstVisitor {
     // appears before the first operand.
     builder.startLazyRule();
 
-    // Flatten out a tree/chain of the same precedence. If we split on this
-    // precedence level, we will break all of them.
+    // Flatten out a tree/chain of the same precedence. If we need to split on
+    // any of them, we split on all of them.
     var precedence = node.operator.type.precedence;
 
-    @override
     void traverse(DartPattern p) {
       if (p is BinaryPattern && p.operator.type.precedence == precedence) {
         traverse(p.leftOperand);
@@ -2592,7 +2590,6 @@ class SourceVisitor extends ThrowingAstVisitor {
     token(node.colon);
 
     builder.indent();
-    // TODO(rnystrom): Allow inline cases?
     newline();
 
     visitNodes(node.statements, between: oneOrTwoNewlines);
@@ -2606,7 +2603,6 @@ class SourceVisitor extends ThrowingAstVisitor {
     token(node.colon);
 
     builder.indent();
-    // TODO(rnystrom): Allow inline cases?
     newline();
 
     visitNodes(node.statements, between: oneOrTwoNewlines);
@@ -2630,7 +2626,6 @@ class SourceVisitor extends ThrowingAstVisitor {
     token(node.colon);
 
     builder.indent();
-    // TODO(rnystrom): Allow inline cases?
     newline();
 
     visitNodes(node.statements, between: oneOrTwoNewlines);

--- a/test/comments/patterns.stmt
+++ b/test/comments/patterns.stmt
@@ -1,0 +1,78 @@
+40 columns                              |
+>>> before first operand of logic
+if (obj case // c
+pattern || otherPattern) {;}
+<<<
+if (obj
+    case // c
+        pattern || otherPattern) {
+  ;
+}
+>>> before first operand of nested logic
+if (obj case pattern || // c
+otherPattern && thirdLongPattern) {;}
+<<<
+if (obj
+    case pattern || // c
+        otherPattern &&
+            thirdLongPattern) {
+  ;
+}
+>>> after left logic operand (looks weird, but user should move comment)
+if (obj case pattern // c
+|| otherPattern) {;}
+<<<
+if (obj
+    case pattern // c
+        ||
+        otherPattern) {
+  ;
+}
+>>> after logic operator
+if (obj case pattern || // c
+otherPattern) {;}
+<<<
+if (obj
+    case pattern || // c
+        otherPattern) {
+  ;
+}
+>>> after right logic operand
+if (obj case somePattern || otherPattern // c
+) {;}
+<<<
+if (obj
+    case somePattern ||
+        otherPattern // c
+    ) {
+  ;
+}
+>>> after relational operator
+if (obj case <= // c
+someConstant + anotherLongConstant) {;}
+<<<
+if (obj
+    case <= // c
+        someConstant +
+            anotherLongConstant) {
+  ;
+}
+>>> after relational operand
+if (obj case <= someConstant + anotherLongConstant // c
+) {;}
+<<<
+if (obj
+    case <= someConstant +
+        anotherLongConstant // c
+    ) {
+  ;
+}
+>>> inside parenthesized
+if (obj case ( // c
+pattern)) {;}
+<<<
+if (obj
+    case ( // c
+        pattern)) {
+  ;
+}

--- a/test/splitting/if_case.stmt
+++ b/test/splitting/if_case.stmt
@@ -1,0 +1,91 @@
+40 columns                              |
+>>> keep case and guard on same line if possible
+if (obj case constant when condition) {;}
+<<<
+if (obj case constant when condition) {
+  ;
+}
+>>> prefer to split guard before case
+if (expression case longConstant when condition) {;}
+<<<
+if (expression case longConstant
+    when condition) {
+  ;
+}
+>>> can split case and keep guard on same line
+if (veryLongExpression case veryLongConstant when cond) {;}
+<<<
+if (veryLongExpression
+    case veryLongConstant when cond) {
+  ;
+}
+>>> split case and guard
+if (veryLongExpression case veryLongConstant when veryLongCondition) {;}
+<<<
+if (veryLongExpression
+    case veryLongConstant
+    when veryLongCondition) {
+  ;
+}
+>>> if value expression block splits then case splits
+if (veryLongExpression + anotherVeryLongOne case someCase) {;}
+<<<
+if (veryLongExpression +
+        anotherVeryLongOne
+    case someCase) {
+  ;
+}
+>>> if value expression block splits then case but guard doesn't have to
+if (veryLongExpression + anotherVeryLongOne case someCase when true) {;}
+<<<
+if (veryLongExpression +
+        anotherVeryLongOne
+    case someCase when true) {
+  ;
+}
+>>> if pattern block splits then case splits
+if (obj case const [element,]) {;}
+<<<
+if (obj
+    case const [
+      element,
+    ]) {
+  ;
+}
+>>> if guard condition block splits then guard splits
+if (obj case constant when [element,]) {;}
+<<<
+if (obj case constant
+    when [
+      element,
+    ]) {
+  ;
+}
+>>> block splits in both pattern and guard
+if (obj case const [element,] when [element,]) {;}
+<<<
+if (obj
+    case const [
+      element,
+    ]
+    when [
+      element,
+    ]) {
+  ;
+}
+>>> if pattern splits then case splits
+if (obj case veryLongConstant || longConstant) {;}
+<<<
+if (obj
+    case veryLongConstant ||
+        longConstant) {
+  ;
+}
+>>> if guard condition block splits then guard splits
+if (obj case constant when veryLongExpression + anotherOne) {;}
+<<<
+if (obj case constant
+    when veryLongExpression +
+        anotherOne) {
+  ;
+}

--- a/test/splitting/list_collection_if.stmt
+++ b/test/splitting/list_collection_if.stmt
@@ -448,3 +448,40 @@ var list = [
     // c
   ]
 ];
+>>> collection if-case
+var list = [
+if (veryLongExpression + anotherVeryLongOne case someCaseConstant || anotherCaseConstant) element
+];
+<<<
+var list = [
+  if (veryLongExpression +
+          anotherVeryLongOne
+      case someCaseConstant ||
+          anotherCaseConstant)
+    element
+];
+>>> collection if-case with guard
+var list = [
+if (veryLongExpression + anotherVeryLongOne case someCase when someGuardCondition || otherCondition) element
+];
+<<<
+var list = [
+  if (veryLongExpression +
+          anotherVeryLongOne
+      case someCase
+      when someGuardCondition ||
+          otherCondition)
+    element
+];
+>>> block formatted pattern in if-case
+var list = [
+if (expression case const [element,]) element
+];
+<<<
+var list = [
+  if (expression
+      case const [
+        element,
+      ])
+    element
+];

--- a/test/splitting/patterns.stmt
+++ b/test/splitting/patterns.stmt
@@ -1,0 +1,41 @@
+40 columns                              |
+>>> chain of same logic all split together
+if (object case first || second || third || fourth) {;}
+<<<
+if (object
+    case first ||
+        second ||
+        third ||
+        fourth) {
+  ;
+}
+>>> chains of different logic operators split separately
+if (object case first && second || third && fourth && fifth && sixth) {;}
+<<<
+if (object
+    case first && second ||
+        third &&
+            fourth &&
+            fifth &&
+            sixth) {
+  ;
+}
+>>> chains of different logic operators split separately
+if (object case first && second && third && fourth || fifth && sixth) {;}
+<<<
+if (object
+    case first &&
+            second &&
+            third &&
+            fourth ||
+        fifth && sixth) {
+  ;
+}
+>>> split in relational constant expression
+if (object case != veryLongConstant + expressionThatSplits) {;}
+<<<
+if (object
+    case != veryLongConstant +
+        expressionThatSplits) {
+  ;
+}

--- a/test/whitespace/if.stmt
+++ b/test/whitespace/if.stmt
@@ -89,3 +89,7 @@ if (condition)
   someLong(argument, another);
 else
   anotherLong(argument, another, arg);
+>>> if-case
+if (   obj   case   123   ||   constant   ) {}
+<<<
+if (obj case 123 || constant) {}

--- a/test/whitespace/patterns.stmt
+++ b/test/whitespace/patterns.stmt
@@ -1,0 +1,33 @@
+40 columns                              |
+>>> logic
+if (o case 1   ||  2   &&  3  ) {}
+<<<
+if (o case 1 || 2 && 3) {}
+>>> logic as subpattern
+if (o case 1   &&  (  2   ||  3   )  ) {}
+<<<
+if (o case 1 && (2 || 3)) {}
+>>> relational
+switch (obj) {
+  case   ==   other:
+  case   !=   other:
+  case   <   other:
+  case   <=   other:
+  case   >   other:
+  case   >=   other:
+    body;
+}
+<<<
+switch (obj) {
+  case == other:
+  case != other:
+  case < other:
+  case <= other:
+  case > other:
+  case >= other:
+    body;
+}
+>>> relational as subpattern
+if (o case  >  1  &&  <   2 && (  ==   3 )) {}
+<<<
+if (o case > 1 && < 2 && (== 3)) {}


### PR DESCRIPTION
I'm breaking this up into a series of PRs so it's not overwhelming. Also, I'm going to merge these PRs into a separate "patterns" branch until #1164 is resolved. That way, master isn't broken.

This first PR:

- Enables parsing patterns.
- Does some rudimentary formatting of constant patterns so that the existing switch tests don't break. I'll add more tests for constant patterns in a later PR.
- Formats if-case statements and elements.
- Formats logic, relational, and parenthesized patterns.