### PR TITLE
Don't insert space into empty switches.

### DIFF
--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2723,6 +2723,15 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   @override
   void visitSwitchExpression(SwitchExpression node) {
+    if (node.cases.isEmpty) {
+      // Don't allow splitting an empty switch expression.
+      _visitSwitchValue(node.switchKeyword, node.leftParenthesis,
+          node.expression, node.rightParenthesis);
+      token(node.leftBracket);
+      token(node.rightBracket);
+      return;
+    }
+
     // Start the rule for splitting between the cases before the value. That
     // way, if the value expression splits, the cases do too. Avoids:
     //
@@ -2739,10 +2748,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
     visitCommaSeparatedNodes(node.cases, between: split);
 
-    // A switch with no cases isn't syntactically valid, but handle it
-    // gracefully instead of crashing.
-    var hasTrailingComma =
-        node.cases.isNotEmpty && node.cases.last.commaAfter != null;
+    var hasTrailingComma = node.cases.last.commaAfter != null;
     _endBody(node.rightBracket, forceSplit: hasTrailingComma);
   }
 
@@ -2789,6 +2795,13 @@ class SourceVisitor extends ThrowingAstVisitor {
   void visitSwitchStatement(SwitchStatement node) {
     _visitSwitchValue(node.switchKeyword, node.leftParenthesis, node.expression,
         node.rightParenthesis);
+    if (node.members.isEmpty) {
+      // Don't allow splitting an empty switch statement.
+      token(node.leftBracket);
+      token(node.rightBracket);
+      return;
+    }
+
     _beginBody(node.leftBracket);
     for (var member in node.members) {
       _visitLabels(member.labels);

--- a/test/regression/1100/1198.stmt
+++ b/test/regression/1100/1198.stmt
@@ -1,0 +1,31 @@
+40 columns                              |
+>>>
+switch (e) {}
+<<<
+switch (e) {}
+>>>
+switch ("a long string that must wrap") {}
+<<<
+switch (
+    "a long string that must wrap") {}
+>>>
+switch ([1,]) {}
+<<<
+switch ([
+  1,
+]) {}
+>>>
+e = switch (e) {};
+<<<
+e = switch (e) {};
+>>>
+e = switch ("a long string that must wrap") {};
+<<<
+e = switch (
+    "a long string that must wrap") {};
+>>>
+e = switch ([1,]) {};
+<<<
+e = switch ([
+  1,
+]) {};

--- a/test/whitespace/switch.stmt
+++ b/test/whitespace/switch.stmt
@@ -289,7 +289,7 @@ switch (obj) {
   case 1 is! int:
     body;
 }
->>> empty switch expression (error but handle gracefully)
+>>> empty switch expression
 var x = switch(y) {};
 <<<
-var x = switch (y) {  };
+var x = switch (y) {};


### PR DESCRIPTION
Fixes #1198.