### PR TITLE
Get ready to publish 2.3.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.3.1-dev
+# 2.3.1
 
 * Hide `--fix` and related options in `--help`. The options are still there and
   supported, but are no longer shown by default. Eventually, we would like all

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -11,7 +11,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '2.3.0';
+const dartStyleVersion = '2.3.1';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 class FormatterOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.1-dev
+version: 2.3.1
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
This is what's shipping in the next stable SDK, so we should get a version out for people using it as a library too.