### PR TITLE
Split metadata on parameters independently.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.3.2-dev
+
+* Don't indent parameters that have metadata annotations. Instead, align them
+  with the metadata and other parameters.
+* Allow metadata annotations on parameters to split independently of annotations
+  on other parameters (#1212).
+
 # 2.3.1
 
 * Hide `--fix` and related options in `--help`. The options are still there and

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.1
+version: 2.3.2-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/comments/functions.unit
+++ b/test/comments/functions.unit
@@ -235,17 +235,16 @@ function({
 }) {
   ;
 }
->>> metadata in trailing comma parameter list splits together even with comment
+>>> splitting in none parameter's metadata doesn't force others to split
 function(@Annotation longParameter,
   // Comment.
 @Annotation @Other @Third longParameter2,) {}
 <<<
 function(
-  @Annotation
-      longParameter,
+  @Annotation longParameter,
   // Comment.
   @Annotation
   @Other
   @Third
-      longParameter2,
+  longParameter2,
 ) {}

--- a/test/regression/0200/0247.unit
+++ b/test/regression/0200/0247.unit
@@ -10,8 +10,8 @@
 <<<
   init(
       {@Option(help: 'The git Uri containing the jefe.yaml.', abbr: 'g')
-          String gitUri,
+      String gitUri,
       @Option(help: 'The directory to install into', abbr: 'd')
-          String installDirectory: '.',
+      String installDirectory: '.',
       @Flag(help: 'Skips the checkout of the develop branch', abbr: 's')
-          bool skipCheckout: false}) async {}
+      bool skipCheckout: false}) async {}

--- a/test/regression/0300/0387.unit
+++ b/test/regression/0300/0387.unit
@@ -7,13 +7,10 @@ greet(@Rest(valueHelp: 'who', help: 'Name(s) to greet.') List<String> who,
     @Option(name: 'greeting', help: 'Alternate word to greet with e.g. "Hi".')
     String salutation: 'Hello'}) {}
 <<<
-greet(
-    @Rest(valueHelp: 'who', help: 'Name(s) to greet.')
-        List<String> who,
+greet(@Rest(valueHelp: 'who', help: 'Name(s) to greet.') List<String> who,
     {@Group.start(title: 'Output')
     @Option(help: 'How many !\'s to append.')
-        int enthusiasm: 0,
-    @Flag(abbr: 'l', help: 'Put names on separate lines.')
-        bool lineMode: false,
+    int enthusiasm: 0,
+    @Flag(abbr: 'l', help: 'Put names on separate lines.') bool lineMode: false,
     @Option(name: 'greeting', help: 'Alternate word to greet with e.g. "Hi".')
-        String salutation: 'Hello'}) {}
+    String salutation: 'Hello'}) {}

--- a/test/regression/0400/0444.unit
+++ b/test/regression/0400/0444.unit
@@ -17,10 +17,8 @@ class MyComponent {
   Object secondArgument;
 
   MyComponent(
-      @Inject(const MyFirstArgument())
-          this.firstArgument,
+      @Inject(const MyFirstArgument()) this.firstArgument,
       @Inject(const MySuperDuperLongNamedArgument())
-          this.superDuperLongNamedArgument, // LOOK AT ME
-      @Inject(const MySecondArgument())
-          this.secondArgument);
+      this.superDuperLongNamedArgument, // LOOK AT ME
+      @Inject(const MySecondArgument()) this.secondArgument);
 }

--- a/test/regression/1200/1212.unit
+++ b/test/regression/1200/1212.unit
@@ -1,0 +1,153 @@
+>>>
+class _$_ProjectOptions extends _ProjectOptions  {
+  const _$_ProjectOptions({required this.routeId, required this.action}): super._();
+
+@override
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  initialize,required TResult Function( AppState state)  receiveUpdatedAppState,required TResult Function()  completedInitialFlow,required TResult Function( RouteId<CommonPageRoutePaywall> routeId)  dismissPaywall,required TResult Function( NotificationPermission status)  receiveNotificationPermissionStatus,required TResult Function( Object error,  StackTrace stackTrace)  receiveError,required TResult Function( Object error,  StackTrace stackTrace)  receiveNonFatalError,required TResult Function( Object error,  StackTrace stackTrace)  receiveProjectOperationError,required TResult Function( String? error)  showErrorDialog,required TResult Function( bool success)  handleNetworkOperationResult,required TResult Function( MineralProject project)  openProject,required TResult Function( LegacyProject legacyProject,  MineralProject mineralProject)  migratedProject,required TResult Function( String collectionId,  Template template,  bool asContentCreator)  openTemplate,required TResult Function( EditorSize size)  openEditorWithSize,required TResult Function()  openEditorAndCreateNewProject,required TResult Function( Uri uri,  bool openedAppThroughUri)  receivedDynamicLink,required TResult Function( NavigationAction<AppRoute> action)  mainNavigation,required TResult Function( RouteId<HomeRoute> routeId,  HomeAction action)  home,required TResult Function( RouteId<SplashRoute> routeId,  SplashAction action)  splash,required TResult Function( RouteId<SurveyRoute> routeId,  MagmaSurveyAction action)  survey,required TResult Function( RouteId<AckRoute> routeId,  AckAction action)  ack,required TResult Function( RouteId<SubInfoRoute> routeId,  MagmaSubInfoAction action)  subInfo,required TResult Function( RouteId<ProjectOptionsRoute> routeId,  ProjectOptionsAction action)  projectOptions,required TResult Function( InitializationAction action)  initialization,required TResult Function( ContentAction action)  content,required TResult Function( RouteId<ErrorDialogRoute> routeId,  ErrorDialogAction action)  errorDialog,required TResult Function( RouteId<InfoDialogRoute> routeId,  InfoDialogAction action)  infoDialog,required TResult Function( MagmaRatingConfiguration configuration)  dismissedRating,required TResult Function( RouteId<SupportRoute> routeId,  MagmaSupportAction action)  support,required TResult Function( RouteId<ClayEditorRoute> routeId,  EditorRootAction action)  clayEditor,required TResult Function( RouteId<TemplateSurveyRoute> routeId,  MagmaTemplateSurveyAction action)  templateSurvey,required TResult Function( RouteId<CollabRoute> routeId,  MagmaCollabAction action)  collab,required TResult Function( RouteId<RedeemCodeRoute> routeId,  MagmaRedeemCodeAction action)  redeemCode,required TResult Function( RouteId<OutdatedDialogRoute> routeId,  OutdatedDialogAction action)  outdatedDialog,required TResult Function( MagazineAction action)  magazine,required TResult Function( RouteId<TemplateCollectionListRoute> routeId,  TemplateCollectionListAction action)  templateCollectionList,required TResult Function( RouteId<CollectionDetailRoute> routeId,  CollectionDetailAction action)  collectionDetail,required TResult Function( RouteId<SimpleNewProjectRoute> routeId,  SimpleNewProjectAction action)  simpleNewProject,required TResult Function( RouteId<AppOnboardingFlowRoute> routeId,  OnboardingFlowAction action)  onboardingFlow,required TResult Function( String locale)  receiveUserLocale,required TResult Function( AuthenticationAction action)  authentication,required TResult Function( ToastType type,  Duration? autoDismissAfter)  showToast,required TResult Function()  hideToast,required TResult Function()  dispose,required TResult Function( LoginRouteState routeState)  pushLogin,required TResult Function( RouteId<UpdateEmailRoute> routeId,  UpdateEmailAction action)  updateEmail,required TResult Function( RouteId<AppDeleteAccountRoute> routeId,  DeleteAccountAction action)  deleteAccount,required TResult Function( RouteId<AppMultipleSubscriptionsRoute> routeId,  MultipleSubscriptionsAction action)  multipleSubscriptions,required TResult Function( RouteId<AppExpiredLinkRoute> routeId,  MagmaExpiredLinkAction action)  expiredLink,required TResult Function( CommonPageAction action)  common,required TResult Function()  fetchFcmToken,required TResult Function( String? token)  receivedFcmToken,required TResult Function( RouteId<AppUnlockRoute> routeId,  UnlockAction action)  unlock,required TResult Function()  setShouldSyncPaymentsAfterFirstStartup,required TResult Function( CustomerPurchaseResult result)  handleCustomerPurchaseResult,required TResult Function()  handleIntent,required TResult Function( RouteId<AppPaymentIssuesRoute> routeId,  PaymentIssuesAction action)  paymentIssues,required TResult Function( RouteId<AppSubscriptionCancellationFlowRoute> routeId,  SubscriptionCancellationFlowAction action)  subscriptionCancellationFlow,required TResult Function( BuiltList<FirebaseProject> remoteProjects)  receivedRemoteProjects,required TResult Function()  uploadRemoteProject,required TResult Function( bool shouldRestore)  abortUpload,required TResult Function( bool background)  setBackgroundState,required TResult Function( RouteId<AppPaymentMethodSettingsRoute> routeId,  PaymentMethodSettingsAction action)  paymentMethodSettings,required TResult Function( String id)  showSurvey,required TResult Function( String id,  Iterable<String> templateIds)  showTemplateSurvey,required TResult Function( RouteId<AppRouteSubscriptionAlreadyAssigned> routeId,  SubscriptionAlreadyAssignedAction action)  subscriptionAlreadyAssigned,}) {
+  return projectOptions(routeId,action);
+}
+}
+<<<
+class _$_ProjectOptions extends _ProjectOptions {
+  const _$_ProjectOptions({required this.routeId, required this.action})
+      : super._();
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialize,
+    required TResult Function(AppState state) receiveUpdatedAppState,
+    required TResult Function() completedInitialFlow,
+    required TResult Function(RouteId<CommonPageRoutePaywall> routeId)
+        dismissPaywall,
+    required TResult Function(NotificationPermission status)
+        receiveNotificationPermissionStatus,
+    required TResult Function(Object error, StackTrace stackTrace) receiveError,
+    required TResult Function(Object error, StackTrace stackTrace)
+        receiveNonFatalError,
+    required TResult Function(Object error, StackTrace stackTrace)
+        receiveProjectOperationError,
+    required TResult Function(String? error) showErrorDialog,
+    required TResult Function(bool success) handleNetworkOperationResult,
+    required TResult Function(MineralProject project) openProject,
+    required TResult Function(
+            LegacyProject legacyProject, MineralProject mineralProject)
+        migratedProject,
+    required TResult Function(
+            String collectionId, Template template, bool asContentCreator)
+        openTemplate,
+    required TResult Function(EditorSize size) openEditorWithSize,
+    required TResult Function() openEditorAndCreateNewProject,
+    required TResult Function(Uri uri, bool openedAppThroughUri)
+        receivedDynamicLink,
+    required TResult Function(NavigationAction<AppRoute> action) mainNavigation,
+    required TResult Function(RouteId<HomeRoute> routeId, HomeAction action)
+        home,
+    required TResult Function(RouteId<SplashRoute> routeId, SplashAction action)
+        splash,
+    required TResult Function(
+            RouteId<SurveyRoute> routeId, MagmaSurveyAction action)
+        survey,
+    required TResult Function(RouteId<AckRoute> routeId, AckAction action) ack,
+    required TResult Function(
+            RouteId<SubInfoRoute> routeId, MagmaSubInfoAction action)
+        subInfo,
+    required TResult Function(
+            RouteId<ProjectOptionsRoute> routeId, ProjectOptionsAction action)
+        projectOptions,
+    required TResult Function(InitializationAction action) initialization,
+    required TResult Function(ContentAction action) content,
+    required TResult Function(
+            RouteId<ErrorDialogRoute> routeId, ErrorDialogAction action)
+        errorDialog,
+    required TResult Function(
+            RouteId<InfoDialogRoute> routeId, InfoDialogAction action)
+        infoDialog,
+    required TResult Function(MagmaRatingConfiguration configuration)
+        dismissedRating,
+    required TResult Function(
+            RouteId<SupportRoute> routeId, MagmaSupportAction action)
+        support,
+    required TResult Function(
+            RouteId<ClayEditorRoute> routeId, EditorRootAction action)
+        clayEditor,
+    required TResult Function(RouteId<TemplateSurveyRoute> routeId,
+            MagmaTemplateSurveyAction action)
+        templateSurvey,
+    required TResult Function(
+            RouteId<CollabRoute> routeId, MagmaCollabAction action)
+        collab,
+    required TResult Function(
+            RouteId<RedeemCodeRoute> routeId, MagmaRedeemCodeAction action)
+        redeemCode,
+    required TResult Function(
+            RouteId<OutdatedDialogRoute> routeId, OutdatedDialogAction action)
+        outdatedDialog,
+    required TResult Function(MagazineAction action) magazine,
+    required TResult Function(RouteId<TemplateCollectionListRoute> routeId,
+            TemplateCollectionListAction action)
+        templateCollectionList,
+    required TResult Function(RouteId<CollectionDetailRoute> routeId,
+            CollectionDetailAction action)
+        collectionDetail,
+    required TResult Function(RouteId<SimpleNewProjectRoute> routeId,
+            SimpleNewProjectAction action)
+        simpleNewProject,
+    required TResult Function(RouteId<AppOnboardingFlowRoute> routeId,
+            OnboardingFlowAction action)
+        onboardingFlow,
+    required TResult Function(String locale) receiveUserLocale,
+    required TResult Function(AuthenticationAction action) authentication,
+    required TResult Function(ToastType type, Duration? autoDismissAfter)
+        showToast,
+    required TResult Function() hideToast,
+    required TResult Function() dispose,
+    required TResult Function(LoginRouteState routeState) pushLogin,
+    required TResult Function(
+            RouteId<UpdateEmailRoute> routeId, UpdateEmailAction action)
+        updateEmail,
+    required TResult Function(
+            RouteId<AppDeleteAccountRoute> routeId, DeleteAccountAction action)
+        deleteAccount,
+    required TResult Function(RouteId<AppMultipleSubscriptionsRoute> routeId,
+            MultipleSubscriptionsAction action)
+        multipleSubscriptions,
+    required TResult Function(
+            RouteId<AppExpiredLinkRoute> routeId, MagmaExpiredLinkAction action)
+        expiredLink,
+    required TResult Function(CommonPageAction action) common,
+    required TResult Function() fetchFcmToken,
+    required TResult Function(String? token) receivedFcmToken,
+    required TResult Function(
+            RouteId<AppUnlockRoute> routeId, UnlockAction action)
+        unlock,
+    required TResult Function() setShouldSyncPaymentsAfterFirstStartup,
+    required TResult Function(CustomerPurchaseResult result)
+        handleCustomerPurchaseResult,
+    required TResult Function() handleIntent,
+    required TResult Function(
+            RouteId<AppPaymentIssuesRoute> routeId, PaymentIssuesAction action)
+        paymentIssues,
+    required TResult Function(
+            RouteId<AppSubscriptionCancellationFlowRoute> routeId,
+            SubscriptionCancellationFlowAction action)
+        subscriptionCancellationFlow,
+    required TResult Function(BuiltList<FirebaseProject> remoteProjects)
+        receivedRemoteProjects,
+    required TResult Function() uploadRemoteProject,
+    required TResult Function(bool shouldRestore) abortUpload,
+    required TResult Function(bool background) setBackgroundState,
+    required TResult Function(RouteId<AppPaymentMethodSettingsRoute> routeId,
+            PaymentMethodSettingsAction action)
+        paymentMethodSettings,
+    required TResult Function(String id) showSurvey,
+    required TResult Function(String id, Iterable<String> templateIds)
+        showTemplateSurvey,
+    required TResult Function(
+            RouteId<AppRouteSubscriptionAlreadyAssigned> routeId,
+            SubscriptionAlreadyAssignedAction action)
+        subscriptionAlreadyAssigned,
+  }) {
+    return projectOptions(routeId, action);
+  }
+}

--- a/test/whitespace/metadata.unit
+++ b/test/whitespace/metadata.unit
@@ -238,7 +238,7 @@ function(@Annotation @VeryLongMetadataAnnotation longParameter) {}
 function(
     @Annotation
     @VeryLongMetadataAnnotation
-        longParameter) {}
+    longParameter) {}
 >>> unsplit with trailing commas
 function(@Annotation longParameter,@Annotation @Other longParameter2,) {}
 <<<
@@ -250,12 +250,11 @@ function(
 function(@Annotation longParameter,@Annotation @Other @Third longParameter2,) {}
 <<<
 function(
-  @Annotation
-      longParameter,
+  @Annotation longParameter,
   @Annotation
   @Other
   @Third
-      longParameter2,
+  longParameter2,
 ) {}
 >>> keep "covariant" with parameter
 class A { function(@Annotation @VeryLongMetadataAnnotation covariant longParameter) {} }
@@ -264,7 +263,7 @@ class A {
   function(
       @Annotation
       @VeryLongMetadataAnnotation
-          covariant longParameter) {}
+      covariant longParameter) {}
 }
 >>> keep "required" with parameter
 class A { function({@Annotation @VeryLongMetadataAnnotation required longParameter}) {} }
@@ -273,7 +272,7 @@ class A {
   function(
       {@Annotation
       @VeryLongMetadataAnnotation
-          required longParameter}) {}
+      required longParameter}) {}
 }
 >>> metadata on function typedef
 @foo typedef Fn = Function();


### PR DESCRIPTION
Also, don't indent parameters with metadata annotations.

Before this change, the formatter indents any parameter that contains metadata annotations that end up splitting:

    function(
        @required
            int n,
        @Deprecated('Some long deprecation string.')
            String s) {
      ...
    }

It also treats all parameters in a parameter list as a unit when deciding how to split their metadata. If any annotation in any parameter splits, then they all do. That's why there's a split after `@required` in the above example.

The intent of both of these is so that a parameter with unsplit metadata doesn't get confused for an annotation on the next parameter:

    function(
        @first('some string') int n,
        @second('another string forces a split')
        String s) {
      ...
    }

Note here that there are two parameters, `n`, and `s`, and not just a single parameter `s` with two annotations.

Unfortunately line splitting all of the parameters as a unit is very bad for performance when there is a large number of parameters (#1212). Also, it's not very helpful. In practice, parameter metadata is rare and most parameters that have any annotations only have one.

And the indentation is just strange looking and inconsistent with how annotations are formatted elsewhere. It also means that parameters with split metadata don't align with parameters that don't have metadata.

This change determines whether each parameter's annotations should split independently from the other parameters' and removes that indentation. The above example becomes:

    function(
        @required int n,
        @Deprecated('Some long deprecation string.')
        String s) {
      ...
    }

This improves performance on large parameter lists and I think looks better on real-world examples. I ran it on a large corpus (2,112,352 lines in 6,911 files) and I think the impact is small enough to not go through the full change process:

293 insertions + 443 deletions = 736 changes
1 changed line for every 2870.04 lines of code
0.3484 changed lines for every 1,000 lines of code

The full diff is: https://gist.github.com/munificent/1dc7361438934a3587f6149049682e29

Fix #1212.

cc @oprypin 