### PR TITLE
Format object patterns, const constructors, and constant expressions.

### DIFF
--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2290,6 +2290,38 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
+  void visitObjectPattern(ObjectPattern node) {
+    // Even though object patterns syntactically resemble constructor or
+    // function calls, we format them like collections (or like argument lists
+    // with trailing commas). In other words, like this:
+    //
+    //     case Foo(
+    //         first: 1,
+    //         second: 2,
+    //         third: 3
+    //       ):
+    //       body;
+    //
+    // Not like:
+    //
+    //     case Foo(
+    //           first: 1,
+    //           second: 2,
+    //           third: 3):
+    //       body;
+    //
+    // This is less consistent with the corresponding expression form, but is
+    // more consistent with all of the other delimited patterns -- list, map,
+    // and record -- which have collection-like formatting.
+    // TODO(rnystrom): If we move to consistently using collection-like
+    // formatting for all argument lists, then this will all be consistent and
+    // this comment should be removed.
+    visit(node.type);
+    _visitCollectionLiteral(
+        node.leftParenthesis, node.fields, node.rightParenthesis);
+  }
+
+  @override
   void visitOnClause(OnClause node) {
     _visitCombinator(node.onKeyword, node.superclassConstraints);
   }

--- a/test/comments/patterns.stmt
+++ b/test/comments/patterns.stmt
@@ -308,3 +308,67 @@ if (obj
     )) {
   ;
 }
+>>> empty object pattern block comment
+if (obj case Foo(  /* comment */  )) {;}
+<<<
+if (obj case Foo(/* comment */)) {
+  ;
+}
+>>> empty object pattern line comment (looks weird, but user should move comment)
+if (obj case Foo(  // comment
+)) {;}
+<<<
+if (obj
+    case Foo(
+      // comment
+    )) {
+  ;
+}
+>>> object line comment between arguments
+if (obj case Foo( first , // comment
+second)){;}
+<<<
+if (obj
+    case Foo(
+      first, // comment
+      second
+    )) {
+  ;
+}
+>>> empty const constructor line comment (looks weird, but user should move comment)
+if (obj case const Foo(  // comment
+)) {;}
+<<<
+if (obj
+    case const Foo(// comment
+        )) {
+  ;
+}
+>>> const constructor line comment between arguments
+if (obj case const Foo( first , // comment
+second)){;}
+<<<
+if (obj
+    case const Foo(
+        first, // comment
+        second)) {
+  ;
+}
+>>> after "(" in parenthesized constant
+if (obj case const ( // comment
+expression)){;}
+<<<
+if (obj
+    case const ( // comment
+        expression)) {
+  ;
+}
+>>> after expression in parenthesized constant (looks weird, but user should move comment)
+if (obj case const ( expression // comment
+)){;}
+<<<
+if (obj
+    case const (expression // comment
+        )) {
+  ;
+}

--- a/test/splitting/arguments.stmt
+++ b/test/splitting/arguments.stmt
@@ -347,3 +347,15 @@ fn(
   name: argument,
   argument,
 );
+>>> preserve line breaks in trailing comma argument list with line comment
+function(// yeah
+first, second, third,
+fourth, fifth,
+sixth,);
+<<<
+function(
+  // yeah
+  first, second, third,
+  fourth, fifth,
+  sixth,
+);

--- a/test/splitting/patterns.stmt
+++ b/test/splitting/patterns.stmt
@@ -497,3 +497,220 @@ if (obj
     )) {
   ;
 }
+>>> split constant constructor in pattern
+if (obj case const Foo(element, element, element, element)) {;}
+<<<
+if (obj
+    case const Foo(element, element,
+        element, element)) {
+  ;
+}
+>>> single-element objects with trailing commas split
+if (obj case Foo(:pattern,)) {;}
+<<<
+if (obj
+    case Foo(
+      :pattern,
+    )) {
+  ;
+}
+>>> split single-element object
+if (obj case Foo(longFieldName: longObjectFieldValu)) {;}
+<<<
+if (obj
+    case Foo(
+      longFieldName: longObjectFieldValu
+    )) {
+  ;
+}
+>>> split field at name
+if (obj case Foo(longFieldName: veryLongObjectFieldValue)) {;}
+<<<
+if (obj
+    case Foo(
+      longFieldName:
+          veryLongObjectFieldValue
+    )) {
+  ;
+}
+>>> split single-element object with inferred name
+if (obj case Foo(:var veryLongInferredFieldName_____)) {;}
+<<<
+if (obj
+    case Foo(
+      :var veryLongInferredFieldName_____
+    )) {
+  ;
+}
+>>> split before inferred field name
+if (obj case Foo(:var firstLongInferredFieldName, :var secondLongInferredName)) {;}
+<<<
+if (obj
+    case Foo(
+      :var firstLongInferredFieldName,
+      :var secondLongInferredName
+    )) {
+  ;
+}
+>>> don't split between name and list subpattern
+if (obj case Foo(longFieldName: [first, second, third])) {;}
+<<<
+if (obj
+    case Foo(
+      longFieldName: [
+        first,
+        second,
+        third
+      ]
+    )) {
+  ;
+}
+>>> don't split between name and map subpattern
+if (obj case Foo(longFieldName: {first: 1, second: 2})) {;}
+<<<
+if (obj
+    case Foo(
+      longFieldName: {
+        first: 1,
+        second: 2
+      }
+    )) {
+  ;
+}
+>>> don't split between name and record subpattern
+if (obj case Foo(longFieldName: (first: 1, second: 2))) {;}
+<<<
+if (obj
+    case Foo(
+      longFieldName: (
+        first: 1,
+        second: 2
+      )
+    )) {
+  ;
+}
+>>> don't split between name and constant list
+if (obj case Foo(longFieldName: const [first, second, third])) {;}
+<<<
+if (obj
+    case Foo(
+      longFieldName: const [
+        first,
+        second,
+        third
+      ]
+    )) {
+  ;
+}
+>>> don't split between name and constant map
+if (obj case Foo(longFieldName: const {first: 1, second: 2})) {;}
+<<<
+if (obj
+    case Foo(
+      longFieldName: const {
+        first: 1,
+        second: 2
+      }
+    )) {
+  ;
+}
+>>> don't split between name and const record
+if (obj case Foo(longFieldName: const (first: 1, second: 2))) {;}
+<<<
+if (obj
+    case Foo(
+      longFieldName: const (
+        first: 1,
+        second: 2
+      )
+    )) {
+  ;
+}
+>>> if any field splits, all do
+if (obj case Foo(first, second, third, fourth, fifth)) {;}
+<<<
+if (obj
+    case Foo(
+      first,
+      second,
+      third,
+      fourth,
+      fifth
+    )) {
+  ;
+}
+>>> don't force outer object to split
+if (obj case Foo(Bar(a: 1, b: 2))) {;}
+<<<
+if (obj case Foo(Bar(a: 1, b: 2))) {
+  ;
+}
+>>> don't force outer record to split
+if (obj case (Foo(a: 1), Bar(b: 2))) {;}
+<<<
+if (obj case (Foo(a: 1), Bar(b: 2))) {
+  ;
+}
+>>> nested split object
+if (obj case Foo(first: 1, Bar(second: 2, third: 3, four: 4), fifth: 5, Baz(sixth: 6, seventh: 7, eighth: 8, nine: 9, tenth: 10,
+    eleventh: 11))) {;}
+<<<
+if (obj
+    case Foo(
+      first: 1,
+      Bar(second: 2, third: 3, four: 4),
+      fifth: 5,
+      Baz(
+        sixth: 6,
+        seventh: 7,
+        eighth: 8,
+        nine: 9,
+        tenth: 10,
+        eleventh: 11
+      )
+    )) {
+  ;
+}
+>>> preserve newlines in objects containing a line comment
+if (obj case Foo(
+  // yeah
+  a:1,b:2,c:3,
+  d:4,e:5,f:6,
+)) {;}
+<<<
+if (obj
+    case Foo(
+      // yeah
+      a: 1, b: 2, c: 3,
+      d: 4, e: 5, f: 6,
+    )) {
+  ;
+}
+>>> split in type argument
+if (obj case LongClassName<First, Second>()) {;}
+<<<
+if (obj
+    case LongClassName<First,
+        Second>()) {
+  ;
+}
+>>> split in type argument and body
+if (obj case LongClassName<First, Second, Third>(first: 1, second: 2, third: 3)) {;}
+<<<
+if (obj
+    case LongClassName<First, Second,
+        Third>(
+      first: 1,
+      second: 2,
+      third: 3
+    )) {
+  ;
+}
+>>> split in parenthesized constant expression
+if (obj case const(longArgument + anotherArgument)) {;}
+<<<
+if (obj
+    case const (longArgument +
+        anotherArgument)) {
+  ;
+}

--- a/test/whitespace/patterns.stmt
+++ b/test/whitespace/patterns.stmt
@@ -177,6 +177,28 @@ switch (obj) {
   case (first: 1, 2, third: 3):
   case (:var x, :var y):
 }
+>>> object
+switch (obj) {
+case  Foo  (  )  :
+case  Foo  (  getter  :  pattern  )  :
+case  Foo  (  getter  :  pattern  ,  )  :
+case  Foo  (  a  :  1  ,  b  :  2  ,  c  :  3  )  :
+case  Foo  (  :  var  x  ,  :  var  y  )  :
+case  Foo  <  int  ,  String  >  (  :  var  x  ,  :  var  y  )  :
+ok;
+}
+<<<
+switch (obj) {
+  case Foo():
+  case Foo(getter: pattern):
+  case Foo(
+      getter: pattern,
+    ):
+  case Foo(a: 1, b: 2, c: 3):
+  case Foo(:var x, :var y):
+  case Foo<int, String>(:var x, :var y):
+    ok;
+}
 >>> constant collections
 switch (obj) {
 case  const  [  ]  :
@@ -199,5 +221,37 @@ switch (obj) {
   case const {1, 2}:
   case const <int, String>{}:
   case const {1: 's', 2: 't'}:
+    ok;
+}
+>>> constant constructor
+switch (obj) {
+case  const  Foo  (  )  :
+case  const  Foo  (  field  ,  another  )  :
+case  const  Foo  (  field  :  value  )  :
+case  const  Foo  (  field  :  value  ,  )  :
+case  const  Foo  <  int  ,  String  >  (  field  )  :
+ok;
+}
+<<<
+switch (obj) {
+  case const Foo():
+  case const Foo(field, another):
+  case const Foo(field: value):
+  case const Foo(
+      field: value,
+    ):
+  case const Foo<int, String>(field):
+    ok;
+}
+>>> parenthesized constant expression
+switch (obj) {
+case  const  (  1  )  :
+case  const  (  -  foo  *  bar  )  :
+ok;
+}
+<<<
+switch (obj) {
+  case const (1):
+  case const (-foo * bar):
     ok;
 }


### PR DESCRIPTION
The latter two were already implemented as part of keeping the existing switch tests passing, but this adds tests for their splitting and other behavior.

For object patterns, I had to decide whether to split them like collections (like other patterns) or like argument lists (which they mirror). I went collection-like because they will appear mixed with other patterns. Also, if we migrate to a consistent flutter-like style at some point, it will be one less thing to change.

Let me know what you think.