### PR TITLE
Remove test for `inline class`

### DIFF
--- a/test/whitespace/classes.unit
+++ b/test/whitespace/classes.unit
@@ -244,7 +244,3 @@ abstract mixin class C12 = Object
     with Mixin;
 abstract base mixin class C13 = Object
     with Mixin;
->>> inline classes
-inline  class C {}
-<<<
-inline class C {}


### PR DESCRIPTION
This test is obsolete and is now problematic because it seems to fail under some circumstances.
