### PR TITLE
Don't force split on a line comment before a switch expression case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.2-dev
+
+* Don't force split on a line comment before a switch expression case (#1215).
+
 # 2.3.1
 
 * Hide `--fix` and related options in `--help`. The options are still there and

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2824,7 +2824,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     if (whenClause != null) {
       // Wrap the when clause rule around the pattern so that if the pattern
       // splits then we split before "when" too.
-      builder.startRule();
+      builder.startLazyRule();
       builder.nestExpression(indent: Indent.block);
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.1
+version: 2.3.2-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/comments/switch.stmt
+++ b/test/comments/switch.stmt
@@ -145,6 +145,18 @@ e = switch (n) {
   1 => one, // comment
   2 => two // comment
 };
+>>> line comment before case with guard does not force split
+e = switch (n) {
+  0 => zero,
+  // comment
+  1 when true => one,
+};
+<<<
+e = switch (n) {
+  0 => zero,
+  // comment
+  1 when true => one,
+};
 >>> line comment
 switch (e) {
   // comment

--- a/test/regression/1200/1215.stmt
+++ b/test/regression/1200/1215.stmt
@@ -1,0 +1,14 @@
+>>>
+return switch (level) {
+  0 => a,
+  // Comment.
+  1
+      when flag =>
+    b,
+};
+<<<
+return switch (level) {
+  0 => a,
+  // Comment.
+  1 when flag => b,
+};


### PR DESCRIPTION
Fix #1215.