### PR TITLE
Don't crash on switches with empty trailing cases.

### DIFF
--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -114,10 +114,8 @@ class Chunk extends Selection {
 
   /// Whether this chunk marks the end of a range of chunks that can be line
   /// split independently of the following chunks.
-  ///
-  /// You must call markDivide() before accessing this.
   bool get canDivide => _canDivide;
-  late final bool _canDivide;
+  late bool _canDivide = true;
 
   /// The number of characters in this chunk when unsplit.
   int get length => (_spaceWhenUnsplit ? 1 : 0) + _text.length;
@@ -177,9 +175,12 @@ class Chunk extends Selection {
   /// that [Rule].
   bool indentBlock(int Function(Rule) getValue) => false;
 
-  // Mark whether this chunk can divide the range of chunks.
-  void markDivide(bool canDivide) {
-    _canDivide = canDivide;
+  /// Prevent the line splitter from diving at this chunk.
+  ///
+  /// This should be called on any chunk where line splitting choices before
+  /// and after this chunk relate to each other.
+  void preventDivide() {
+    _canDivide = false;
   }
 
   @override

--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -115,7 +115,7 @@ class Chunk extends Selection {
   /// Whether this chunk marks the end of a range of chunks that can be line
   /// split independently of the following chunks.
   bool get canDivide => _canDivide;
-  late bool _canDivide = true;
+  bool _canDivide = true;
 
   /// The number of characters in this chunk when unsplit.
   int get length => (_spaceWhenUnsplit ? 1 : 0) + _text.length;

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -199,7 +199,8 @@ class DartFormatter {
   // brittle), we just try parsing everything with patterns enabled. When a
   // parse error occurs, we try parsing it again with pattern disabled. If that
   // happens to parse without error, then we use that result instead.
-  ParseStringResult _parse(String source, String? uri, {required bool patterns}) {
+  ParseStringResult _parse(String source, String? uri,
+      {required bool patterns}) {
     // Enable all features that are enabled by default in the current analyzer
     // version.
     var featureSet = FeatureSet.fromEnableFlags2(

--- a/lib/src/debug.dart
+++ b/lib/src/debug.dart
@@ -76,9 +76,6 @@ void dumpChunks(int start, List<Chunk> chunks) {
 
   addSpans(chunks);
 
-  var spans = spanSet.toList();
-  var rules = chunks.map((chunk) => chunk.rule).toSet();
-
   var rows = <List<String>>[];
 
   void addChunk(List<Chunk> chunks, String prefix, int index) {
@@ -108,6 +105,7 @@ void dumpChunks(int start, List<Chunk> chunks) {
     if (rule.isHardened) ruleString += '!';
     row.add(ruleString);
 
+    var rules = chunks.map((chunk) => chunk.rule).toSet();
     var constrainedRules = rule.constrainedRules.toSet().intersection(rules);
     writeIf(
         constrainedRules.isNotEmpty, () => "-> ${constrainedRules.join(" ")}");
@@ -123,6 +121,7 @@ void dumpChunks(int start, List<Chunk> chunks) {
     writeIf(chunk.indent != 0, () => 'indent ${chunk.indent}');
     writeIf(chunk.nesting.indent != 0, () => 'nest ${chunk.nesting}');
 
+    var spans = spanSet.toList();
     if (spans.length <= 20) {
       var spanBars = '';
       for (var span in spans) {

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2834,13 +2834,13 @@ class SourceVisitor extends ThrowingAstVisitor {
 
         // We don't want the split between cases to force them to split.
         caseRule.disableSplitOnInnerRules();
-        oneOrTwoNewlines();
+        oneOrTwoNewlines(preventDivide: true);
       } else {
         // We don't want the split between cases to force them to split.
         caseRule.disableSplitOnInnerRules();
 
         // Don't preserve blank lines between empty cases.
-        newline();
+        builder.writeNewline(preventDivide: true);
       }
     }
 
@@ -3640,7 +3640,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     builder = builder.startBlock();
 
     for (var parameter in parameters.parameters) {
-      newline();
+      builder.writeNewline(preventDivide: true);
       visit(parameter);
       _writeCommaAfter(parameter);
 
@@ -3657,7 +3657,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     var firstDelimiter =
         parameters.rightDelimiter ?? parameters.rightParenthesis;
     if (firstDelimiter.precedingComments != null) {
-      newline();
+      builder.writeNewline(preventDivide: true);
       writePrecedingCommentsAndNewlines(firstDelimiter);
     }
 
@@ -4120,12 +4120,9 @@ class SourceVisitor extends ThrowingAstVisitor {
   /// Allow either one or two newlines to be emitted before the next
   /// non-whitespace token based on whether any blank lines exist in the source
   /// between the last token and the next one.
-  void oneOrTwoNewlines() {
-    if (_linesBeforeNextToken > 1) {
-      twoNewlines();
-    } else {
-      newline();
-    }
+  void oneOrTwoNewlines({bool preventDivide = false}) {
+    builder.writeNewline(
+        isDouble: _linesBeforeNextToken > 1, preventDivide: preventDivide);
   }
 
   /// The number of newlines between the last written token and the next one to

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  analyzer: ^5.5.0
+  analyzer: ^5.6.0
   args: ">=1.0.0 <3.0.0"
   path: ^1.0.0
   pub_semver: ">=1.4.4 <3.0.0"

--- a/test/comments/functions.unit
+++ b/test/comments/functions.unit
@@ -235,3 +235,17 @@ function({
 }) {
   ;
 }
+>>> metadata in trailing comma parameter list splits together even with comment
+function(@Annotation longParameter,
+  // Comment.
+@Annotation @Other @Third longParameter2,) {}
+<<<
+function(
+  @Annotation
+      longParameter,
+  // Comment.
+  @Annotation
+  @Other
+  @Third
+      longParameter2,
+) {}

--- a/test/comments/switch.stmt
+++ b/test/comments/switch.stmt
@@ -87,6 +87,21 @@ switch (n) {
   case 2:
   // comment 2
 }
+>>> bodies all split or don't together even with comment in the middle
+switch (n) {
+  case 0: longBodyExpression + thatForcesSplit;
+  // comment
+  case 1: c;
+}
+<<<
+switch (n) {
+  case 0:
+    longBodyExpression +
+        thatForcesSplit;
+  // comment
+  case 1:
+    c;
+}
 >>> keeps one blank line around case comments in switch expression
 e = switch (n) {
 

--- a/test/regression/1100/1181.stmt
+++ b/test/regression/1100/1181.stmt
@@ -1,0 +1,11 @@
+>>>
+switch (e) {
+  case E.e1:
+    break;
+  case E.e2:
+}
+<<<
+switch (e) {
+  case E.e1: break;
+  case E.e2:
+}


### PR DESCRIPTION
In the process, I came up with a cleaner and faster solution for handling rules that span hard splits.

Fix #1181.