### PR TITLE
Bump version to public 2.3.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.3.3-dev
+## 2.3.3
 
 * Always split enum declarations containing a line comment (#1254).
 * Fix regression in splitting type annotations with library prefixes (#1249).

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -11,7 +11,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '2.3.2';
+const dartStyleVersion = '2.3.3';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 class FormatterOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.3-dev
+version: 2.3.3
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
I want to kick out a release before I start landing the new IR stuff on the main branch.
