### PR TITLE
Format list, map, and record patterns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2.2.5-dev
 
+* Format patterns and related features.
+* Don't split after `<` in collection literals.
 * Format record expressions and record type annotations.
 * Better indentation of multiline function types inside type argument lists. 
 * Require `package:analyzer` `^5.1.0`.

--- a/lib/src/argument_list_visitor.dart
+++ b/lib/src/argument_list_visitor.dart
@@ -476,7 +476,8 @@ class ArgumentSublist {
     }
 
     if (argument is NamedExpression) {
-      visitor.visitNamedArgument(argument, rule as NamedRule);
+      visitor.visitNamedNode(argument.name.label.token, argument.name.colon,
+          argument.expression, rule as NamedRule);
     } else {
       visitor.visit(argument);
     }

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2411,9 +2411,18 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   @override
   void visitRecordPatternField(RecordPatternField node) {
-    var name = node.fieldName;
-    if (name != null) {
-      visitNamedNode(name.name!, name.colon, node.pattern);
+    var fieldName = node.fieldName;
+    if (fieldName != null) {
+      var name = fieldName.name;
+      if (name != null) {
+        visitNamedNode(fieldName.name!, fieldName.colon, node.pattern);
+      } else {
+        // Named field with inferred name, like:
+        //
+        //     var (:x) = (x: 1);
+        token(fieldName.colon);
+        visit(node.pattern);
+      }
     } else {
       visit(node.pattern);
     }

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -255,7 +255,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     // and the ")" ends up on its own line.
     if (node.arguments.hasCommaAfter) {
       _visitCollectionLiteral(
-          null, node.leftParenthesis, node.arguments, node.rightParenthesis);
+          node.leftParenthesis, node.arguments, node.rightParenthesis);
       return;
     }
 
@@ -289,7 +289,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     // and the ")" ends up on its own line.
     if (arguments.hasCommaAfter) {
       _visitCollectionLiteral(
-          null, node.leftParenthesis, arguments, node.rightParenthesis);
+          node.leftParenthesis, arguments, node.rightParenthesis);
       return;
     }
 
@@ -313,7 +313,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       // and the ")" ends up on its own line.
       if (arguments.hasCommaAfter) {
         _visitCollectionLiteral(
-            null, node.leftParenthesis, arguments, node.rightParenthesis);
+            node.leftParenthesis, arguments, node.rightParenthesis);
         return;
       }
 
@@ -2108,12 +2108,37 @@ class SourceVisitor extends ThrowingAstVisitor {
     // Corner case: Splitting inside a list looks bad if there's only one
     // element, so make those more costly.
     var cost = node.elements.length <= 1 ? Cost.singleElementList : Cost.normal;
-    _visitCollectionLiteral(
-        node, node.leftBracket, node.elements, node.rightBracket, cost);
+    _visitCollectionLiteral(node.leftBracket, node.elements, node.rightBracket,
+        constKeyword: node.constKeyword,
+        typeArguments: node.typeArguments,
+        splitOuterCollection: true,
+        cost: cost);
+  }
+
+  @override
+  void visitListPattern(ListPattern node) {
+    _visitCollectionLiteral(node.leftBracket, node.elements, node.rightBracket,
+        typeArguments: node.typeArguments);
   }
 
   @override
   void visitMapLiteralEntry(MapLiteralEntry node) {
+    builder.nestExpression();
+    visit(node.key);
+    token(node.separator);
+    soloSplit();
+    visit(node.value);
+    builder.unnest();
+  }
+
+  @override
+  void visitMapPattern(MapPattern node) {
+    _visitCollectionLiteral(node.leftBracket, node.elements, node.rightBracket,
+        typeArguments: node.typeArguments);
+  }
+
+  @override
+  void visitMapPatternEntry(MapPatternEntry node) {
     builder.nestExpression();
     visit(node.key);
     token(node.separator);
@@ -2232,7 +2257,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   @override
   void visitNamedExpression(NamedExpression node) {
-    visitNamedArgument(node);
+    visitNamedNode(node.name.label.token, node.name.colon, node.expression);
   }
 
   @override
@@ -2373,7 +2398,25 @@ class SourceVisitor extends ThrowingAstVisitor {
   void visitRecordLiteral(RecordLiteral node) {
     modifier(node.constKeyword);
     _visitCollectionLiteral(
-        node, node.leftParenthesis, node.fields, node.rightParenthesis);
+        node.leftParenthesis, node.fields, node.rightParenthesis,
+        isRecord: true);
+  }
+
+  @override
+  void visitRecordPattern(RecordPattern node) {
+    _visitCollectionLiteral(
+        node.leftParenthesis, node.fields, node.rightParenthesis,
+        isRecord: true);
+  }
+
+  @override
+  void visitRecordPatternField(RecordPatternField node) {
+    var name = node.fieldName;
+    if (name != null) {
+      visitNamedNode(name.name!, name.colon, node.pattern);
+    } else {
+      visit(node.pattern);
+    }
   }
 
   @override
@@ -2486,6 +2529,12 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
+  void visitRestPatternElement(RestPatternElement node) {
+    token(node.operator);
+    visit(node.pattern);
+  }
+
+  @override
   void visitReturnStatement(ReturnStatement node) {
     _simpleStatement(node, () {
       token(node.returnKeyword);
@@ -2505,8 +2554,10 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   @override
   void visitSetOrMapLiteral(SetOrMapLiteral node) {
-    _visitCollectionLiteral(
-        node, node.leftBracket, node.elements, node.rightBracket);
+    _visitCollectionLiteral(node.leftBracket, node.elements, node.rightBracket,
+        constKeyword: node.constKeyword,
+        typeArguments: node.typeArguments,
+        splitOuterCollection: true);
   }
 
   @override
@@ -2642,11 +2693,13 @@ class SourceVisitor extends ThrowingAstVisitor {
     token(node.keyword);
     space();
 
+    builder.indent();
     builder.startBlockArgumentNesting();
     builder.nestExpression();
     visit(node.guardedPattern.pattern);
     builder.unnest();
     builder.endBlockArgumentNesting();
+    builder.unindent();
 
     visit(node.guardedPattern.whenClause);
     token(node.colon);
@@ -2927,20 +2980,31 @@ class SourceVisitor extends ThrowingAstVisitor {
   /// split between the name and argument forces the argument list to split
   /// too.
   void visitNamedArgument(NamedExpression node, [NamedRule? rule]) {
+    visitNamedNode(
+        node.name.label.token, node.name.colon, node.expression, rule);
+  }
+
+  /// Visits syntax of the form `identifier: <node>`: a named argument or a
+  /// named record field.
+  void visitNamedNode(Token name, Token colon, AstNode node,
+      [NamedRule? rule]) {
     builder.nestExpression();
     builder.startSpan();
-    visit(node.name);
+    token(name);
+    token(colon);
 
     // Don't allow a split between a name and a collection. Instead, we want
     // the collection itself to split, or to split before the argument.
-    if (node.expression is ListLiteral || node.expression is SetOrMapLiteral) {
+    if (node is ListLiteral ||
+        node is SetOrMapLiteral ||
+        node is RecordLiteral) {
       space();
     } else {
       var split = soloSplit();
       if (rule != null) split.constrainWhenSplit(rule);
     }
 
-    visit(node.expression);
+    visit(node);
     builder.endSpan();
     builder.unnest();
   }
@@ -3207,26 +3271,67 @@ class SourceVisitor extends ThrowingAstVisitor {
     }
   }
 
-  /// Visits the collection literal [node] whose body starts with [leftBracket],
+  /// Visits the construct whose body starts with [leftBracket],
   /// ends with [rightBracket] and contains [elements].
   ///
-  /// This is also used for argument lists with a trailing comma which are
-  /// considered "collection-like". In that case, [node] is `null`.
-  void _visitCollectionLiteral(Literal? node, Token leftBracket,
-      List<AstNode> elements, Token rightBracket,
-      [int? cost]) {
-    if (node is TypedLiteral) {
-      // See if `const` should be removed.
-      if (node.constKeyword != null &&
-          _constNesting > 0 &&
-          _formatter.fixes.contains(StyleFix.optionalConst)) {
-        // Don't lose comments before the discarded keyword, if any.
-        writePrecedingCommentsAndNewlines(node.constKeyword!);
-      } else {
-        modifier(node.constKeyword);
+  /// This is used for collection literals, collection patterns, and argument
+  /// lists with a trailing comma which are considered "collection-like".
+  ///
+  /// If [splitOuterCollection] is `true` then this collection forces any
+  /// surrounding collections to split even if this one doesn't. We do this for
+  /// collection literals, but not other collection-like constructs.
+  void _visitCollectionLiteral(
+      Token leftBracket, List<AstNode> elements, Token rightBracket,
+      {Token? constKeyword,
+      TypeArgumentList? typeArguments,
+      int? cost,
+      bool splitOuterCollection = false,
+      bool isRecord = false}) {
+    // See if `const` should be removed.
+    if (constKeyword != null &&
+        _constNesting > 0 &&
+        _formatter.fixes.contains(StyleFix.optionalConst)) {
+      // Don't lose comments before the discarded keyword, if any.
+      writePrecedingCommentsAndNewlines(constKeyword);
+    } else {
+      modifier(constKeyword);
+    }
+
+    // Don't use the normal type argument list formatting code because we don't
+    // want to allow splitting before the "<" since there is no preceding
+    // identifier and it looks weird to have a "<" hanging by itself. Prevents:
+    //
+    //   var list = <
+    //       LongTypeName<
+    //           TypeArgument,
+    //           TypeArgument>>[];
+    if (typeArguments != null) {
+      builder.startSpan();
+      builder.nestExpression();
+      token(typeArguments.leftBracket);
+      builder.startRule(Rule(Cost.typeArgument));
+
+      for (var typeArgument in typeArguments.arguments) {
+        visit(typeArgument);
+
+        // Write the comma separator.
+        if (typeArgument != typeArguments.arguments.last) {
+          var comma = typeArgument.endToken.next;
+
+          // TODO(rnystrom): There is a bug in analyzer where the end token of a
+          // nullable record type is the ")" and not the "?". This works around
+          // that. Remove that's fixed.
+          if (comma?.lexeme == '?') comma = comma?.next;
+
+          token(comma);
+          split();
+        }
       }
 
-      visit(node.typeArguments);
+      token(typeArguments.rightBracket);
+      builder.endRule();
+      builder.unnest();
+      builder.endSpan();
     }
 
     // Handle empty collections, with or without comments.
@@ -3236,7 +3341,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     }
 
     // Unlike other collections, records don't force outer ones to split.
-    if (node is! RecordLiteral) {
+    if (splitOuterCollection) {
       // Force all of the surrounding collections to split.
       _collectionSplits.fillRange(0, _collectionSplits.length, true);
 
@@ -3245,7 +3350,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     }
 
     _beginBody(leftBracket);
-    if (node is TypedLiteral) _startPossibleConstContext(node.constKeyword);
+    _startPossibleConstContext(constKeyword);
 
     // If a collection contains a line comment, we assume it's a big complex
     // blob of data with some documented structure. In that case, the user
@@ -3285,20 +3390,19 @@ class SourceVisitor extends ThrowingAstVisitor {
       }
     }
 
-    var force = false;
-
     // If there is a collection inside this one, it forces this one to split.
-    if (node is! RecordLiteral) {
+    var force = false;
+    if (splitOuterCollection) {
       force = _collectionSplits.removeLast();
     }
 
     // If the collection has a trailing comma, the user must want it to split.
     // (Unless it's a single-element record literal, in which case the trailing
     // comma is required for disambiguation.)
-    var isSingleElementRecord = node is RecordLiteral && elements.length == 1;
+    var isSingleElementRecord = isRecord && elements.length == 1;
     if (elements.hasCommaAfter && !isSingleElementRecord) force = true;
 
-    if (node is TypedLiteral) _endPossibleConstContext(node.constKeyword);
+    _endPossibleConstContext(constKeyword);
     _endBody(rightBracket, forceSplit: force);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  analyzer: ^5.2.0
+  analyzer: ^5.4.0
   args: ">=1.0.0 <3.0.0"
   path: ^1.0.0
   pub_semver: ">=1.4.4 <3.0.0"

--- a/test/comments/patterns.stmt
+++ b/test/comments/patterns.stmt
@@ -183,3 +183,128 @@ if (obj
         x) {
   ;
 }
+>>> indent line comment inside list
+if (obj case [
+ // c
+]) {;}
+<<<
+if (obj
+    case [
+      // c
+    ]) {
+  ;
+}
+>>> line comment on opening line of list
+if (obj case [// c
+]) {;}
+<<<
+if (obj
+    case [
+      // c
+    ]) {
+  ;
+}
+>>> indented block comment in list
+if (obj case [
+  /* comment */
+]){;}
+<<<
+if (obj
+    case [
+      /* comment */
+    ]) {
+  ;
+}
+>>> inline block comment in list
+if (obj case [  /* comment */  e  ]){;}
+<<<
+if (obj case [/* comment */ e]) {
+  ;
+}
+>>> line comment between list items
+if (obj case ['a', // comment
+  'b']){;}
+<<<
+if (obj
+    case [
+      'a', // comment
+      'b'
+    ]) {
+  ;
+}
+>>> indent line comment inside map
+if (obj case {
+ // c
+}) {;}
+<<<
+if (obj
+    case {
+      // c
+    }) {
+  ;
+}
+>>> line comment on opening line of map
+if (obj case {// c
+}) {;}
+<<<
+if (obj
+    case {
+      // c
+    }) {
+  ;
+}
+>>> indented block comment in map
+if (obj case {
+  /* comment */
+}){;}
+<<<
+if (obj
+    case {
+      /* comment */
+    }) {
+  ;
+}
+>>> inline block comment in map
+if (obj case {  /* comment */  k: v  }){;}
+<<<
+if (obj case {/* comment */ k: v}) {
+  ;
+}
+>>> line comment between map items
+if (obj case {k: 'a', // comment
+  m: 'b'}){;}
+<<<
+if (obj
+    case {
+      k: 'a', // comment
+      m: 'b'
+    }) {
+  ;
+}
+>>> empty record pattern block comment
+if (obj case (  /* comment */  )) {;}
+<<<
+if (obj case (/* comment */)) {
+  ;
+}
+>>> empty record pattern line comment
+if (obj case (  // comment
+)) {;}
+<<<
+if (obj
+    case (
+      // comment
+    )) {
+  ;
+}
+>>> record line comment between fields
+if (obj case ( first , // comment
+second)){;}
+<<<
+if (obj
+    case (
+      first, // comment
+      second
+    )) {
+  ;
+}

--- a/test/regression/other/misc.unit
+++ b/test/regression/other/misc.unit
@@ -16,3 +16,22 @@ main() {
           args: ["publish", "-f"], description: "Publishes a New Version"),
       dependencies: ["version"]);
 }
+>>>
+Widget build() {
+  var text = textData;
+  <AccountValue,
+      Function>{
+    AccountValue.start: () {
+      ;
+    },
+  };
+}
+<<<
+Widget build() {
+  var text = textData;
+  <AccountValue, Function>{
+    AccountValue.start: () {
+      ;
+    },
+  };
+}

--- a/test/splitting/list_arguments.stmt
+++ b/test/splitting/list_arguments.stmt
@@ -477,3 +477,18 @@ function([
     .method()
     .method()
     .method();
+>>> don't allow splitting between name and list
+longFunctionName(argument, argument, argument, argument, argument, argument, argumentName: [element, element, element]);
+<<<
+longFunctionName(
+    argument,
+    argument,
+    argument,
+    argument,
+    argument,
+    argument,
+    argumentName: [
+      element,
+      element,
+      element
+    ]);

--- a/test/splitting/map_arguments.stmt
+++ b/test/splitting/map_arguments.stmt
@@ -239,3 +239,18 @@ function({
     .method()
     .method()
     .method();
+>>> don't allow splitting between name and list
+longFunctionName(argument, argument, argument, argument, argument, argument, argumentName: {a: element, b: element, c: element});
+<<<
+longFunctionName(
+    argument,
+    argument,
+    argument,
+    argument,
+    argument,
+    argument,
+    argumentName: {
+      a: element,
+      b: element,
+      c: element
+    });

--- a/test/splitting/patterns.stmt
+++ b/test/splitting/patterns.stmt
@@ -303,6 +303,25 @@ if (obj
     )) {
   ;
 }
+>>> split single-element record with inferred name
+if (obj case (:var veryLongInferredFieldName_____)) {;}
+<<<
+if (obj
+    case (
+      :var veryLongInferredFieldName_____
+    )) {
+  ;
+}
+>>> split before inferred field name
+if (obj case (:var firstLongInferredFieldName, :var secondLongInferredName)) {;}
+<<<
+if (obj
+    case (
+      :var firstLongInferredFieldName,
+      :var secondLongInferredName
+    )) {
+  ;
+}
 >>> don't split between name and list subpattern
 if (obj case (longFieldName: [first, second, third])) {;}
 <<<

--- a/test/splitting/patterns.stmt
+++ b/test/splitting/patterns.stmt
@@ -112,3 +112,369 @@ if (obj
         longVariableName) {
   ;
 }
+>>> unsplit list
+if (obj case [1, ...var x, 3]) {;}
+<<<
+if (obj case [1, ...var x, 3]) {
+  ;
+}
+>>> if it splits anywhere, it splits at every element
+if (obj case [first,second,third,fourth]) {;}
+<<<
+if (obj
+    case [
+      first,
+      second,
+      third,
+      fourth
+    ]) {
+  ;
+}
+>>> split in element forces list to split
+if (obj case [first,secondLongPattern ||thirdLongPattern]) {;}
+<<<
+if (obj
+    case [
+      first,
+      secondLongPattern ||
+          thirdLongPattern
+    ]) {
+  ;
+}
+>>> a trailing comma forces a split
+if (obj case [1,]) {;}
+<<<
+if (obj
+    case [
+      1,
+    ]) {
+  ;
+}
+>>> does not split after "..."
+if (obj case [...firstPattern || secondLongPattern]) {;}
+<<<
+if (obj
+    case [
+      ...firstPattern ||
+          secondLongPattern
+    ]) {
+  ;
+}
+>>> nested list patterns don't force outer to split
+if (obj case [[1, 2], [[3]]]) {;}
+<<<
+if (obj case [[1, 2], [[3]]]) {
+  ;
+}
+>>> list constant in list pattern doesn't force pattern to split
+if (obj case [const [1, 2]]) {;}
+<<<
+if (obj case [const [1, 2]]) {
+  ;
+}
+>>> preserve newlines in list containing a line comment
+if (obj case [
+  // yeah
+  a,b,c,
+  d,e,f,
+]) {;}
+<<<
+if (obj
+    case [
+      // yeah
+      a, b, c,
+      d, e, f,
+    ]) {
+  ;
+}
+>>> split in type argument but not body
+if (obj case <Map<VeryLongTypeArgument, VeryLongTypeArgument>>[e]) {;}
+<<<
+if (obj
+    case <Map<VeryLongTypeArgument,
+        VeryLongTypeArgument>>[e]) {
+  ;
+}
+>>> split in type argument and body
+if (obj case <Map<VeryLongTypeArgument, VeryLongTypeArgument>>[element]) {;}
+<<<
+if (obj
+    case <Map<VeryLongTypeArgument,
+        VeryLongTypeArgument>>[
+      element
+    ]) {
+  ;
+}
+>>> unsplit map
+if (obj case {k: 1, m: 3, ...}) {;}
+<<<
+if (obj case {k: 1, m: 3, ...}) {
+  ;
+}
+>>> if it splits anywhere, it splits at every element
+if (obj case {first: 1,second: 2,third: 3}) {;}
+<<<
+if (obj
+    case {
+      first: 1,
+      second: 2,
+      third: 3
+    }) {
+  ;
+}
+>>> split in value forces map to split
+if (obj case {k: first, m: secondLongPattern ||thirdLongPattern}) {;}
+<<<
+if (obj
+    case {
+      k: first,
+      m: secondLongPattern ||
+          thirdLongPattern
+    }) {
+  ;
+}
+>>> a trailing comma forces a split
+if (obj case {k:1,}) {;}
+<<<
+if (obj
+    case {
+      k: 1,
+    }) {
+  ;
+}
+>>> nested map patterns don't force outer to split
+if (obj case {a: {k: 1}, m: [{k: 3}]}) {;}
+<<<
+if (obj case {a: {k: 1}, m: [{k: 3}]}) {
+  ;
+}
+>>> map constant in map pattern doesn't force pattern to split
+if (obj case {k: const {1: 2}}) {;}
+<<<
+if (obj case {k: const {1: 2}}) {
+  ;
+}
+>>> preserve newlines in maps containing a line comment
+if (obj case {
+  // yeah
+  a:1,b:2,c:3,
+  d:4,e:5,f:6,
+}) {;}
+<<<
+if (obj
+    case {
+      // yeah
+      a: 1, b: 2, c: 3,
+      d: 4, e: 5, f: 6,
+    }) {
+  ;
+}
+>>> single-element records don't have to split
+if (obj case (pattern,)) {;}
+<<<
+if (obj case (pattern,)) {
+  ;
+}
+>>> single-element records can split after ","
+if (obj case (veryLongRecordField____________,)) {;}
+<<<
+if (obj
+    case (
+      veryLongRecordField____________,
+    )) {
+  ;
+}
+>>> split single-element named record
+if (obj case (longFieldName: longRecordFieldValu)) {;}
+<<<
+if (obj
+    case (
+      longFieldName: longRecordFieldValu
+    )) {
+  ;
+}
+>>> split single-element named record at name
+if (obj case (longFieldName: veryLongRecordFieldValue)) {;}
+<<<
+if (obj
+    case (
+      longFieldName:
+          veryLongRecordFieldValue
+    )) {
+  ;
+}
+>>> don't split between name and list subpattern
+if (obj case (longFieldName: [first, second, third])) {;}
+<<<
+if (obj
+    case (
+      longFieldName: [
+        first,
+        second,
+        third
+      ]
+    )) {
+  ;
+}
+>>> don't split between name and map subpattern
+if (obj case (longFieldName: {first: 1, second: 2})) {;}
+<<<
+if (obj
+    case (
+      longFieldName: {
+        first: 1,
+        second: 2
+      }
+    )) {
+  ;
+}
+>>> don't split between name and record subpattern
+if (obj case (longFieldName: (first: 1, second: 2))) {;}
+<<<
+if (obj
+    case (
+      longFieldName: (
+        first: 1,
+        second: 2
+      )
+    )) {
+  ;
+}
+>>> don't split between name and constant list
+if (obj case (longFieldName: const [first, second, third])) {;}
+<<<
+if (obj
+    case (
+      longFieldName: const [
+        first,
+        second,
+        third
+      ]
+    )) {
+  ;
+}
+>>> don't split between name and constant map
+if (obj case (longFieldName: const {first: 1, second: 2})) {;}
+<<<
+if (obj
+    case (
+      longFieldName: const {
+        first: 1,
+        second: 2
+      }
+    )) {
+  ;
+}
+>>> don't split between name and const record
+if (obj case (longFieldName: const (first: 1, second: 2))) {;}
+<<<
+if (obj
+    case (
+      longFieldName: const (
+        first: 1,
+        second: 2
+      )
+    )) {
+  ;
+}
+>>> if any field splits, all do
+if (obj case (first, second, third, fourth, fifth)) {;}
+<<<
+if (obj
+    case (
+      first,
+      second,
+      third,
+      fourth,
+      fifth
+    )) {
+  ;
+}
+>>> don't force outer record to split
+if (obj case ((a,), (b, c))) {;}
+<<<
+if (obj case ((a,), (b, c))) {
+  ;
+}
+>>> nested split record
+if (obj case (first, (second, third, fourth), fifth, (sixth, seventh, eighth, nine, tenth,
+    eleventh))) {;}
+<<<
+if (obj
+    case (
+      first,
+      (second, third, fourth),
+      fifth,
+      (
+        sixth,
+        seventh,
+        eighth,
+        nine,
+        tenth,
+        eleventh
+      )
+    )) {
+  ;
+}
+>>> preserve newlines in records containing a line comment
+if (obj case (
+  // yeah
+  a,b,c,
+  d,e,f,
+)) {;}
+<<<
+if (obj
+    case (
+      // yeah
+      a, b, c,
+      d, e, f,
+    )) {
+  ;
+}
+>>> split list constant in pattern
+if (obj case const [element, element, element, element]) {;}
+<<<
+if (obj
+    case const [
+      element,
+      element,
+      element,
+      element
+    ]) {
+  ;
+}
+>>> split map constant in pattern
+if (obj case const {a: element, b: element, c: element}) {;}
+<<<
+if (obj
+    case const {
+      a: element,
+      b: element,
+      c: element
+    }) {
+  ;
+}
+>>> split set constant in pattern
+if (obj case const {element, element, element, element}) {;}
+<<<
+if (obj
+    case const {
+      element,
+      element,
+      element,
+      element
+    }) {
+  ;
+}
+>>> split record constant in pattern
+if (obj case const (element, element, element, element)) {;}
+<<<
+if (obj
+    case const (
+      element,
+      element,
+      element,
+      element
+    )) {
+  ;
+}

--- a/test/splitting/records.stmt
+++ b/test/splitting/records.stmt
@@ -171,3 +171,28 @@ longFunctionName(
       element,
       element
     ));
+>>> don't allow splitting between field name and record
+var record = (argument, argument, argument, recordFieldName: (veryLongElement__________,));
+<<<
+var record = (
+  argument,
+  argument,
+  argument,
+  recordFieldName: (
+    veryLongElement__________,
+  )
+);
+>>> don't allow splitting between argument name and record
+longFunctionName(argument, argument, argument, argument, argument, argument,
+argumentName: (veryLongElement__________,));
+<<<
+longFunctionName(
+    argument,
+    argument,
+    argument,
+    argument,
+    argument,
+    argument,
+    argumentName: (
+      veryLongElement__________,
+    ));

--- a/test/splitting/sets.stmt
+++ b/test/splitting/sets.stmt
@@ -205,3 +205,18 @@ var set = {
   }(),
   4
 };
+>>> don't allow splitting between argument name and set
+longFunctionName(argument, argument, argument, argument, argument, argument, argumentName: {element, element, element});
+<<<
+longFunctionName(
+    argument,
+    argument,
+    argument,
+    argument,
+    argument,
+    argument,
+    argumentName: {
+      element,
+      element,
+      element
+    });

--- a/test/splitting/type_arguments.stmt
+++ b/test/splitting/type_arguments.stmt
@@ -134,3 +134,29 @@ LongClassName<
     Inner<Second, Third, Fourth, Fifth,
         Sixth, Seventh>,
     Eighth>;
+>>> split in inner type argument list forces outer to split
+LongClassName<First, Inner<
+    Second, Third, Fourth, Fifth>>;
+<<<
+LongClassName<
+    First,
+    Inner<Second, Third, Fourth,
+        Fifth>>;
+>>> don't split after "<" in list literal
+var list = <Inner<First, Second, Third, Fourth, Fifth>, Sixth>[];
+<<<
+var list = <Inner<First, Second, Third,
+        Fourth, Fifth>,
+    Sixth>[];
+>>> don't split after "<" in set literal
+var set = <Inner<First, Second, Third, Fourth, Fifth>, Sixth>{};
+<<<
+var set = <Inner<First, Second, Third,
+        Fourth, Fifth>,
+    Sixth>{};
+>>> don't split after "<" in map literal
+var map = <First, Inner<Second, Third, Fourth, Fifth, Sixth>>{};
+<<<
+var map = <First,
+    Inner<Second, Third, Fourth, Fifth,
+        Sixth>>{};

--- a/test/whitespace/patterns.stmt
+++ b/test/whitespace/patterns.stmt
@@ -105,3 +105,97 @@ switch (obj) {
   case final (int, String) name:
     ok;
 }
+>>> list
+switch (obj) {
+case  [  ]  :
+case  <  int  >  [  ]  :
+case  [  _  ]  :
+case  [  _  ,  ]  :
+case  [  _  ,  _  ]  :
+case  [  ...  ]  :
+case  [  ...  _  ]  :
+case  [  _  ,  ...  ]  :
+case  [  ...  ,  _  ]  :
+case  [  ...  ,  ]  :
+  ok;
+}
+<<<
+switch (obj) {
+  case []:
+  case <int>[]:
+  case [_]:
+  case [
+      _,
+    ]:
+  case [_, _]:
+  case [...]:
+  case [..._]:
+  case [_, ...]:
+  case [..., _]:
+  case [
+      ...,
+    ]:
+    ok;
+}
+>>> map
+switch (obj) {
+case  {  }  :
+case  <  int  ,  String  >  {  }  :
+case  {  k  :  _  }  :
+case  {  k  :  _  ,  }  :
+case  {  k  :  1  ,  m  :  2  }  :
+case  {  ...  }  :
+case  {  k  :  _  ,  ...  }  :
+  ok;
+}
+<<<
+switch (obj) {
+  case {}:
+  case <int, String>{}:
+  case {k: _}:
+  case {
+      k: _,
+    }:
+  case {k: 1, m: 2}:
+  case {...}:
+  case {k: _, ...}:
+    ok;
+}
+>>> record
+switch (obj) {
+  case  (  )  :
+  case  (  value  ,  )  :
+  case  (  first  ,  second  ,  third  )  :
+  case  (  first  :  1  ,  2  ,  third  :  3  )  :
+}
+<<<
+switch (obj) {
+  case ():
+  case (value,):
+  case (first, second, third):
+  case (first: 1, 2, third: 3):
+}
+>>> constant collections
+switch (obj) {
+case  const  [  ]  :
+case  const  <  int  >  [  ]  :
+case  const  [  1  ,  2  ]  :
+case  const  {  }  :
+case  const  <  int  >  {  }  :
+case  const  {  1  ,  2  }  :
+case  const  <  int  ,  String  >  {  }  :
+case  const  {  1  :  's'  ,  2  :  't'  }  :
+  ok;
+}
+<<<
+switch (obj) {
+  case const []:
+  case const <int>[]:
+  case const [1, 2]:
+  case const {}:
+  case const <int>{}:
+  case const {1, 2}:
+  case const <int, String>{}:
+  case const {1: 's', 2: 't'}:
+    ok;
+}

--- a/test/whitespace/patterns.stmt
+++ b/test/whitespace/patterns.stmt
@@ -167,6 +167,7 @@ switch (obj) {
   case  (  value  ,  )  :
   case  (  first  ,  second  ,  third  )  :
   case  (  first  :  1  ,  2  ,  third  :  3  )  :
+  case  (  :  var  x  ,  :  var  y  )  :
 }
 <<<
 switch (obj) {
@@ -174,6 +175,7 @@ switch (obj) {
   case (value,):
   case (first, second, third):
   case (first: 1, 2, third: 3):
+  case (:var x, :var y):
 }
 >>> constant collections
 switch (obj) {


### PR DESCRIPTION
Also test list, map, set, and record constants inside patterns.

In the process of working on this, I noticed that the formatting for collection literal type arguments isn't ideal. In rare cases, it would split after the initial "<", which looks totally broken. I fixed that here too. I'd normally pull that out into a separate PR but it's mixed in with the other changes to _visitCollectionLiteral() so that would be hard.

Also added some more tests around avoiding splitting between a named argument and a subsequent collection literal. The code was there to handle it but it wasn't tested well. (It's hard to come up with an example that hits that exact code path without formatting correctly for other reasons.)