### PR TITLE
Use analyzer 5.12, fix uses of deprecated APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   on other parameters (#1212).
 * Don't split before `.` following a record literal (#1213).
 * Don't force split on a line comment before a switch expression case (#1215).
+* Require `package:analyzer` `^5.12.0`.
 
 # 2.3.1
 

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -153,13 +153,13 @@ class DartFormatter {
       var token = node.endToken.next!;
       if (token.type != TokenType.CLOSE_CURLY_BRACKET) {
         var stringSource = StringSource(text, source.uri);
-        var error = AnalysisError(
-            stringSource,
-            token.offset - inputOffset,
-            math.max(token.length, 1),
-            ParserErrorCode.UNEXPECTED_TOKEN,
-            [token.lexeme]);
-
+        var error = AnalysisError.tmp(
+            source: stringSource,
+            offset: token.offset - inputOffset,
+            length: math.max(token.length, 1),
+            errorCode: ParserErrorCode.UNEXPECTED_TOKEN,
+            arguments: [token.lexeme],
+        );
         throw FormatterException([error]);
       }
     }

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -9,8 +9,6 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/source/line_info.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/clients/dart_style/rewrite_cascade.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/dart/ast/ast.dart' as src_ast;
 
 import 'argument_list_visitor.dart';
 import 'ast_extensions.dart';
@@ -2254,24 +2252,22 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   @override
   void visitNamedType(NamedType node) {
-    final importPrefix = node.importPrefix;
+    var importPrefix = node.importPrefix;
     if (importPrefix != null) {
-      // TODO(scheglov) This is wrong, we should not create nodes here.
-      // But I don't see how to change CallChainVisitor() to work with tokens.
-      // So, I will leave it to the maintainers to figure this out.
-      visit(
-        src_ast.PrefixedIdentifierImpl(
-          prefix: src_ast.SimpleIdentifierImpl(importPrefix.name),
-          period: importPrefix.period,
-          identifier: src_ast.SimpleIdentifierImpl(node.name2),
-        ),
-      );
-    } else {
-      token(node.name2);
+      builder.startSpan();
+
+      token(importPrefix.name);
+      soloZeroSplit();
+      token(importPrefix.period);
     }
 
+    token(node.name2);
     visit(node.typeArguments);
     token(node.question);
+
+    if (importPrefix != null) {
+      builder.endSpan();
+    }
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
-  analyzer: ^5.7.0
+  analyzer: ^5.12.0
   args: ">=1.0.0 <3.0.0"
   path: ^1.0.0
   pub_semver: ">=1.4.4 <3.0.0"


### PR DESCRIPTION
This PR requires `analyzer 5.12.0` and higher, and stops using deprecated APIs.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for a week or two of latency for initial review feedback.

---
