### PR TITLE
Don't split before `.` following a record literal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.2-dev
+
+* Don't split before `.` following a record literal (#1213).
+
 # 2.3.1
 
 * Hide `--fix` and related options in `--help`. The options are still there and

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -38,6 +38,10 @@ extension AstNodeExtensions on AstNode {
     return body is BlockFunctionBody && body.block.statements.isNotEmpty;
   }
 
+  /// Whether this node is a bracket-delimited collection literal.
+  bool get isCollectionLiteral =>
+      this is ListLiteral || this is RecordLiteral || this is SetOrMapLiteral;
+
   bool get isControlFlowElement => this is IfElement || this is ForElement;
 
   /// Whether this is immediately contained within an anonymous

--- a/lib/src/call_chain_visitor.dart
+++ b/lib/src/call_chain_visitor.dart
@@ -284,8 +284,7 @@ class CallChainVisitor {
     }
 
     // Don't split right after a collection literal.
-    if (expression is ListLiteral) return false;
-    if (expression is SetOrMapLiteral) return false;
+    if (expression.isCollectionLiteral) return false;
 
     // Don't split right after a non-empty curly-bodied function.
     if (expression is FunctionExpression) {

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -428,9 +428,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     var splitIfTargetSplits = true;
     if (node.cascadeSections.length > 1) {
       // Always split if there are multiple cascade sections.
-    } else if (target is ListLiteral ||
-        target is RecordLiteral ||
-        target is SetOrMapLiteral) {
+    } else if (target.isCollectionLiteral) {
       splitIfTargetSplits = false;
     } else if (target is InvocationExpression) {
       // If the target is a call with a trailing comma in the argument list,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.1
+version: 2.3.2-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/regression/1200/1213.unit
+++ b/test/regression/1200/1213.unit
@@ -1,0 +1,25 @@
+>>>
+main() {
+  final a = (
+    element,
+    element,
+  )
+      .getter;
+
+  final b = [
+    element,
+    element,
+  ].getter;
+}
+<<<
+main() {
+  final a = (
+    element,
+    element,
+  ).getter;
+
+  final b = [
+    element,
+    element,
+  ].getter;
+}

--- a/test/splitting/invocations.stmt
+++ b/test/splitting/invocations.stmt
@@ -278,6 +278,16 @@ someVeryLongTargetFunction(
   "key": "value",
   "another": "another value"
 }.someLongMethod();
+>>> do not split on "." when target is record
+(element, element, element, element, element).someLongMethod();
+<<<
+(
+  element,
+  element,
+  element,
+  element,
+  element
+).someLongMethod();
 >>> do not split on "." when target is function literal passed to method
 method(() {;}).someLongMethod();
 <<<


### PR DESCRIPTION
Fix #1213.