### PR TITLE
Don't indent outermost "||" pattern operands in switch expression cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Hide `--fix` and related options in `--help`. The options are still there and
   supported, but are no longer shown by default. Eventually, we would like all
   users to move to using `dart fix` instead of `dart format --fix`.
+* Don't indent `||` pattern operands in switch expression cases.  
 * Don't format `sealed`, `interface`, and `final` keywords on mixin
   declarations. The proposal was updated to no longer support them.
 

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2795,6 +2795,7 @@ class SourceVisitor extends ThrowingAstVisitor {
 
     // Write the "||" operands up to the last one.
     for (var i = 0; i < orBranches.length - 1; i++) {
+      // Note that orBranches will always have one more element than orTokens.
       visit(orBranches[i]);
       space();
       token(orTokens[i]);

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2755,25 +2755,71 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   @override
   void visitSwitchExpressionCase(SwitchExpressionCase node) {
+    // If the pattern is a series of `||` patterns, then flatten them out and
+    // format them like empty cases with fallthrough in a switch statement
+    // instead of like a single indented binary pattern. Prefer:
+    //
+    //   e = switch (obj) {
+    //     constant1 ||
+    //     constant2 ||
+    //     constant3 =>
+    //       body
+    //   };
+    //
+    // Instead of:
+    //
+    //   e = switch (obj) {
+    //     constant1 ||
+    //        constant2 ||
+    //        constant3 =>
+    //       body
+    //   };
+    var orBranches = <DartPattern>[];
+    var orTokens = <Token>[];
+
+    void flattenOr(DartPattern e) {
+      if (e is! LogicalOrPattern) {
+        orBranches.add(e);
+      } else {
+        flattenOr(e.leftOperand);
+        orTokens.add(e.operator);
+        flattenOr(e.rightOperand);
+      }
+    }
+
+    flattenOr(node.guardedPattern.pattern);
+
     // Wrap the rule for splitting after "=>" around the pattern so that a
     // split in the pattern forces the expression to move to the next line too.
     builder.startLazyRule();
 
-    // Wrap the expression's nesting around the pattern too so that a split in
+    // Write the "||" operands up to the last one.
+    for (var i = 0; i < orBranches.length - 1; i++) {
+      visit(orBranches[i]);
+      space();
+      token(orTokens[i]);
+      split();
+    }
+
+    // Wrap the expression's nesting around the final pattern so that a split in
     // the pattern is indented farther then the body expression. Used +2 indent
     // because switch expressions are block-like, similar to how we split the
     // bodies of if and for elements in collections.
     builder.nestExpression(indent: Indent.block);
 
     var whenClause = node.guardedPattern.whenClause;
-    if (whenClause == null) {
-      visit(node.guardedPattern.pattern);
-    } else {
+    if (whenClause != null) {
       // Wrap the when clause rule around the pattern so that if the pattern
       // splits then we split before "when" too.
       builder.startRule();
       builder.nestExpression(indent: Indent.block);
-      visit(node.guardedPattern.pattern);
+    }
+
+    // Write the last pattern in the "||" chain. If the case pattern isn't an
+    // "||" pattern at all, this writes the one pattern.
+    visit(orBranches.last);
+
+    if (whenClause != null) {
       split();
       builder.startBlockArgumentNesting();
       _visitWhenClause(whenClause);
@@ -2785,10 +2831,12 @@ class SourceVisitor extends ThrowingAstVisitor {
     space();
     token(node.arrow);
     split();
-
     builder.endRule();
 
+    builder.startBlockArgumentNesting();
     visit(node.expression);
+    builder.endBlockArgumentNesting();
+
     builder.unnest();
   }
 

--- a/test/regression/1100/1197.unit
+++ b/test/regression/1100/1197.unit
@@ -1,0 +1,104 @@
+>>>
+main() {
+  {
+    return TextFieldTapRegion(
+      onLongPressMoveUpdate: (longPressMoveUpdateDetails) {
+        (switch (Theme.of(this.context).platform) {
+          TargetPlatform.iOS || TargetPlatform.macOS =>
+            _renderEditable.selectPositionAt(
+            from: longPressMoveUpdateDetails.globalPosition,
+            cause: SelectionChangedCause.longPress,
+          ),
+          TargetPlatform.android ||
+                TargetPlatform.fuchsia ||
+                TargetPlatform.linux ||
+                TargetPlatform.windows =>
+            _renderEditable.selectWordsInRange(
+            from: longPressMoveUpdateDetails.globalPosition -
+                longPressMoveUpdateDetails.offsetFromOrigin,
+            to: longPressMoveUpdateDetails.globalPosition,
+            cause: SelectionChangedCause.longPress,
+          )
+        });
+      },
+    );
+  }
+}
+<<<
+main() {
+  {
+    return TextFieldTapRegion(
+      onLongPressMoveUpdate: (longPressMoveUpdateDetails) {
+        (switch (Theme.of(this.context).platform) {
+          TargetPlatform.iOS ||
+          TargetPlatform.macOS =>
+            _renderEditable.selectPositionAt(
+              from: longPressMoveUpdateDetails.globalPosition,
+              cause: SelectionChangedCause.longPress,
+            ),
+          TargetPlatform.android ||
+          TargetPlatform.fuchsia ||
+          TargetPlatform.linux ||
+          TargetPlatform.windows =>
+            _renderEditable.selectWordsInRange(
+              from: longPressMoveUpdateDetails.globalPosition -
+                  longPressMoveUpdateDetails.offsetFromOrigin,
+              to: longPressMoveUpdateDetails.globalPosition,
+              cause: SelectionChangedCause.longPress,
+            )
+        });
+      },
+    );
+  }
+}
+>>>
+main() {
+  {
+    return TextFieldTapRegion(
+      onLongPressMoveUpdate: (longPressMoveUpdateDetails) =>
+          switch (Theme.of(this.context).platform) {
+        TargetPlatform.iOS || TargetPlatform.macOS =>
+          _renderEditable.selectPositionAt(
+          from: longPressMoveUpdateDetails.globalPosition,
+          cause: SelectionChangedCause.longPress,
+        ),
+        TargetPlatform.android ||
+              TargetPlatform.fuchsia ||
+              TargetPlatform.linux ||
+              TargetPlatform.windows =>
+          _renderEditable.selectWordsInRange(
+          from: longPressMoveUpdateDetails.globalPosition -
+              longPressMoveUpdateDetails.offsetFromOrigin,
+          to: longPressMoveUpdateDetails.globalPosition,
+          cause: SelectionChangedCause.longPress,
+        )
+      },
+    );
+  }
+}
+<<<
+main() {
+  {
+    return TextFieldTapRegion(
+      onLongPressMoveUpdate: (longPressMoveUpdateDetails) =>
+          switch (Theme.of(this.context).platform) {
+        TargetPlatform.iOS ||
+        TargetPlatform.macOS =>
+          _renderEditable.selectPositionAt(
+            from: longPressMoveUpdateDetails.globalPosition,
+            cause: SelectionChangedCause.longPress,
+          ),
+        TargetPlatform.android ||
+        TargetPlatform.fuchsia ||
+        TargetPlatform.linux ||
+        TargetPlatform.windows =>
+          _renderEditable.selectWordsInRange(
+            from: longPressMoveUpdateDetails.globalPosition -
+                longPressMoveUpdateDetails.offsetFromOrigin,
+            to: longPressMoveUpdateDetails.globalPosition,
+            cause: SelectionChangedCause.longPress,
+          )
+      },
+    );
+  }
+}

--- a/test/splitting/arrows.stmt
+++ b/test/splitting/arrows.stmt
@@ -14,3 +14,31 @@ doSomethingWithFn((argument) =>
   () => one;
   () => two;
 }
+>>> indent entire block body
+SomeLongFunctionName(
+  (longParameterName______) =>
+      <LongTypeArgument>[
+    longListElement,
+  ],
+);
+<<<
+SomeLongFunctionName(
+  (longParameterName______) =>
+      <LongTypeArgument>[
+    longListElement,
+  ],
+);
+>>>
+SomeLongFunctionName(
+  (longParameterName______) =>
+      switch (value) {
+    constant => body,
+  },
+);
+<<<
+SomeLongFunctionName(
+  (longParameterName______) =>
+      switch (value) {
+    constant => body,
+  },
+);

--- a/test/splitting/switch.stmt
+++ b/test/splitting/switch.stmt
@@ -266,3 +266,14 @@ switch (obj) {
       ]:
     body;
 }
+>>> indent || patterns when outermost in switch statement (as opposed to expr)
+switch (obj) {
+  case oneConstant || twoConstant || threeConstant: body;
+}
+<<<
+switch (obj) {
+  case oneConstant ||
+        twoConstant ||
+        threeConstant:
+    body;
+}

--- a/test/splitting/switch_expression.stmt
+++ b/test/splitting/switch_expression.stmt
@@ -149,33 +149,33 @@ e = switch (obj) {
 };
 >>> expression split in pattern
 e = switch (obj) {
-  veryVeryLongPattern || reallyMustSplit => body
+  veryVeryLongPattern && reallyMustSplit => body
 };
 <<<
 e = switch (obj) {
-  veryVeryLongPattern ||
+  veryVeryLongPattern &&
         reallyMustSplit =>
     body
 };
 >>> expression split in pattern forces guard to split
 e = switch (obj) {
-  veryVeryLongPattern || reallyMustSplitHere when true => body
+  veryVeryLongPattern && reallyMustSplitHere when true => body
 };
 <<<
 e = switch (obj) {
-  veryVeryLongPattern ||
+  veryVeryLongPattern &&
           reallyMustSplitHere
       when true =>
     body
 };
 >>> expression split in pattern, expression split in guard
 e = switch (obj) {
-  veryVeryLongPattern || reallyMustSplitToo when veryLongCondition
+  veryVeryLongPattern && reallyMustSplitToo when veryLongCondition
   || anotherLongCondition => body
 };
 <<<
 e = switch (obj) {
-  veryVeryLongPattern ||
+  veryVeryLongPattern &&
           reallyMustSplitToo
       when veryLongCondition ||
           anotherLongCondition =>
@@ -183,15 +183,73 @@ e = switch (obj) {
 };
 >>> expression split in pattern, block split in guard
 e = switch (obj) {
+  veryLongPattern && reallyMustSplitAgain when [element,] => body
+};
+<<<
+e = switch (obj) {
+  veryLongPattern &&
+          reallyMustSplitAgain
+      when [
+        element,
+      ] =>
+    body
+};
+>>> outermost logic-or patterns are indented like parallel cases
+e = switch (obj) {
+  veryVeryLongPattern || reallyMustSplit => body
+};
+<<<
+e = switch (obj) {
+  veryVeryLongPattern ||
+  reallyMustSplit =>
+    body
+};
+>>> outermost logic-or split does not force guard to split
+e = switch (obj) {
+  veryVeryLongPattern || reallyMustSplitHere when true => body
+};
+<<<
+e = switch (obj) {
+  veryVeryLongPattern ||
+  reallyMustSplitHere when true =>
+    body
+};
+>>> outermost logic-or split in pattern, expression split in guard
+e = switch (obj) {
+  veryVeryLongPattern || reallyMustSplitToo when veryLongCondition
+  || anotherLongCondition => body
+};
+<<<
+e = switch (obj) {
+  veryVeryLongPattern ||
+  reallyMustSplitToo
+      when veryLongCondition ||
+          anotherLongCondition =>
+    body
+};
+>>> outermost logic-or split in pattern, block split in guard
+e = switch (obj) {
   veryLongPattern || reallyMustSplitAgain when [element,] => body
 };
 <<<
 e = switch (obj) {
   veryLongPattern ||
-          reallyMustSplitAgain
+  reallyMustSplitAgain
       when [
         element,
       ] =>
+    body
+};
+>>> nested logic-or operands are indented
+e = switch (obj) {
+  Foo(veryVeryLongPattern || reallyMustSplit) => body
+};
+<<<
+e = switch (obj) {
+  Foo(
+    veryVeryLongPattern ||
+        reallyMustSplit
+  ) =>
     body
 };
 >>> block split in pattern
@@ -244,3 +302,67 @@ e = switch (obj) {
       ] =>
     body
 };
+>>> unsplit pattern with trailing comma argument list body
+e = switch (obj) {
+  pattern => function(argument, argument,)
+};
+<<<
+e = switch (obj) {
+  pattern => function(
+      argument,
+      argument,
+    )
+};
+>>> don't indent || patterns when outermost in switch expression
+e = switch (obj) {
+  oneConstant || twoConstant || threeConstant => body
+};
+<<<
+e = switch (obj) {
+  oneConstant ||
+  twoConstant ||
+  threeConstant =>
+    body
+};
+>>> do indent || patterns when nested inside pattern
+e = switch (obj) {
+  [oneConstant || twoConstant || threeConstant] => body
+};
+<<<
+e = switch (obj) {
+  [
+    oneConstant ||
+        twoConstant ||
+        threeConstant
+  ] =>
+    body
+};
+>>> split pattern with trailing comma argument list body
+e = switch (obj) {
+  pattern || anotherPattern || aThirdOne => function(argument, argument,)
+};
+<<<
+e = switch (obj) {
+  pattern ||
+  anotherPattern ||
+  aThirdOne =>
+    function(
+      argument,
+      argument,
+    )
+};
+>>> trailing comma argument list body with switch inside => function body
+longFunctionName(veryLongParameter) => switch (obj) {
+  oneConstant || twoConstant || threeConstant => function(argument, argument,)
+};
+<<<
+longFunctionName(veryLongParameter) =>
+    switch (obj) {
+      oneConstant ||
+      twoConstant ||
+      threeConstant =>
+        function(
+          argument,
+          argument,
+        )
+    };


### PR DESCRIPTION
This makes them all line up as if they were empty cases in a switch statement, which is essentially how they behave. Instead of:

```dart
e = switch (obj) {
  constant1 ||
     constant2 ||
     constant3 =>
    body
};
```

Gives:

```dart
e = switch (obj) {
  constant1 ||
  constant2 ||
  constant3 =>
    body
};
```

This addresses some of the bad formatting in #1197. The rest is #1202.

cc @mit-mit 