### PR TITLE
Fix how spans are rendered in the debug output.

### DIFF
--- a/lib/src/debug.dart
+++ b/lib/src/debug.dart
@@ -127,25 +127,30 @@ void dumpChunks(int start, List<Chunk> chunks) {
       var spanBars = '';
       for (var span in spans) {
         if (chunk.spans.contains(span)) {
-          if (index == 0 || !chunks[index - 1].spans.contains(span)) {
+          if (index == chunks.length - 1 ||
+              !chunks[index + 1].spans.contains(span)) {
+            // This is the last chunk with the span.
+            spanBars += '╙';
+          } else {
+            spanBars += '║';
+          }
+        } else {
+          // If the next chunk has this span, then show it bridging this chunk
+          // and the next because a split between them breaks the span.
+          if (index < chunks.length - 1 &&
+              chunks[index + 1].spans.contains(span)) {
             if (span.cost == 1) {
               spanBars += '╓';
             } else {
               spanBars += span.cost.toString();
             }
-          } else {
-            spanBars += '║';
-          }
-        } else {
-          if (index > 0 && chunks[index - 1].spans.contains(span)) {
-            spanBars += '╙';
-          } else {
-            spanBars += ' ';
           }
         }
       }
       row.add(spanBars);
     }
+
+    row.add(chunk.spans.map((span) => span.id).join(' '));
 
     if (chunk.text.length > 70) {
       row.add(chunk.text.substring(0, 70));


### PR DESCRIPTION
A while back, I did a big refactoring where each Chunk's split now describes the line split before that Chunk's text instead of after. When I did that, it looks like I didn't update how the debug output draws spans.

Since this is only used for debugging the formatter, it doesn't affect users. But it make for some very confusing debugging for me.