### PR TITLE
Fix the directory path shown by the old CLI.

### DIFF
--- a/lib/src/cli/show.dart
+++ b/lib/src/cli/show.dart
@@ -71,7 +71,7 @@ enum Show {
   /// Describes the directory whose contents are about to be processed.
   void directory(String path) {
     if (this == Show.legacy || this == Show.overwrite) {
-      print('Formatting directory $directory:');
+      print('Formatting directory $path:');
     }
   }
 


### PR DESCRIPTION
If you run bin/format.dart, it prints:

  Formatting directory Closure: (String) => void from Function 'directory':.:

Which is obviously not right. :) This fixes that.

Almost no one with notice this because `dart format` goes through the new CLI and doesn't use this entrypoint. But if you global activate the dart_style package or use `dart pub run` to get to the old entrypoint you might see it.