### PR TITLE
Hide "--fix" and related options in help output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.3.1-dev
+
+* Hide `--fix` and related options in `--help`. The options are still there and
+  supported, but are no longer shown by default. Eventually, we would like all
+  users to move to using `dart fix` instead of `dart format --fix`.
+
 # 2.3.0
 
 ## New language features

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -74,10 +74,10 @@ void defineOptions(ArgParser parser,
       help: 'Return exit code 1 if there are any formatting changes.');
 
   if (verbose) parser.addSeparator('Non-whitespace fixes (off by default):');
-  parser.addFlag('fix', negatable: false, help: 'Apply all style fixes.');
+  parser.addFlag('fix',
+      negatable: false, help: 'Apply all style fixes.', hide: !verbose);
 
   for (var fix in StyleFix.all) {
-    // TODO(rnystrom): Allow negating this if used in concert with "--fix"?
     parser.addFlag('fix-${fix.name}',
         negatable: false, help: fix.description, hide: !verbose);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.0
+version: 2.3.1-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/command_line_test.dart
+++ b/test/command_line_test.dart
@@ -121,7 +121,6 @@ void main() {
       await expectLater(process.stdout, emitsThrough(contains('--overwrite')));
       await expectLater(
           process.stdout, emitsThrough(contains('--set-exit-if-changed')));
-      await expectLater(process.stdout, emitsThrough(contains('--fix')));
       await process.shouldExit(0);
     });
 

--- a/test/command_test.dart
+++ b/test/command_test.dart
@@ -286,7 +286,6 @@ void main() {
       expect(
           await process.stdout.next, 'Idiomatically format Dart source code.');
       await expectLater(process.stdout, emitsThrough(contains('-o, --output')));
-      await expectLater(process.stdout, emitsThrough(contains('--fix')));
       await expectLater(process.stdout, neverEmits(contains('--summary')));
       await process.shouldExit(0);
     });


### PR DESCRIPTION
This doesn't completely fix #1153 because the command is still there and supported, but it's a step towards deprecating it.