### PR TITLE
Give record expressions block-like formatting in argument lists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Don't indent `||` pattern operands in switch expression cases.  
 * Don't format `sealed`, `interface`, and `final` keywords on mixin
   declarations. The proposal was updated to no longer support them.
+* Give records block-like formatting in argument lists (#1205).
 
 # 2.3.0
 

--- a/lib/src/argument_list_visitor.dart
+++ b/lib/src/argument_list_visitor.dart
@@ -541,6 +541,7 @@ class ArgumentSublist {
     // TODO(rnystrom): Should we step into parenthesized expressions?
 
     if (expression is ListLiteral) return expression.leftBracket;
+    if (expression is RecordLiteral) return expression.leftParenthesis;
     if (expression is SetOrMapLiteral) return expression.leftBracket;
     if (expression is SingleStringLiteral && expression.isMultiline) {
       return expression.beginToken;

--- a/test/regression/1200/1205.stmt
+++ b/test/regression/1200/1205.stmt
@@ -1,0 +1,12 @@
+>>>
+error(
+    offset: 10,
+    (
+      code: 'unclosed-block',
+      message: 'Block was left open',
+    ));
+<<<
+error(offset: 10, (
+  code: 'unclosed-block',
+  message: 'Block was left open',
+));

--- a/test/splitting/records.stmt
+++ b/test/splitting/records.stmt
@@ -150,27 +150,27 @@ var record = (
 
   element
 );
->>> unlike collections, records do not do block-like formatting in arguments
+>>> format like a block in an argument list
 longFunctionName((element, element), (element, element, element, element));
 <<<
-longFunctionName(
-    (element, element),
-    (
-      element,
-      element,
-      element,
-      element
-    ));
->>> unlike collections, records do not do block-like formatting in arguments
+longFunctionName((
+  element,
+  element
+), (
+  element,
+  element,
+  element,
+  element
+));
+>>> format like a block in an argument list
 longFunctionName((element, element, element, element));
 <<<
-longFunctionName(
-    (
-      element,
-      element,
-      element,
-      element
-    ));
+longFunctionName((
+  element,
+  element,
+  element,
+  element
+));
 >>> don't allow splitting between field name and record
 var record = (argument, argument, argument, recordFieldName: (veryLongElement__________,));
 <<<


### PR DESCRIPTION
This is consistent with how other collection literals are formatted in argument lists.

I originally made the formatting diverge deliberately because I felt it would make it clearer when you're looking at a record versus a series of arguments. But based on the thumbs up on:

https://github.com/dart-lang/dart_style/issues/1205

It appears that users prefer the more consistent formatting. In retrospect, I think I do too.