### PR TITLE
Revamp how comments are handled.

### DIFF
--- a/lib/src/chunk_builder.dart
+++ b/lib/src/chunk_builder.dart
@@ -4,6 +4,7 @@
 import 'dart:math' as math;
 
 import 'chunk.dart';
+import 'comment_type.dart';
 import 'constants.dart';
 import 'dart_formatter.dart';
 import 'debug.dart' as debug;

--- a/lib/src/comment_type.dart
+++ b/lib/src/comment_type.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+enum CommentType {
+  /// A `///` or `/**` doc comment.
+  doc,
+
+  /// A non-doc line comment.
+  line,
+
+  /// A `/* ... */` comment that should be on its own line.
+  ///
+  /// These occur when the block comment doesn't appear with any code on the
+  /// same line preceding the `/*` or after the `*/`.
+  block,
+
+  /// A `/* ... */` comment that can share a line with other code.
+  ///
+  /// These occur when there is code on the same line either immediately
+  /// preceding the `/*`, after the `*/`, or both. An inline block comment
+  /// may be multiple lines, as in:
+  ///
+  /// ```
+  /// code /* comment
+  ///   more */
+  /// ```
+  inlineBlock,
+}

--- a/lib/src/front_end/comment_writer.dart
+++ b/lib/src/front_end/comment_writer.dart
@@ -7,18 +7,20 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/source/line_info.dart';
 
 import '../comment_type.dart';
-import '../piece/sequence.dart';
 import 'piece_writer.dart';
 
-/// Functionality used by [AstNodeVisitor] to build text and pieces from the
-/// comment tokens between meaningful tokens used by AST nodes.
+/// Functionality used by [AstNodeVisitor] and [SequenceBuilder] to build text
+/// and pieces from the comment tokens between meaningful tokens used by AST
+/// nodes.
 ///
-/// Also handles preserving discretionary blank lines in places where they are
-/// allowed. These are handled with comments because both comments and
-/// whitespace are found between the linear series of [Token]s produced by the
-/// analyzer parser. Likewise, both are output as whitespace (in the sense of
-/// not being executable code) interleaved with the [Piece]-building code that
-/// walks the actual AST and processes the code tokens.
+/// Also handles tracking newlines between tokens and comments so that
+/// information can be used to preserve discretionary blank lines in places
+/// where they are allowed. These are handled along with comments because both
+/// comments and whitespace are found between the linear series of [Token]s
+/// produced by the analyzer parser. Likewise, both are output as whitespace
+/// (in the sense of not being executable code) interleaved with the
+/// [Piece]-building code that walks the actual AST and processes the code
+/// tokens.
 ///
 /// Comments are a challenge because they confound the intuitive tree-like
 /// structure of the code. A comment can appear between any two tokens, and a
@@ -26,109 +28,51 @@ import 'piece_writer.dart';
 /// one wouldn't otherwise make sense. When that happens, the formatter then
 /// has to decide how to indent the next line.
 ///
-/// To deal with that, there are two styles or ways that comments are handled:
+/// At the same time, comments appearing in idiomatic locations like between
+/// statements should be formatted gracefully and give users control over the
+/// blank lines around them. To support all of that, comments are handled in a
+/// couple of different ways.
 ///
-/// ### Sequence comments
-///
-/// Most comments appear around statements in a block, members in a class, or
-/// at the top level of a file. At the point the comment appears, the formatter
-/// is in the middle of building a [SequencePiece]. For those, [CommentWriter]
-/// treats the comments almost like their own statements or members and inserts
-/// them into the surrounding sequence as their own separate pieces.
-///
-/// Sequences already support allowing discretionary blank lines between child
-/// pieces, so this lets us use that same functionality to control blank lines
-/// between comments as well.
-///
-/// ### Non-sequence comments
+/// Comments between top-level declarations, member declarations inside types,
+/// and statements are handled directly by [SequenceBuilder].
 ///
 /// All other comments occur inside the middle of some expression or other
 /// construct. These get directly embedded in the [TextPiece] of the code being
 /// written. When that [TextPiece] is output later, it will include the comments
 /// as well.
+// TODO(tall): When argument lists and their comment handling is supported,
+// mention that here.
 mixin CommentWriter {
   PieceWriter get writer;
 
   LineInfo get lineInfo;
 
-  /// If the next token written is the first token in a sequence element, this
-  /// will be that sequence.
-  SequencePiece? _pendingSequence;
+  /// The tokens whose preceding comments have already been taken by calls to
+  /// [takeCommentsBefore()].
+  final Set<Token> _takenTokens = {};
 
-  /// Call this before visiting an AST node that will become a piece in a
-  /// [SequencePiece].
-  void beforeSequenceNode(SequencePiece sequence) {
-    _pendingSequence = sequence;
+  /// Returns the comments that appear before [token].
+  ///
+  /// The caller is required to write them because a later call to [token()]
+  /// for this token will not write the preceding comments.
+  CommentSequence takeCommentsBefore(Token token) {
+    if (_takenTokens.contains(token)) return CommentSequence.empty;
+    _takenTokens.add(token);
+    return _collectComments(token);
   }
 
   /// Writes comments that appear before [token].
-  void writeCommentsAndBlanksBefore(Token token) {
-    if (_pendingSequence case var sequence?) {
-      _pendingSequence = null;
-      _writeSequenceComments(sequence, token);
-    } else {
-      _writeNonSequenceComments(token);
-    }
-  }
-
-  /// Writes [comments] to [sequence].
-  ///
-  /// This is used when the token is the first token in a node inside a
-  /// sequence. In that case, any comments that belong on their own line go as
-  /// separate elements in the sequence. This lets the sequence handle blank
-  /// lines before and/or after them.
-  void _writeSequenceComments(SequencePiece sequence, Token token) {
-    var comments = _collectComments(token);
-
-    // Edge case: if we require a blank line, but there exists one between
-    // some of the comments, or after the last one, then we don't need to
-    // enforce one before the first comment. Example:
-    //
-    //     library foo;
-    //     // comment
-    //
-    //     class Bar {}
-    //
-    // Normally, a blank line is required after `library`, but since there is
-    // one after the comment, we don't need one before it. This is mainly so
-    // that commented out directives stick with their preceding group.
-    if (comments.containsBlank) {
-      sequence.removeBlank();
-    }
-
-    for (var i = 0; i < comments.length; i++) {
-      var comment = comments[i];
-      if (sequence.contents.isNotEmpty && comments.isHanging(i)) {
-        // Attach the comment to the previous token.
-        writer.space();
-
-        writer.writeComment(comment, following: true);
-      } else {
-        // Write the comment as its own sequence piece.
-        writer.writeComment(comment);
-        if (comments.linesBefore(i) > 1) sequence.addBlank();
-        sequence.add(writer.pop());
-        writer.split();
-      }
-    }
-
-    // Write a blank before the token if there should be one.
-    if (comments.linesBeforeNextToken > 1) sequence.addBlank();
-  }
-
-  /// Writes comments before [token] when [token] is not the first element in
-  /// a sequence.
-  ///
-  /// In that case, the comments are directly embedded in the [TextPiece]s for
-  /// the preceding token and/or [token].
-  void _writeNonSequenceComments(Token token) {
+  void writeCommentsBefore(Token token) {
     // In the common case where there are no comments before the token, early
     // out. This avoids calculating the number of newlines between every pair
     // of tokens which is slow and unnecessary.
     if (token.precedingComments == null) return;
 
-    var comments = _collectComments(token);
+    // Don't write the comments if some other construct has already handled
+    // them.
+    if (_takenTokens.contains(token)) return;
 
+    var comments = _collectComments(token);
     for (var i = 0; i < comments.length; i++) {
       var comment = comments[i];
 
@@ -161,7 +105,7 @@ mixin CommentWriter {
     // just override the script tag's line.
     if (token.previous!.type == TokenType.SCRIPT_TAG) previousLine = tokenLine;
 
-    var comments = CommentSequence();
+    var comments = CommentSequence._([], []);
     for (Token? comment = token.precedingComments;
         comment != null;
         comment = comment.next) {
@@ -287,13 +231,17 @@ class SourceComment {
 /// * 3 newlines between `/* c3 */` and `b`
 /// ```
 class CommentSequence extends ListBase<SourceComment> {
+  static const CommentSequence empty = CommentSequence._([0], []);
+
   /// The number of newlines between a pair of comments or the preceding or
   /// following tokens.
   ///
   /// This list is always one element longer than [_comments].
-  final List<int> _linesBetween = [];
+  final List<int> _linesBetween;
 
-  final List<SourceComment> _comments = [];
+  final List<SourceComment> _comments;
+
+  const CommentSequence._(this._linesBetween, this._comments);
 
   /// The number of newlines between the comment at [commentIndex] and the
   /// preceding comment or token.

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -7,6 +7,7 @@ import '../dart_formatter.dart';
 import '../debug.dart' as debug;
 import '../piece/piece.dart';
 import '../source_code.dart';
+import 'comment_writer.dart';
 
 /// Incrementally builds [Piece]s while visiting AST nodes.
 ///
@@ -114,7 +115,18 @@ class PieceWriter {
   ///
   /// If [text] internally contains a newline, then [containsNewline] should
   /// be `true`.
-  void write(String text,
+  void write(String text) {
+    _write(text);
+  }
+
+  /// Write the contents of [comment] to the current innnermost [TextPiece],
+  /// handling any newlines that may appear in it.
+  void writeComment(SourceComment comment, {bool following = false}) {
+    _write(comment.text,
+        containsNewline: comment.containsNewline, following: following);
+  }
+
+  void _write(String text,
       {bool containsNewline = false, bool following = false}) {
     var textPiece = _currentText;
 

--- a/lib/src/front_end/sequence_builder.dart
+++ b/lib/src/front_end/sequence_builder.dart
@@ -1,0 +1,93 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+
+import '../piece/piece.dart';
+import '../piece/sequence.dart';
+import 'piece_factory.dart';
+
+/// Incrementally builds a [SequencePiece], including handling comments and
+/// newlines that may appear before, between, or after its contents.
+///
+/// Comments are handled specially here so that we can give them better
+/// formatting than we would be able to if we treated all comments generally.
+///
+/// Most comments appear around statements in a block, members in a class, or
+/// at the top level of a file. For those, we treat them essentially like
+/// separate statements inside the sequence. This lets us gracefully handle
+/// indenting them and supporting blank lines around them the same way we handle
+/// other statements or members in a sequence.
+class SequenceBuilder {
+  final PieceFactory _visitor;
+
+  /// The series of members or statements.
+  final List<Piece> _contents = [];
+
+  /// The pieces that should have a blank line preserved between them and the
+  /// next piece.
+  final Set<Piece> _blanksAfter = {};
+
+  SequenceBuilder(this._visitor);
+
+  SequencePiece build() => SequencePiece(_contents, _blanksAfter);
+
+  /// Visits [node] and adds the resulting [Piece] to this sequence, handling
+  /// any comments or blank lines that appear before it.
+  void add(AstNode node) {
+    addCommentsBefore(node.beginToken);
+    _visitor.visit(node);
+    _contents.add(_visitor.writer.pop());
+    _visitor.writer.split();
+  }
+
+  /// Appends a blank line before the next piece in the sequence.
+  void addBlank() {
+    if (_contents.isEmpty) return;
+    _blanksAfter.add(_contents.last);
+  }
+
+  /// Writes any comments appearing before [token] to the sequence.
+  ///
+  /// Comments between sequence elements get special handling where comments
+  /// on their own line become standalone sequence elements.
+  void addCommentsBefore(Token token) {
+    var comments = _visitor.takeCommentsBefore(token);
+
+    // Edge case: if we require a blank line, but there exists one between
+    // some of the comments, or after the last one, then we don't need to
+    // enforce one before the first comment. Example:
+    //
+    //     library foo;
+    //     // comment
+    //
+    //     class Bar {}
+    //
+    // Normally, a blank line is required after `library`, but since there is
+    // one after the comment, we don't need one before it. This is mainly so
+    // that commented out directives stick with their preceding group.
+    if (comments.containsBlank && _contents.isNotEmpty) {
+      _blanksAfter.remove(_contents.last);
+    }
+
+    for (var i = 0; i < comments.length; i++) {
+      var comment = comments[i];
+      if (_contents.isNotEmpty && comments.isHanging(i)) {
+        // Attach the comment to the previous token.
+        _visitor.writer.space();
+
+        _visitor.writer.writeComment(comment, following: true);
+      } else {
+        // Write the comment as its own sequence piece.
+        _visitor.writer.writeComment(comment);
+        if (comments.linesBefore(i) > 1) addBlank();
+        _contents.add(_visitor.writer.pop());
+        _visitor.writer.split();
+      }
+    }
+
+    // Write a blank before the token if there should be one.
+    if (comments.linesBeforeNextToken > 1) addBlank();
+  }
+}

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -9,28 +9,13 @@ import 'piece.dart';
 /// body.
 class SequencePiece extends Piece {
   /// The series of members or statements.
-  final List<Piece> contents = [];
+  final List<Piece> contents;
 
   /// The pieces that should have a blank line preserved between them and the
   /// next piece.
-  final Set<Piece> _blanksAfter = {};
+  final Set<Piece> _blanksAfter;
 
-  /// Appends [piece] to the sequence.
-  void add(Piece piece) {
-    contents.add(piece);
-  }
-
-  /// Appends a blank line before the next piece in the sequence.
-  void addBlank() {
-    if (contents.isEmpty) return;
-    _blanksAfter.add(contents.last);
-  }
-
-  /// Removes the blank line that has been appended over the last piece.
-  void removeBlank() {
-    if (contents.isEmpty) return;
-    _blanksAfter.remove(contents.last);
-  }
+  SequencePiece(this.contents, this._blanksAfter);
 
   @override
   int get stateCount => 1;

--- a/lib/src/source_comment.dart
+++ b/lib/src/source_comment.dart
@@ -1,33 +1,8 @@
 // Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'comment_type.dart';
 import 'selection.dart';
-
-enum CommentType {
-  /// A `///` or `/**` doc comment.
-  doc,
-
-  /// A non-doc line comment.
-  line,
-
-  /// A `/* ... */` comment that should be on its own line.
-  ///
-  /// These occur when the block comment doesn't appear with any code on the
-  /// same line preceding the `/*` or after the `*/`.
-  block,
-
-  /// A `/* ... */` comment that can share a line with other code.
-  ///
-  /// These occur when there is code on the same line either immediately
-  /// preceding the `/*`, after the `*/`, or both. An inline block comment
-  /// may be multiple lines, as in:
-  ///
-  /// ```
-  /// code /* comment
-  ///   more */
-  /// ```
-  inlineBlock,
-}
 
 /// A comment in the source, with a bit of information about the surrounding
 /// whitespace.

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -15,6 +15,7 @@ import 'ast_extensions.dart';
 import 'call_chain_visitor.dart';
 import 'chunk.dart';
 import 'chunk_builder.dart';
+import 'comment_type.dart';
 import 'constants.dart';
 import 'dart_formatter.dart';
 import 'rule/argument.dart';

--- a/test/statement/block_comment.stmt
+++ b/test/statement/block_comment.stmt
@@ -12,7 +12,7 @@
 {/* comment */}
 >>>
 {
-  
+
   /* comment */
 
 
@@ -29,7 +29,7 @@ line */
 }
 >>>
 {
-  
+
   /* comment
 line */
 
@@ -65,7 +65,7 @@ line */
 
 
 
-  // commennt
+  // comment
 
 
 
@@ -80,7 +80,18 @@ line */
 
   b;
 
-  // commennt
+  // comment
 
+  c;
+}
+>>> comment before labeled statement
+{
+  /* c */ a: b: c;
+}
+<<<
+{
+  /* c */
+  a:
+  b:
   c;
 }


### PR DESCRIPTION
I'm working on getting argument lists formatting, including comments, and that pushed on a bunch of weak spots in the current way comments are handled. So I tried to clean that up first.

The general problem is comments are a sort of "fencepost" data structure where we need to track the number of newlines between each comment, including before the first and after the last. The previous code modeled that by having each comment store the number of lines before it, and then passing around a separate int for the number of newlines after it.

This commit adds a new CommentSequence class that models it directly and has nicer operations to get the newlines before or after any given comment. I believe it will make argument list comments easier to implement, and easier to share code with how sequences/blocks handle their comments.

The main downside is that I forked the SourceComment class. There's the old one for the old style and the new one. I couldn't come up with a better name, so the two classes have the same name. But no library should end up importing both of them, so it's not a problem in practice, just a little confusing.

I also cleaned up some logic in `_convertComments()` that was ported directly over from the old code but isn't needed in the new system. It used to have to do some hacky stuff like look at the raw characters before a comment to determine whether to split before. That was because the old IR doesn't have much context when it's handling comments. With the new sequence/non-sequence comment approach, we know directly whether we're at the beginning of a block/sequence.
