### PR TITLE
Optimize certain operations

### DIFF
--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'fast_hash.dart';
-import 'marking_schemes.dart';
+import 'marking_scheme.dart';
 import 'nesting_level.dart';
 import 'rule/rule.dart';
 
@@ -295,7 +295,7 @@ class OpenSpan {
 /// This is a wrapper around the cost so that spans have unique identities.
 /// This way we can correctly avoid paying the cost multiple times if the same
 /// span is split by multiple chunks.
-class Span extends FastHash with MarkingScheme1 {
+class Span extends FastHash with MarkingScheme {
   /// The cost applied when the span is split across multiple lines or `null`
   /// if the span is for a multisplit.
   final int cost;

--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -295,6 +295,10 @@ class OpenSpan {
 /// This is a wrapper around the cost so that spans have unique identities.
 /// This way we can correctly avoid paying the cost multiple times if the same
 /// span is split by multiple chunks.
+///
+/// Spans can be marked during processing in an algorithm but should be left
+/// unmarked when the algorithm finishes to make marking work in subsequent
+/// calls.
 class Span extends FastHash with MarkingScheme {
   /// The cost applied when the span is split across multiple lines or `null`
   /// if the span is for a multisplit.

--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -299,7 +299,7 @@ class OpenSpan {
 /// Spans can be marked during processing in an algorithm but should be left
 /// unmarked when the algorithm finishes to make marking work in subsequent
 /// calls.
-class Span extends FastHash with MarkingScheme {
+class Span extends FastHash with Markable {
   /// The cost applied when the span is split across multiple lines or `null`
   /// if the span is for a multisplit.
   final int cost;

--- a/lib/src/chunk.dart
+++ b/lib/src/chunk.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'fast_hash.dart';
+import 'marking_schemes.dart';
 import 'nesting_level.dart';
 import 'rule/rule.dart';
 
@@ -294,7 +295,7 @@ class OpenSpan {
 /// This is a wrapper around the cost so that spans have unique identities.
 /// This way we can correctly avoid paying the cost multiple times if the same
 /// span is split by multiple chunks.
-class Span extends FastHash {
+class Span extends FastHash with MarkingScheme1 {
   /// The cost applied when the span is split across multiple lines or `null`
   /// if the span is for a multisplit.
   final int cost;

--- a/lib/src/line_splitting/solve_state.dart
+++ b/lib/src/line_splitting/solve_state.dart
@@ -272,17 +272,23 @@ class SolveState {
   void _calculateSplits() {
     // Figure out which expression nesting levels got split and need to be
     // assigned columns.
-    var usedNestingLevels = <NestingLevel>{};
+    var usedNestingLevels = <NestingLevel>[];
     for (var i = 0; i < _splitter.chunks.length; i++) {
       var chunk = _splitter.chunks[i];
       if (chunk.rule.isSplit(getValue(chunk.rule), chunk)) {
-        usedNestingLevels.add(chunk.nesting);
-        chunk.nesting.clearTotalUsedIndent();
+        var nesting = chunk.nesting;
+        if (nesting.mark()) {
+          usedNestingLevels.add(nesting);
+          nesting.clearTotalUsedIndent();
+        }
       }
     }
 
     for (var nesting in usedNestingLevels) {
-      nesting.refreshTotalUsedIndent(usedNestingLevels);
+      nesting.refreshTotalUsedIndent();
+    }
+    for (var nesting in usedNestingLevels) {
+      nesting.unmark();
     }
 
     _splits = SplitSet(_splitter.chunks.length);

--- a/lib/src/line_splitting/solve_state.dart
+++ b/lib/src/line_splitting/solve_state.dart
@@ -343,7 +343,7 @@ class SolveState {
     // The set of spans that contain chunks that ended up splitting. We store
     // these in a set so a span's cost doesn't get double-counted if more than
     // one split occurs in it.
-    var splitSpans = <Span>{};
+    var splitSpans = <Span>[];
 
     // The nesting level of the chunk that ended the previous line.
     NestingLevel? previousNesting;
@@ -354,7 +354,12 @@ class SolveState {
       if (_splits.shouldSplitAt(i)) {
         endLine(i);
 
-        splitSpans.addAll(chunk.spans);
+        for (var span in chunk.spans) {
+          if (span.mark()) {
+            splitSpans.add(span);
+            cost += span.cost;
+          }
+        }
 
         // Do not allow sequential lines to have the same indentation but for
         // different reasons. In other words, don't allow different expressions
@@ -410,7 +415,7 @@ class SolveState {
 
     // Add the costs for the spans containing splits.
     for (var span in splitSpans) {
-      cost += span.cost;
+      span.unmark();
     }
 
     // Finish the last line.

--- a/lib/src/line_splitting/solve_state.dart
+++ b/lib/src/line_splitting/solve_state.dart
@@ -346,9 +346,10 @@ class SolveState {
       start = end;
     }
 
-    // The set of spans that contain chunks that ended up splitting. We store
-    // these in a set so a span's cost doesn't get double-counted if more than
-    // one split occurs in it.
+    // The list of spans that contain chunks that ended up splitting. These are
+    // made unique by marking the spans during the run, adding them to this list
+    // to be able to unmark them again. We have to keep track of uniqueness to
+    // avoid double-counted if more than one split occurs in it.
     var splitSpans = <Span>[];
 
     // The nesting level of the chunk that ended the previous line.
@@ -419,7 +420,7 @@ class SolveState {
       if (value != Rule.unsplit) cost += rule.cost;
     });
 
-    // Add the costs for the spans containing splits.
+    // Unmark spans again so they're ready for another run.
     for (var span in splitSpans) {
       span.unmark();
     }

--- a/lib/src/line_splitting/solve_state.dart
+++ b/lib/src/line_splitting/solve_state.dart
@@ -349,7 +349,7 @@ class SolveState {
     // The list of spans that contain chunks that ended up splitting. These are
     // made unique by marking the spans during the run, adding them to this list
     // to be able to unmark them again. We have to keep track of uniqueness to
-    // avoid double-counted if more than one split occurs in it.
+    // avoid double-counting if more than one split occurs in it.
     var splitSpans = <Span>[];
 
     // The nesting level of the chunk that ended the previous line.

--- a/lib/src/line_splitting/solve_state_queue.dart
+++ b/lib/src/line_splitting/solve_state_queue.dart
@@ -88,8 +88,8 @@ class SolveStateQueue {
 
   /// Compares the overflow and cost of [a] to [b].
   int _compareScore(SolveState a, SolveState b) {
-    int aCost = a.splits.cost;
-    int bCost = b.splits.cost;
+    var aCost = a.splits.cost;
+    var bCost = b.splits.cost;
     if (aCost != bCost) {
       if (aCost < bCost) return -1;
       return 1;

--- a/lib/src/line_splitting/solve_state_queue.dart
+++ b/lib/src/line_splitting/solve_state_queue.dart
@@ -88,8 +88,11 @@ class SolveStateQueue {
 
   /// Compares the overflow and cost of [a] to [b].
   int _compareScore(SolveState a, SolveState b) {
-    if (a.splits.cost != b.splits.cost) {
-      return a.splits.cost.compareTo(b.splits.cost);
+    int aCost = a.splits.cost;
+    int bCost = b.splits.cost;
+    if (aCost != bCost) {
+      if (aCost < bCost) return -1;
+      return 1;
     }
 
     return a.overflowChars.compareTo(b.overflowChars);

--- a/lib/src/marking_scheme.dart
+++ b/lib/src/marking_scheme.dart
@@ -3,18 +3,18 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A mixin for marking classes.
-mixin MarkingScheme {
-  int _markingFlag = 0;
+mixin Markable {
+  bool _isMarked = false;
 
   bool mark() {
-    if (_markingFlag != 0) return false;
-    _markingFlag = 1;
+    if (_isMarked) return false;
+    _isMarked = true;
     return true;
   }
 
-  bool isMarked() => _markingFlag != 0;
+  bool get isMarked => _isMarked;
 
   void unmark() {
-    _markingFlag = 0;
+    _isMarked = false;
   }
 }

--- a/lib/src/marking_scheme.dart
+++ b/lib/src/marking_scheme.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A mixin for marking classes.
+mixin MarkingScheme {
+  int _markingFlag = 0;
+
+  bool mark() {
+    if (_markingFlag != 0) return false;
+    _markingFlag = 1;
+    return true;
+  }
+
+  bool isMarked() => _markingFlag != 0;
+
+  void unmark() {
+    _markingFlag = 0;
+  }
+}

--- a/lib/src/nesting_level.dart
+++ b/lib/src/nesting_level.dart
@@ -20,6 +20,10 @@ import 'marking_scheme.dart';
 /// indented relative to the outer expression. It's almost always
 /// [Indent.expression], but cascades are special magic snowflakes and use
 /// [Indent.cascade].
+///
+/// NestingLEvels can be marked during processing in an algorithm but should be
+/// left unmarked when the algorithm finishes to make marking work in subsequent
+/// calls.
 class NestingLevel extends FastHash with MarkingScheme {
   /// The nesting level surrounding this one, or `null` if this is represents
   /// top level code in a block.

--- a/lib/src/nesting_level.dart
+++ b/lib/src/nesting_level.dart
@@ -24,7 +24,7 @@ import 'marking_scheme.dart';
 /// NestingLEvels can be marked during processing in an algorithm but should be
 /// left unmarked when the algorithm finishes to make marking work in subsequent
 /// calls.
-class NestingLevel extends FastHash with MarkingScheme {
+class NestingLevel extends FastHash with Markable {
   /// The nesting level surrounding this one, or `null` if this is represents
   /// top level code in a block.
   final NestingLevel? parent;
@@ -73,7 +73,7 @@ class NestingLevel extends FastHash with MarkingScheme {
       totalIndent += parent!.totalUsedIndent;
     }
 
-    if (isMarked()) totalIndent += indent;
+    if (isMarked) totalIndent += indent;
 
     _totalUsedIndent = totalIndent;
   }

--- a/lib/src/nesting_level.dart
+++ b/lib/src/nesting_level.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'fast_hash.dart';
+import 'marking_schemes.dart';
 
 /// A single level of expression nesting.
 ///
@@ -19,7 +20,7 @@ import 'fast_hash.dart';
 /// indented relative to the outer expression. It's almost always
 /// [Indent.expression], but cascades are special magic snowflakes and use
 /// [Indent.cascade].
-class NestingLevel extends FastHash {
+class NestingLevel extends FastHash with MarkingScheme1 {
   /// The nesting level surrounding this one, or `null` if this is represents
   /// top level code in a block.
   final NestingLevel? parent;
@@ -56,19 +57,19 @@ class NestingLevel extends FastHash {
   }
 
   /// Calculates the total amount of indentation from this nesting level and
-  /// all of its parents assuming only [usedNesting] levels are in use.
-  void refreshTotalUsedIndent(Set<NestingLevel> usedNesting) {
+  /// all of its parents assuming only marked levels are in use.
+  void refreshTotalUsedIndent() {
     var totalIndent = _totalUsedIndent;
     if (totalIndent != null) return;
 
     totalIndent = 0;
 
     if (parent != null) {
-      parent!.refreshTotalUsedIndent(usedNesting);
+      parent!.refreshTotalUsedIndent();
       totalIndent += parent!.totalUsedIndent;
     }
 
-    if (usedNesting.contains(this)) totalIndent += indent;
+    if (isMarked()) totalIndent += indent;
 
     _totalUsedIndent = totalIndent;
   }

--- a/lib/src/nesting_level.dart
+++ b/lib/src/nesting_level.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'fast_hash.dart';
-import 'marking_schemes.dart';
+import 'marking_scheme.dart';
 
 /// A single level of expression nesting.
 ///
@@ -20,7 +20,7 @@ import 'marking_schemes.dart';
 /// indented relative to the outer expression. It's almost always
 /// [Indent.expression], but cascades are special magic snowflakes and use
 /// [Indent.cascade].
-class NestingLevel extends FastHash with MarkingScheme1 {
+class NestingLevel extends FastHash with MarkingScheme {
   /// The nesting level surrounding this one, or `null` if this is represents
   /// top level code in a block.
   final NestingLevel? parent;


### PR DESCRIPTION
I noticed that formating the file "pkg/front_end/lib/src/fasta/fasta_codes_cfe_generated.dart" from the dart sdk was quite slow, took a look into it and made some changes.
It's still quite slow, but at least it's better.

I've:

- Updated _compareScore to "cache" the costs and inlined the `compareTo` call (the sdk version takes a num and don't know it's already been compared to 0).
- Replaced the usage of Set in a few places with markings on the actual classes.

My measured runtimes:

```
AS-IS
Formatted 1 file (0 changed) in 3.53 seconds.
Formatted 1 file (0 changed) in 3.65 seconds.
Formatted 1 file (0 changed) in 3.64 seconds.
Formatted 1 file (0 changed) in 3.70 seconds.
Formatted 1 file (0 changed) in 3.85 seconds.
Formatted 1 file (0 changed) in 3.70 seconds.
Formatted 1 file (0 changed) in 3.76 seconds.
Formatted 1 file (0 changed) in 3.59 seconds.
Formatted 1 file (0 changed) in 3.77 seconds.
Formatted 1 file (0 changed) in 3.80 seconds.

_compareScore change
Formatted 1 file (0 changed) in 3.21 seconds.
Formatted 1 file (0 changed) in 3.35 seconds.
Formatted 1 file (0 changed) in 3.28 seconds.
Formatted 1 file (0 changed) in 3.10 seconds.
Formatted 1 file (0 changed) in 3.06 seconds.
Formatted 1 file (0 changed) in 3.35 seconds.
Formatted 1 file (0 changed) in 3.39 seconds.
Formatted 1 file (0 changed) in 3.08 seconds.
Formatted 1 file (0 changed) in 3.15 seconds.
Formatted 1 file (0 changed) in 3.31 seconds.

Difference at 95.0% confidence
        -0.471 +/- 0.105388
        -12.7332% +/- 2.84909%
        (Student's t, pooled s = 0.112163)

Mark Spans instead of using set in _calculateCost
Formatted 1 file (0 changed) in 2.96 seconds.
Formatted 1 file (0 changed) in 2.92 seconds.
Formatted 1 file (0 changed) in 2.98 seconds.
Formatted 1 file (0 changed) in 2.99 seconds.
Formatted 1 file (0 changed) in 3.10 seconds.
Formatted 1 file (0 changed) in 3.20 seconds.
Formatted 1 file (0 changed) in 2.93 seconds.
Formatted 1 file (0 changed) in 2.84 seconds.
Formatted 1 file (0 changed) in 3.09 seconds.
Formatted 1 file (0 changed) in 3.05 seconds.

Difference at 95.0% confidence
        -0.222 +/- 0.107951
        -6.87732% +/- 3.34422%
        (Student's t, pooled s = 0.114891)

Mark NestingLevels instead of using set in _calculateSplits
Formatted 1 file (0 changed) in 2.77 seconds.
Formatted 1 file (0 changed) in 2.97 seconds.
Formatted 1 file (0 changed) in 2.86 seconds.
Formatted 1 file (0 changed) in 2.90 seconds.
Formatted 1 file (0 changed) in 3.01 seconds.
Formatted 1 file (0 changed) in 2.83 seconds.
Formatted 1 file (0 changed) in 2.88 seconds.
Formatted 1 file (0 changed) in 2.88 seconds.
Formatted 1 file (0 changed) in 2.88 seconds.
Formatted 1 file (0 changed) in 2.90 seconds.

Difference at 95.0% confidence
        -0.118 +/- 0.0826868
        -3.92548% +/- 2.75073%
        (Student's t, pooled s = 0.0880025)
```

Which is a combined changed of
```
Difference at 95.0% confidence
        -0.811 +/- 0.079311
        -21.9248% +/- 2.14412%
        (Student's t, pooled s = 0.0844097)
```

i.e ~800 ms or almost 22% faster on this - apparently particularly bad - file.