### PR TITLE
Format the remaining simple patterns.

### DIFF
--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -602,6 +602,19 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
+  void visitCastPattern(CastPattern node) {
+    builder.startSpan();
+    builder.nestExpression();
+    visit(node.pattern);
+    soloSplit();
+    token(node.asToken);
+    space();
+    visit(node.type);
+    builder.unnest();
+    builder.endSpan();
+  }
+
+  @override
   void visitCatchClause(CatchClause node) {
     token(node.onKeyword, after: space);
     visit(node.exceptionType);
@@ -947,6 +960,13 @@ class SourceVisitor extends ThrowingAstVisitor {
   void visitDeclaredIdentifier(DeclaredIdentifier node) {
     modifier(node.keyword);
     visit(node.type, after: space);
+    token(node.name);
+  }
+
+  @override
+  void visitDeclaredVariablePattern(DeclaredVariablePattern node) {
+    modifier(node.keyword);
+    visit(node.type, after: soloSplit);
     token(node.name);
   }
 
@@ -2300,6 +2320,12 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
+  void visitPostfixPattern(PostfixPattern node) {
+    visit(node.operand);
+    token(node.operator);
+  }
+
+  @override
   void visitPrefixedIdentifier(PrefixedIdentifier node) {
     CallChainVisitor(this, node).visit();
   }
@@ -3443,7 +3469,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       token(caseClause.caseKeyword);
       space();
       builder.startBlockArgumentNesting();
-      builder.nestExpression();
+      builder.nestExpression(now: true);
       visit(caseClause.guardedPattern.pattern);
       builder.unnest();
       builder.endBlockArgumentNesting();

--- a/test/comments/patterns.stmt
+++ b/test/comments/patterns.stmt
@@ -67,6 +67,58 @@ if (obj
     ) {
   ;
 }
+>>> before "as"
+if (obj case constant // c
+as Type) {;}
+<<<
+if (obj
+    case constant // c
+        as Type) {
+  ;
+}
+>>> after "as"
+if (obj case constant as // c
+Type) {;}
+<<<
+if (obj
+    case constant as // c
+        Type) {
+  ;
+}
+>>> before null-check (looks weird, but user should move comment)
+if (obj case pattern // c
+?) {;}
+<<<
+if (obj
+    case pattern // c
+        ?) {
+  ;
+}
+>>> after null-check (looks weird, but user should move comment)
+if (obj case pattern? // c
+) {;}
+<<<
+if (obj case pattern? // c
+    ) {
+  ;
+}
+>>> before null-assert (looks weird, but user should move comment)
+if (obj case pattern // c
+!) {;}
+<<<
+if (obj
+    case pattern // c
+        !) {
+  ;
+}
+>>> after null-assert (looks weird, but user should move comment)
+if (obj case pattern! // c
+) {;}
+<<<
+if (obj case pattern! // c
+    ) {
+  ;
+}
 >>> inside parenthesized
 if (obj case ( // c
 pattern)) {;}
@@ -74,5 +126,60 @@ pattern)) {;}
 if (obj
     case ( // c
         pattern)) {
+  ;
+}
+>>> in qualified name
+if (obj case qualified // c
+.name) {;}
+<<<
+if (obj
+    case qualified // c
+        .name) {
+  ;
+}
+>>> in prefixed qualified name
+if (obj case qualified // c
+.prefixed // c
+.name) {;}
+<<<
+if (obj
+    case qualified // c
+        .prefixed // c
+        .name) {
+  ;
+}
+>>> before "var"
+if (obj case // c
+var x) {;}
+<<<
+if (obj
+    case // c
+        var x) {
+  ;
+}
+>>> after "var"
+if (obj case var // c
+x) {;}
+<<<
+if (obj
+    case var // c
+        x) {
+  ;
+}
+>>> after variable (looks weird, but user should move comment)
+if (obj case var x // c
+) {;}
+<<<
+if (obj case var x // c
+    ) {
+  ;
+}
+>>> after type
+if (obj case List<int> // c
+x) {;}
+<<<
+if (obj
+    case List<int> // c
+        x) {
   ;
 }

--- a/test/splitting/patterns.stmt
+++ b/test/splitting/patterns.stmt
@@ -39,3 +39,76 @@ if (object
         expressionThatSplits) {
   ;
 }
+>>> split in cast
+if (object case veryLongConstant as VeryLongType) {;}
+<<<
+if (object
+    case veryLongConstant
+        as VeryLongType) {
+  ;
+}
+>>> split in qualified name
+if (object case veryLongPrefix.longIdentifierName) {;}
+<<<
+if (object
+    case veryLongPrefix
+        .longIdentifierName) {
+  ;
+}
+>>> prefer to split in first part prefixed qualified name
+if (object case longPrefix.longType.longIdentifierName) {;}
+<<<
+if (object
+    case longPrefix
+        .longType.longIdentifierName) {
+  ;
+}
+>>> split just at second part of prefixed qualified name
+if (object case longPrefix.veryLongType.longIdentifierName) {;}
+<<<
+if (object
+    case longPrefix.veryLongType
+        .longIdentifierName) {
+  ;
+}
+>>> split both parts of prefixed qualified name
+if (object case veryLongPrefixIdentifier.veryLongType.longIdentifierName) {;}
+<<<
+if (object
+    case veryLongPrefixIdentifier
+        .veryLongType
+        .longIdentifierName) {
+  ;
+}
+>>> no split after "var"
+if (obj case var thisIsReallyQuiteAVeryLongVariableName) {;}
+<<<
+if (obj
+    case var thisIsReallyQuiteAVeryLongVariableName) {
+  ;
+}
+>>> no split after "final"
+if (obj case final thisIsReallyQuiteAVeryLongVariableName) {;}
+<<<
+if (obj
+    case final thisIsReallyQuiteAVeryLongVariableName) {
+  ;
+}
+>>> no split between "final" and type
+if (obj case final ThisIsReallyQuiteAVeryLongTypeName variable) {;}
+<<<
+if (obj
+    case final ThisIsReallyQuiteAVeryLongTypeName
+        variable) {
+  ;
+}
+>>> split between type and name
+if (obj case SomeLongTypeName longVariableName) {
+  ;
+}
+<<<
+if (obj
+    case SomeLongTypeName
+        longVariableName) {
+  ;
+}

--- a/test/whitespace/patterns.stmt
+++ b/test/whitespace/patterns.stmt
@@ -31,3 +31,77 @@ switch (obj) {
 if (o case  >  1  &&  <   2 && (  ==   3 )) {}
 <<<
 if (o case > 1 && < 2 && (== 3)) {}
+>>> cast
+if (o case   1   as   List < int > ?  ) {}
+<<<
+if (o case 1 as List<int>?) {}
+>>> null-check
+if (o case pattern  ?  ) {}
+<<<
+if (o case pattern?) {}
+>>> null-assert
+if (o case pattern  !  ) {}
+<<<
+if (o case pattern!) {}
+>>> simple constants
+switch (obj) {
+case  true  :
+case  false  :
+case  null  :
+case  123  :
+case  12.34  :
+case  -  123  :
+case  -  12.34  :
+case  'string'  :
+case  's$tr${  ing  }'  :
+case  #symbol  :
+  ok;
+}
+<<<
+switch (obj) {
+  case true:
+  case false:
+  case null:
+  case 123:
+  case 12.34:
+  case -123:
+  case -12.34:
+  case 'string':
+  case 's$tr${ing}':
+  case #symbol:
+    ok;
+}
+>>> identifiers
+switch (obj) {
+case  _  :
+case  name  :
+case  qualified  .  name  :
+case  prefixed  .  qualified  .  name  :
+  ok;
+}
+<<<
+switch (obj) {
+  case _:
+  case name:
+  case qualified.name:
+  case prefixed.qualified.name:
+    ok;
+}
+>>> variables
+switch (obj) {
+case  int  ?  _  :
+case  List < String >  name  :
+case  var  name  :
+case  final  name  :
+case  final  (  int  ,  String  )  name  :
+  ok;
+}
+<<<
+switch (obj) {
+  case int? _:
+  case List<String> name:
+  case var name:
+  case final name:
+  case final (int, String) name:
+    ok;
+}


### PR DESCRIPTION
That means unary and primary patterns, but excludes all of the delimited
ones: list, map, record, object and the corresponding constants.