### PR TITLE
Don't split cascades on record literals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Don't indent `||` pattern operands in switch expression cases.  
 * Don't format `sealed`, `interface`, and `final` keywords on mixin
   declarations. The proposal was updated to no longer support them.
+* Don't split before a single-section cascade following a record literal.
 
 # 2.3.0
 

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -88,40 +88,6 @@ extension AstIterableExtensions on Iterable<AstNode> {
 }
 
 extension ExpressionExtensions on Expression {
-  /// Whether [expression] is a collection literal, or a call with a trailing
-  /// comma in an argument list.
-  ///
-  /// In that case, when the expression is a target of a cascade, we don't
-  /// force a split before the ".." as eagerly to avoid ugly results like:
-  ///
-  ///     [
-  ///       1,
-  ///       2,
-  ///     ]..addAll(numbers);
-  bool get isCollectionLike {
-    var expression = this;
-    if (expression is ListLiteral) return true;
-    if (expression is SetOrMapLiteral) return true;
-
-    // If the target is a call with a trailing comma in the argument list,
-    // treat it like a collection literal.
-    ArgumentList? arguments;
-    if (expression is InvocationExpression) {
-      arguments = expression.argumentList;
-    } else if (expression is InstanceCreationExpression) {
-      arguments = expression.argumentList;
-    }
-
-    // TODO(rnystrom): Do we want to allow an invocation where the last
-    // argument is a collection literal? Like:
-    //
-    //     foo(argument, [
-    //       element
-    //     ])..cascade();
-
-    return arguments != null && arguments.arguments.hasCommaAfter;
-  }
-
   /// Whether this is an argument in an argument list with a trailing comma.
   bool get isTrailingCommaArgument {
     var parent = this.parent;

--- a/test/whitespace/cascades.stmt
+++ b/test/whitespace/cascades.stmt
@@ -108,6 +108,13 @@ var map = {1:2,}..addAll(more);
 var map = {
   1: 2,
 }..addAll(more);
+>>> omit split if single section on record literal
+(1,2,)..addAll(more);
+<<<
+(
+  1,
+  2,
+)..addAll(more);
 >>> omit split if single section on trailing comma call
 foo(1,)..addAll(more);
 <<<


### PR DESCRIPTION
This is consistent with how other collection literals preceding single-section cascades are formatted.