### PR TITLE
Enable support for inline class syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 * Don't split after `<` in collection literals.
 * Format record expressions and record type annotations.
 * Format class modifiers `base`, `final`, `interface`, `mixin`, and `sealed`
-* Better indentation of multiline function types inside type argument lists. 
+* Handle `inline class` syntax.
+* Better indentation of multiline function types inside type argument lists.
 * Require `package:analyzer` `^5.1.0`.
 * Format unnamed libraries.
 * Require Dart 2.18.
@@ -36,7 +37,7 @@
 * Don't allow a line comment in an argument list to cause preceding arguments
   to be misformatted.
 * Remove blank lines after a line comment at the end of a body.
-* Require `package:analyzer` `>=4.4.0 <6.0.0`. 
+* Require `package:analyzer` `>=4.4.0 <6.0.0`.
 
 # 2.2.3
 

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -206,6 +206,7 @@ class DartFormatter {
     var featureSet = FeatureSet.fromEnableFlags2(
       sdkLanguageVersion: Version(2, 19, 0),
       flags: [
+        'inline-class',
         'class-modifiers',
         if (patterns) 'patterns',
         'records',

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -588,6 +588,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     modifier(node.finalKeyword);
     modifier(node.sealedKeyword);
     modifier(node.mixinKeyword);
+    modifier((node as dynamic).inlineKeyword);
     token(node.classKeyword);
     space();
     token(node.name);

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -588,7 +588,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     modifier(node.finalKeyword);
     modifier(node.sealedKeyword);
     modifier(node.mixinKeyword);
-    modifier((node as dynamic).inlineKeyword);
+    modifier(node.inlineKeyword);
     token(node.classKeyword);
     space();
     token(node.name);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  analyzer: ^5.6.0
+  analyzer: ^5.7.0
   args: ">=1.0.0 <3.0.0"
   path: ^1.0.0
   pub_semver: ">=1.4.4 <3.0.0"

--- a/test/whitespace/classes.unit
+++ b/test/whitespace/classes.unit
@@ -244,3 +244,7 @@ abstract mixin class C12 = Object
     with Mixin;
 abstract base mixin class C13 = Object
     with Mixin;
+>>> inline classes
+inline  class C {}
+<<<
+inline class C {}


### PR DESCRIPTION
Quick and dirty draft of the support. Currently we can't access `inlineToken` because public AST API does not expose it. 

We need [this CL](https://dart-review.googlesource.com/c/sdk/+/286180) to land first and then publish analyzer. Once that happens I will bump analyzer version in pubspec and convert this draft PR into a proper PR. 

/cc @munificent 

Fixes #1129