### PR TITLE
Remove support for `inline class`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.3.3
+## 2.3.3-dev
 
 * Remove support for `inline class` since that syntax has changed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.3
+
+* Remove support for `inline class` since that syntax has changed.
+
 ## 2.3.2
 
 * Don't indent parameters that have metadata annotations. Instead, align them

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -590,7 +590,6 @@ class SourceVisitor extends ThrowingAstVisitor {
     modifier(node.finalKeyword);
     modifier(node.sealedKeyword);
     modifier(node.mixinKeyword);
-    modifier(node.inlineKeyword);
     token(node.classKeyword);
     space();
     token(node.name);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.2
+version: 2.3.3-dev
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/whitespace/classes.unit
+++ b/test/whitespace/classes.unit
@@ -244,7 +244,3 @@ abstract mixin class C12 = Object
     with Mixin;
 abstract base mixin class C13 = Object
     with Mixin;
->>> inline classes
-inline  class C {}
-<<<
-inline class C {}


### PR DESCRIPTION
That isn't the syntax we're going with and this will let the analyzer team change the AST API.

Fix #1241.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

cc @oprypin 