### PR TITLE
Add some more tests to pin down comment indentation in switches.

### DIFF
--- a/test/comments/switch.stmt
+++ b/test/comments/switch.stmt
@@ -55,7 +55,39 @@ switch (n) {
   case 1: one; // comment
   case 2: two; // comment
 }
->>> keeps one blank line around  case comments in switch expression
+>>> line comment indentation
+switch (n) {
+  // before first
+  case 0: zero;
+  // between
+  case 1: one;
+  // after last
+}
+<<<
+switch (n) {
+  // before first
+  case 0: zero;
+  // between
+  case 1: one;
+  // after last
+}
+>>> line comment in empty cases
+switch (n) {
+  case 0: // comment 0
+  case 1:
+    // comment 1
+  case 2:
+    // comment 2
+}
+<<<
+switch (n) {
+  case 0: // comment 0
+  case 1:
+  // comment 1
+  case 2:
+  // comment 2
+}
+>>> keeps one blank line around case comments in switch expression
 e = switch (n) {
 
 


### PR DESCRIPTION
I spent a bunch of time investigating whether comments in switches that aren't inside a case body (i.e. not between the "case" line and some statement inside the case) should be indented to align with the cases or the bodies.

After trying a bunch of alternatives and running them on a big corpus, I concluded that the current behavior (always align to the cases) actually works very well in almost all real-world code. But it's not pinned down well by tests, so this does that.