### PR TITLE
Remove support for compact switch statements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
 # 2.3.0-dev
 
+## New language features
+
 * Format patterns and related features.
+* Format record expressions and record type annotations.
+* Format class modifiers `base`, `final`, `interface`, `mixin`, and `sealed`.
+* Format unnamed libraries.
+
+## Bug fixes and style changes
+
 * Handle `sync*` and `async*` functions with `=>` bodies.
-* Allow switch statements where all case bodies are on the same line as the
-  case when they all fit.
 * Fix bug where parameter metadata wouldn't always split when it should.
 * Don't split after `<` in collection literals.
-* Format record expressions and record type annotations.
-* Format class modifiers `base`, `final`, `interface`, `mixin`, and `sealed`
 * Better indentation of multiline function types inside type argument lists. 
+
+## Internal changes
+
 * Use typed `_visitFunctionOrMethodDeclaration` instead of dynamically typed.
 * Fix metadata test to not fail when record syntax makes whitespace between
   metadata annotation names and `(` significant ([sdk#50769][]).

--- a/test/comments/switch.stmt
+++ b/test/comments/switch.stmt
@@ -27,7 +27,8 @@ switch (n) {
 
   // comment
 
-  case 1: body;
+  case 1:
+    body;
 
   // comment
 }
@@ -39,9 +40,11 @@ switch (n) {
 }
 <<<
 switch (n) {
-  case 0: zero;
+  case 0:
+    zero;
   // comment
-  case 1: one;
+  case 1:
+    one;
 }
 >>> line comment at end of statement does not force split
 switch (n) {
@@ -51,9 +54,12 @@ switch (n) {
 }
 <<<
 switch (n) {
-  case 0: zero; // comment
-  case 1: one; // comment
-  case 2: two; // comment
+  case 0:
+    zero; // comment
+  case 1:
+    one; // comment
+  case 2:
+    two; // comment
 }
 >>> line comment indentation
 switch (n) {
@@ -66,9 +72,11 @@ switch (n) {
 <<<
 switch (n) {
   // before first
-  case 0: zero;
+  case 0:
+    zero;
   // between
-  case 1: one;
+  case 1:
+    one;
   // after last
 }
 >>> line comment in empty cases
@@ -86,21 +94,6 @@ switch (n) {
   // comment 1
   case 2:
   // comment 2
-}
->>> bodies all split or don't together even with comment in the middle
-switch (n) {
-  case 0: longBodyExpression + thatForcesSplit;
-  // comment
-  case 1: c;
-}
-<<<
-switch (n) {
-  case 0:
-    longBodyExpression +
-        thatForcesSplit;
-  // comment
-  case 1:
-    c;
 }
 >>> keeps one blank line around case comments in switch expression
 e = switch (n) {

--- a/test/regression/1100/1181.stmt
+++ b/test/regression/1100/1181.stmt
@@ -6,6 +6,7 @@ switch (e) {
 }
 <<<
 switch (e) {
-  case E.e1: break;
+  case E.e1:
+    break;
   case E.e2:
 }

--- a/test/regression/1100/1190.unit
+++ b/test/regression/1100/1190.unit
@@ -1,0 +1,401 @@
+>>> long switches that could be inline should not time out
+AaaaaaaAaaaaaaaaAaaaaaaaAaaaa _aaaAaaaaaaaaAaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
+    AaaaaaAaaaaaaaa aaaaaaAaaaaaaaa, Aaaaaa aaaaaaAaaa, Aaaaaa? aaaaaaaaAaaa) {
+  switch (aaaaaaAaaa) {
+    case aaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaa);
+    case aaaaaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaaaaaaa);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(
+          aaaaaaa?.aaaaaaaaaaAaaaa, aaaaaaaaAaaa, aaaaaaaAaaaaaaaAaaaaa: aaaaa);
+    case aaaAaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaAaaaaaaa);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(aaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa() == true
+              ? aaaaaaa!.aaaaaaaaaaAaaaaAaaaaa
+              : null);
+    case aaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+          aaaaaaa?.aaaAaaAaaaaaaaaaAaaaaAaaaaa() == true
+              ? aaaaaaa!.aaaAaaaaaaaaaAaaaaAaaaaa
+              : null);
+    case aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(aaaaaaa?.aaaAaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa() == true ? aaaaaaa!.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa : null);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaa);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaAaaaaa);
+    case aaaaAaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaaaAaaaaAaaaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaAaaaaAaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa);
+    default:
+      throw AaaaaaaaaaaaaAaaaa(aaaaaaAaaa);
+  }
+}
+<<<
+AaaaaaaAaaaaaaaaAaaaaaaaAaaaa _aaaAaaaaaaaaAaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
+    AaaaaaAaaaaaaaa aaaaaaAaaaaaaaa, Aaaaaa aaaaaaAaaa, Aaaaaa? aaaaaaaaAaaa) {
+  switch (aaaaaaAaaa) {
+    case aaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaa);
+    case aaaaaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaaaaaaa);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaaaaaaaaAaaaa, aaaaaaaaAaaa,
+              aaaaaaaAaaaaaaaAaaaaa: aaaaa);
+    case aaaAaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaAaaaaaaa);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+              aaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa() == true
+                  ? aaaaaaa!.aaaaaaaaaaAaaaaAaaaaa
+                  : null);
+    case aaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+              aaaaaaa?.aaaAaaAaaaaaaaaaAaaaaAaaaaa() == true
+                  ? aaaaaaa!.aaaAaaaaaaaaaAaaaaAaaaaa
+                  : null);
+    case aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+              aaaaaaa?.aaaAaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa() == true
+                  ? aaaaaaa!.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa
+                  : null);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaa);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaAaaaaa);
+    case aaaaAaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaaaAaaaaAaaaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaAaaaaAaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa);
+    default:
+      throw AaaaaaaaaaaaaAaaaa(aaaaaaAaaa);
+  }
+}
+>>>
+AaaaaaaAaaaaaaaaAaaaaaaaAaaaa _aaaAaaaaaaaaAaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
+    AaaaaaAaaaaaaaa aaaaaaAaaaaaaaa, Aaaaaa aaaaaaAaaa, Aaaaaa? aaaaaaaaAaaa) {
+  switch (aaaaaaAaaa) {
+    case aaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaa);
+    case aaaaaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaaaaaaa);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(
+          aaaaaaa?.aaaaaaaaaaAaaaa, aaaaaaaaAaaa, aaaaaaaAaaaaaaaAaaaaa: false);
+    case aaaAaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaAaaaaaaa);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(aaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa() == true
+              ? aaaaaaa!.aaaaaaaaaaAaaaaAaaaaa
+              : null);
+    case aaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+          aaaaaaa?.aaaAaaAaaaaaaaaaAaaaaAaaaaa() == true
+              ? aaaaaaa!.aaaAaaaaaaaaaAaaaaAaaaaa
+              : null);
+    case aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(aaaaaaa?.aaaAaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa() == true ? aaaaaaa!.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa : null);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaa);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaAaaaaa);
+    case aaaaAaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaaaAaaaaAaaaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaAaaaaAaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa);
+    default:
+      throw AaaaaaaaaaaaaAaaaa(aaaaaaAaaa);
+  }
+}
+<<<
+AaaaaaaAaaaaaaaaAaaaaaaaAaaaa _aaaAaaaaaaaaAaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
+    AaaaaaAaaaaaaaa aaaaaaAaaaaaaaa, Aaaaaa aaaaaaAaaa, Aaaaaa? aaaaaaaaAaaa) {
+  switch (aaaaaaAaaa) {
+    case aaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaa);
+    case aaaaaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaaaaaaa);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaaaaaaaaAaaaa, aaaaaaaaAaaa,
+              aaaaaaaAaaaaaaaAaaaaa: false);
+    case aaaAaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaAaaaaaaa);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+              aaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa() == true
+                  ? aaaaaaa!.aaaaaaaaaaAaaaaAaaaaa
+                  : null);
+    case aaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+              aaaaaaa?.aaaAaaAaaaaaaaaaAaaaaAaaaaa() == true
+                  ? aaaaaaa!.aaaAaaaaaaaaaAaaaaAaaaaa
+                  : null);
+    case aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+              aaaaaaa?.aaaAaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa() == true
+                  ? aaaaaaa!.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa
+                  : null);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaa);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaAaaaaa);
+    case aaaaAaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaaaAaaaaAaaaa, aaaaaaaaAaaa);
+    case aaaaaAaaaaAaaaaAaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa);
+    default:
+      throw AaaaaaaaaaaaaAaaaa(aaaaaaAaaa);
+  }
+}
+>>>
+AaaaaaaAaaaaaaaaAaaaaaaaAaaaa
+    _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
+        AaaaaaAaaaaaaaa aaaaaaAaaaaaaaa,
+        Aaaaaa aaaaaaAaaa,
+        Aaaaaa? aaaaaaaaAaaa,
+        {aaaa aaaaaaaAaaaaaaaaaa = false,
+        aaaa aaaaaaaAaaa = false}) {
+  switch (aaaaaaAaaa) {
+    case aaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaa, aaaaaaa?.aaaaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaaaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaaaaaaa, aaaaaaa?.aaaaaaaaaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(
+          aaaaaaaa?.aaaaaaaaaaAaaaa, aaaaaaa?.aaaaaaaaaaAaaaa, aaaaaaaaAaaa!,
+          aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+          aaaaaaaAaaa: aaaaaaaAaaa,
+          aaaaaaaaaaaAaaa: true,
+          aaaaAaaa: true);
+    case aaaAaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaAaaaaAaaaa(aaaaaaaa?.aaaAaaaaaaa, aaaaaaa?.aaaAaaaaaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaaaaaaAaaaaAaaaaa, aaaaaaa?.aaaaaaaaaaAaaaaAaaaaa, aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa, aaaaaaaAaaa: aaaaaaaAaaa, aaaaAaaa: true);
+    case aaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(aaaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa, aaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa, aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa, aaaaaaaAaaa: aaaaaaaAaaa, aaaaAaaa: true);
+    case aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa, aaaaaaa?.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa, aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa, aaaaaaaAaaa: aaaaaaaAaaa, aaaaAaaa: true);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(aaaaaaaa?.aaa, aaaaaaa?.aaa, aaaaaaaaAaaa!, aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa, aaaaaaaAaaa: aaaaaaaAaaa, aaaaaaaaaaaAaaa: true, aaaaAaaa: true);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(aaaaaaaa?.aaa, aaaaaaa?.aaa, aaaaaaaaAaaa!, aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa, aaaaaaaAaaa: aaaaaaaAaaa, aaaaaaaaaaaAaaa: true, aaaaAaaa: true);
+    case aaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaAaaaaAaaaa(aaaaaaaa?.aaaa, aaaaaaa?.aaaa, aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa, aaaaaaaAaaa: aaaaaaaAaaa, aaaaAaaa: true);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(aaaaaaaa?.aaa, aaaaaaa?.aaa, aaaaaaaaAaaa!, aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa, aaaaaaaAaaa: aaaaaaaAaaa, aaaaaaaaaaaAaaa: true, aaaaAaaa: true);
+    case aaaaaAaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaAaaaaa, aaaaaaa?.aaaaaAaaaaa, aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa, aaaaaaaAaaa: aaaaaaaAaaa, aaaaAaaa: true);
+    case aaaaAaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(aaaaaaaa?.aaaa, aaaaaaa?.aaaa, aaaaaaaaAaaa!, aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa, aaaaaaaAaaa: aaaaaaaAaaa, aaaaAaaa: true);
+    case aaaaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaAaaaaAaaaa, aaaaaaa?.aaaaaAaaaaAaaaa, aaaaaaaaAaaa!, aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa, aaaaaaaAaaa: aaaaaaaAaaa, aaaaAaaa: true);
+    case aaaaaAaaaaAaaaaAaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa, aaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa, aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa, aaaaaaaAaaa: aaaaaaaAaaa, aaaaAaaa: true);
+    default:
+      throw AaaaaaaaaaaaaAaaaa(aaaaaaAaaa);
+  }
+}
+<<<
+AaaaaaaAaaaaaaaaAaaaaaaaAaaaa
+    _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
+        AaaaaaAaaaaaaaa aaaaaaAaaaaaaaa,
+        Aaaaaa aaaaaaAaaa,
+        Aaaaaa? aaaaaaaaAaaa,
+        {aaaa aaaaaaaAaaaaaaaaaa = false,
+        aaaa aaaaaaaAaaa = false}) {
+  switch (aaaaaaAaaa) {
+    case aaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
+          .aaaaaaAaaaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaa, aaaaaaa?.aaaaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaaaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
+          .aaaaaaAaaaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaaaaaaa, aaaaaaa?.aaaaaaaaaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaaaaaaAaaaa,
+              aaaaaaa?.aaaaaaaaaaAaaaa, aaaaaaaaAaaa!,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaaaaaaaaAaaa: true,
+              aaaaAaaa: true);
+    case aaaAaaaaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
+          .aaaaaaAaaaaaaAaaaaAaaaa(aaaaaaaa?.aaaAaaaaaaa, aaaaaaa?.aaaAaaaaaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(
+              aaaaaaaa?.aaaaaaaaaaAaaaaAaaaaa, aaaaaaa?.aaaaaaaaaaAaaaaAaaaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(
+              aaaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa,
+              aaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(
+              aaaaaaaa?.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa,
+              aaaaaaa?.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
+          .aaaaaaAaaaaAaaaaAaaaa(aaaaaaaa?.aaa, aaaaaaa?.aaa, aaaaaaaaAaaa!,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaaaaaaaaAaaa: true,
+              aaaaAaaa: true);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
+          .aaaaaaAaaaaAaaaaAaaaa(aaaaaaaa?.aaa, aaaaaaa?.aaa, aaaaaaaaAaaa!,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaaaaaaaaAaaa: true,
+              aaaaAaaa: true);
+    case aaaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
+          .aaaaaaaaaAaaaaaAaaaaAaaaa(aaaaaaaa?.aaaa, aaaaaaa?.aaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaAaaaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
+          .aaaaaaAaaaaAaaaaAaaaa(aaaaaaaa?.aaa, aaaaaaa?.aaa, aaaaaaaaAaaa!,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaaaaaaaaAaaa: true,
+              aaaaAaaa: true);
+    case aaaaaAaaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
+          .aaaaaaAaaaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaAaaaaa, aaaaaaa?.aaaaaAaaaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaaAaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
+          .aaaaaaAaaaaAaaaaAaaaa(aaaaaaaa?.aaaa, aaaaaaa?.aaaa, aaaaaaaaAaaa!,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaaaAaaaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(aaaaaaaa?.aaaaaAaaaaAaaaa,
+              aaaaaaa?.aaaaaAaaaaAaaaa, aaaaaaaaAaaa!,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    case aaaaaAaaaaAaaaaAaaAaaaaAaaaaaAaaa:
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaAaaaaAaaaa(
+              aaaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa,
+              aaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa,
+              aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
+              aaaaaaaAaaa: aaaaaaaAaaa,
+              aaaaAaaa: true);
+    default:
+      throw AaaaaaaaaaaaaAaaaa(aaaaaaAaaa);
+  }
+}

--- a/test/splitting/switch.stmt
+++ b/test/splitting/switch.stmt
@@ -7,7 +7,8 @@ switch ("a long string that must wrap") {
 <<<
 switch (
     "a long string that must wrap") {
-  case 0: return "ok";
+  case 0:
+    return "ok";
 }
 >>> block split in value
 switch ([1,]) {
@@ -18,7 +19,8 @@ switch ([1,]) {
 switch ([
   1,
 ]) {
-  case 0: return "ok";
+  case 0:
+    return "ok";
 }
 >>> empty cases always get their own line
 switch (obj) {
@@ -29,9 +31,10 @@ switch (obj) {
 <<<
 switch (obj) {
   case 1:
-  case 2: a();
+  case 2:
+    a();
 }
->>> single-statement cases can stay on one line
+>>> single-statement cases split
 switch (obj) {
   case 1: a();
   case 2: b();
@@ -39,11 +42,14 @@ switch (obj) {
 }
 <<<
 switch (obj) {
-  case 1: a();
-  case 2: b();
-  default: c();
+  case 1:
+    a();
+  case 2:
+    b();
+  default:
+    c();
 }
->>> multiple statement case always splits
+>>> multiple statement cases split
 switch (obj) {
   case 1: a(); b();
   case 2: c(); d();
@@ -61,7 +67,7 @@ switch (obj) {
     d();
     e();
 }
->>> any split case forces all cases to split
+>>> cases always split
 switch (obj) {
   case 1: a(); b();
   case 2: c();
@@ -118,7 +124,8 @@ switch (obj) {
 }
 <<<
 switch (obj) {
-  case constant when condition: body;
+  case constant when condition:
+    body;
 }
 >>> pattern and guard on same line, split after ":"
 switch (obj) {

--- a/test/whitespace/patterns.stmt
+++ b/test/whitespace/patterns.stmt
@@ -24,7 +24,8 @@ switch (obj) {
   case < other:
   case <= other:
   case > other:
-  case >= other: body;
+  case >= other:
+    body;
 }
 >>> relational as subpattern
 if (o case  >  1  &&  <   2 && (  ==   3 )) {}
@@ -67,7 +68,8 @@ switch (obj) {
   case -12.34:
   case 'string':
   case 's$tr${ing}':
-  case #symbol: ok;
+  case #symbol:
+    ok;
 }
 >>> identifiers
 switch (obj) {
@@ -82,7 +84,8 @@ switch (obj) {
   case _:
   case name:
   case qualified.name:
-  case prefixed.qualified.name: ok;
+  case prefixed.qualified.name:
+    ok;
 }
 >>> variables
 switch (obj) {
@@ -99,7 +102,8 @@ switch (obj) {
   case List<String> name:
   case var name:
   case final name:
-  case final (int, String) name: ok;
+  case final (int, String) name:
+    ok;
 }
 >>> list
 switch (obj) {
@@ -172,7 +176,8 @@ switch (obj) {
   case (value,):
   case (first, second, third):
   case (first: 1, 2, third: 3):
-  case (:var x, :var y): ok;
+  case (:var x, :var y):
+    ok;
 }
 >>> object
 switch (obj) {
@@ -239,7 +244,8 @@ switch (obj) {
   case const <int>{}:
   case const {1, 2}:
   case const <int, String>{}:
-  case const {1: 's', 2: 't'}: ok;
+  case const {1: 's', 2: 't'}:
+    ok;
 }
 >>> constant constructor
 switch (obj) {
@@ -270,5 +276,6 @@ ok;
 <<<
 switch (obj) {
   case const (1):
-  case const (-foo * bar): ok;
+  case const (-foo * bar):
+    ok;
 }

--- a/test/whitespace/switch.stmt
+++ b/test/whitespace/switch.stmt
@@ -71,10 +71,12 @@ switch (foo) {
 switch (foo) {
   case 1:
   case 2:
-  case 3: body;
+  case 3:
+    body;
 
   case 4:
-  default: body;
+  default:
+    body;
 }
 >>> require at least one newline between statements in a default
 switch (foo) {default:a();b();c();}
@@ -131,7 +133,8 @@ switch (foo) {case 0:case 1:case 2:body();}
 switch (foo) {
   case 0:
   case 1:
-  case 2: body();
+  case 2:
+    body();
 }
 >>> allow an extra newline between non-empty cases
 switch (foo) {case 0: body();
@@ -141,10 +144,12 @@ switch (foo) {case 0: body();
 }
 <<<
 switch (foo) {
-  case 0: body();
+  case 0:
+    body();
 
   case 1:
-  case 2: body();
+  case 2:
+    body();
 }
 >>> collapse any other newlines in a case
 switch (foo) {
@@ -168,7 +173,8 @@ switch (foo) {
 switch (foo) {
   case 0:
   case 1:
-  case 2: body();
+  case 2:
+    body();
 }
 >>> indentation
 switch (fruit) {
@@ -212,16 +218,6 @@ switch (fruit) {
   default:
     break;
 }
->>> without breaks
-switch (obj) {
-case  1 :  print('one');
-case  2 :  print('two');
-}
-<<<
-switch (obj) {
-  case 1: print('one');
-  case 2: print('two');
-}
 >>> switch expression
 var x = switch  (  obj  )  {
 1  =>  'one'  ,  var  two  =>  'two'
@@ -260,6 +256,7 @@ switch (obj) {
   case 's'.length:
   case 1 is int:
   case 1 is! int:
+    body;
 }
 <<<
 switch (obj) {
@@ -290,6 +287,7 @@ switch (obj) {
   case 's'.length:
   case 1 is int:
   case 1 is! int:
+    body;
 }
 >>> empty switch expression (error but handle gracefully)
 var x = switch(y) {};


### PR DESCRIPTION
I'm still interested in supporting this, but it causes a lot of churn. That means it really needs to go through the full dart style change process. Given how many other things are in the air with Dart 3.0, it seems like now is probably not the ideal time for that.

So, for now, I think we should keep the old formatting where case bodies always go on their own line.

cc @natebosch @iinozemtsev 