### PR TITLE
Add formatting for `extension type` declarations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add `tall-style` experiment flag to enable the in-progress unstable new
   formatting style (#1253).
+* Format extension types.
 
 ## 2.3.3
 

--- a/bin/format.dart
+++ b/bin/format.dart
@@ -132,7 +132,8 @@ void main(List<String> args) async {
       show: show,
       output: output,
       summary: summary,
-      setExitIfChanged: setExitIfChanged);
+      setExitIfChanged: setExitIfChanged,
+      experimentFlags: argResults['enable-experiment']);
 
   if (argResults.rest.isEmpty) {
     await formatStdin(options, selection, argResults['stdin-name'] as String);

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1294,8 +1294,10 @@ class SourceVisitor extends ThrowingAstVisitor {
     space();
     token(node.name);
 
+    builder.nestExpression();
     visit(node.typeParameters);
     visit(node.representation);
+    builder.unnest();
 
     builder.startRule(CombinatorRule());
     visit(node.implementsClause);

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2633,48 +2633,8 @@ class SourceVisitor extends ThrowingAstVisitor {
   @override
   void visitRepresentationDeclaration(RepresentationDeclaration node) {
     // Consider having `node.asFormalParameterList()`, and format based on that.
-    // Inline `visitFormalParameterList`, remove all that doesn't apply.
-    void writeAsParameter() {
-      // Inline `visitSimpleFormalParameter`.
-      visitParameterMetadata(node.fieldMetadata, () {
-        // Inline `_beginFormalParameter`
-        builder.startLazyRule(Rule(Cost.parameterType));
-        builder.nestExpression();
-
-        visit(node.fieldType);
-        _separatorBetweenTypeAndVariable(node.fieldType);
-        token(node.fieldName);
-
-        // Inline `_endFormalParameter`
-        builder.unnest();
-        builder.endRule();
-      });
-    }
 
     visit(node.constructorName);
-    if (node.commaAfter != null) {
-      // Trailing comma is not currently allowed, so this code is not tested.
-      // Inline _visitTrailingCommaParameterList
-      builder.startRule(Rule.hard());
-      token(node.leftParenthesis);
-      // Process the parameters as a separate set of chunks.
-      builder = builder.startBlock();
-      builder.writeNewline();
-      // Inlined `visitSimpleFormalParameter`
-      writeAsParameter();
-      _writeCommaAfter(node);
-
-      if (node.rightParenthesis.precedingComments != null) {
-        builder.writeNewline();
-        writePrecedingCommentsAndNewlines(node.rightParenthesis);
-      }
-
-      builder = builder.endBlock();
-      builder.endRule();
-
-      token(node.leftParenthesis);
-      return;
-    }
 
     token(node.leftParenthesis);
 
@@ -2687,7 +2647,22 @@ class SourceVisitor extends ThrowingAstVisitor {
     builder.startBlockArgumentNesting();
     builder.startSpan();
 
-    writeAsParameter();
+    // Inline `visitFormalParameterList`, remove all that doesn't apply
+    // to a required positional parameter with no modifiers
+    // and no trailing comma.
+    visitParameterMetadata(node.fieldMetadata, () {
+      // Inline `_beginFormalParameter`
+      builder.startLazyRule(Rule(Cost.parameterType));
+      builder.nestExpression();
+
+      visit(node.fieldType);
+      _separatorBetweenTypeAndVariable(node.fieldType);
+      token(node.fieldName);
+
+      // Inline `_endFormalParameter`
+      builder.unnest();
+      builder.endRule();
+    });
 
     builder.endBlockArgumentNesting();
     builder.endSpan();

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2632,8 +2632,6 @@ class SourceVisitor extends ThrowingAstVisitor {
 
   @override
   void visitRepresentationDeclaration(RepresentationDeclaration node) {
-    // Consider having `node.asFormalParameterList()`, and format based on that.
-
     visit(node.constructorName);
 
     token(node.leftParenthesis);
@@ -2647,11 +2645,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     builder.startBlockArgumentNesting();
     builder.startSpan();
 
-    // Inline `visitFormalParameterList`, remove all that doesn't apply
-    // to a required positional parameter with no modifiers
-    // and no trailing comma.
     visitParameterMetadata(node.fieldMetadata, () {
-      // Inline `_beginFormalParameter`
       builder.startLazyRule(Rule(Cost.parameterType));
       builder.nestExpression();
 
@@ -2659,7 +2653,6 @@ class SourceVisitor extends ThrowingAstVisitor {
       _separatorBetweenTypeAndVariable(node.fieldType);
       token(node.fieldName);
 
-      // Inline `_endFormalParameter`
       builder.unnest();
       builder.endRule();
     });

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1296,7 +1296,6 @@ class SourceVisitor extends ThrowingAstVisitor {
 
     visit(node.typeParameters);
     visit(node.representation);
-    soloSplit();
 
     builder.startRule(CombinatorRule());
     visit(node.implementsClause);

--- a/lib/src/testing/test_file.dart
+++ b/lib/src/testing/test_file.dart
@@ -59,11 +59,6 @@ class TestFile {
     var tests = <FormatTest>[];
 
     String readLine() {
-      // Skip comment lines.
-      while (lines[i].startsWith('###')) {
-        i++;
-      }
-
       return lines[i++];
     }
 
@@ -188,8 +183,8 @@ SourceCode _extractSelection(String source, {bool isCompilationUnit = false}) {
 /// Turn the special Unicode escape marker syntax used in the tests into real
 /// Unicode characters.
 ///
-/// This does not use Dart's own string escape sequences so that we don't
-/// accidentally modify the Dart code being formatted.
+/// These escapes do not use Dart's own string escape sequences,
+/// to avoid accidentally modifying the Dart code being formatted.
 String _unescapeUnicode(String input) {
   return input.replaceAllMapped(_unicodeUnescapePattern, (match) {
     var codePoint = int.parse(match[1]!, radix: 16);

--- a/lib/src/testing/test_file.dart
+++ b/lib/src/testing/test_file.dart
@@ -59,6 +59,11 @@ class TestFile {
     var tests = <FormatTest>[];
 
     String readLine() {
+      // Skip comment lines.
+      while (lines[i].startsWith('###')) {
+        i++;
+      }
+
       return lines[i++];
     }
 
@@ -183,8 +188,8 @@ SourceCode _extractSelection(String source, {bool isCompilationUnit = false}) {
 /// Turn the special Unicode escape marker syntax used in the tests into real
 /// Unicode characters.
 ///
-/// These escapes do not use Dart's own string escape sequences,
-/// to avoid accidentally modifying the Dart code being formatted.
+/// This does not use Dart's own string escape sequences so that we don't
+/// accidentally modify the Dart code being formatted.
 String _unescapeUnicode(String input) {
   return input.replaceAllMapped(_unicodeUnescapePattern, (match) {
     var codePoint = int.parse(match[1]!, radix: 16);

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -150,8 +150,9 @@ void _testFile(
             pageWidth: testFile.pageWidth,
             indent: formatTest.leadingIndent,
             fixes: [...?baseFixes, ...formatTest.fixes],
-            experimentFlags:
-                useTallStyle ? const [tallStyleExperimentFlag] : null);
+            experimentFlags: useTallStyle
+                ? const ['inline-class', tallStyleExperimentFlag]
+                : const ['inline-class']);
 
         var actual = formatter.formatSource(formatTest.input);
 

--- a/test/whitespace/extension_types.unit
+++ b/test/whitespace/extension_types.unit
@@ -20,8 +20,14 @@ extension type const A(int a) {
 <<<
 @Anno<int, int>()
 extension type const A<S, T>.name(
-    @required Map<int, int> a)
+        @required Map<int, int> a)
     implements I<S>, J<T> {}
+>>> parameter is only double-indented if there is an implements
+extension type const A<S, T>.name(
+        @required Map<int, int> a) {}
+<<<
+extension type const A<S, T>.name(
+    @required Map<int, int> a) {}
 >>> implements on same line if they fit
 extension type E(T i)
     implements I, J {}
@@ -54,12 +60,12 @@ extension type A(int a) {}
 implements /*k*/ I1 /*l*/ , /*m*/ I2 /*n*/ { /*o*/ } /*p*/
 <<<
 /*a*/ extension /*b*/ type /*c*/ A /*d*/ (
-    /*e*/ @ /*f*/ override /*g*/
-    int /*h*/ a /*i*/) /*j*/
+        /*e*/ @ /*f*/ override /*g*/
+        int /*h*/ a /*i*/) /*j*/
     implements /*k*/
         I1 /*l*/,
         /*m*/ I2 /*n*/ {/*o*/} /*p*/
->>> eol comments everywhere
+>>> eol comments everywhere, all retained.
 // 0
 @patch // a
 extension // b
@@ -89,17 +95,17 @@ extension // b
     const // d
     A // e
     < // f
-        T // g
-        > // h
-    . // i
-    name // j
-    (
-    // k
-    @ // l
-    required // m
-    int // n
-        a // o
-    ) // p
+            T // g
+            > // h
+        . // i
+        name // j
+        (
+        // k
+        @ // l
+        required // m
+        int // n
+            a // o
+        ) // p
     implements // q
         I // r
 {

--- a/test/whitespace/extension_types.unit
+++ b/test/whitespace/extension_types.unit
@@ -32,7 +32,7 @@ extension type A(int a) {
   }
 <<<
 extension type A(int a) {}
->>> leading space before "class"
+>>> leading space before "extension type"
   extension type A(int a) {
 }
 <<<
@@ -110,8 +110,66 @@ extension
 
 type
 
+const
 
+A
 
-A(int a){}
+<
+
+T
+
+>
+
+.
+
+name
+
+(
+
+int
+
+a
+
+)
+
+{
+
+}
 <<<
-extension type A(int a) {}
+extension type const A<T>.name(int a) {}
+>>> Supports all members except instance fields
+extension type const A<T>.name(int a) {
+  static  const int c = 1;
+  static  final int f = 1;
+  static  late final int l;
+  static  var v;
+  static  int get g => c;
+  static  set g(int i) {}
+  static  int m<X>(X x) => c;
+  const  A(int a) : this.a = a;
+  const  A.r(int a) : this(a);
+  const  factory A.rf(int a) = A;
+  factory  A.f(int a) => A(a);
+  int  get pr => 0;
+  set  pr(int x) {}
+  int  me(int x) => x;
+  int  operator+(int x) => x;
+}
+<<<
+extension type const A<T>.name(int a) {
+  static const int c = 1;
+  static final int f = 1;
+  static late final int l;
+  static var v;
+  static int get g => c;
+  static set g(int i) {}
+  static int m<X>(X x) => c;
+  const A(int a) : this.a = a;
+  const A.r(int a) : this(a);
+  const factory A.rf(int a) = A;
+  factory A.f(int a) => A(a);
+  int get pr => 0;
+  set pr(int x) {}
+  int me(int x) => x;
+  int operator +(int x) => x;
+}

--- a/test/whitespace/extension_types.unit
+++ b/test/whitespace/extension_types.unit
@@ -1,0 +1,117 @@
+40 columns                              |
+>>> indentation
+extension type const A(int a) {
+inc(int x) => ++x;
+foo(int x) {
+if (x == 0) {
+return true;
+}}}
+<<<
+extension type const A(int a) {
+  inc(int x) => ++x;
+  foo(int x) {
+    if (x == 0) {
+      return true;
+    }
+  }
+}
+>>> all tokens
+@Anno<int, int>() extension type const A<S, T>.name(@required Map<int, int> a) implements I<S>, J<T> {}
+<<<
+@Anno<int, int>()
+extension type const A<S, T>.name(
+    @required Map<int, int> a)
+    implements I<S>, J<T> {}
+>>> implements on same line if they fit
+extension type E(T i)
+    implements I, J {}
+<<<
+extension type E(T i) implements I, J {}
+>>> trailing space inside body
+extension type A(int a) {
+  }
+<<<
+extension type A(int a) {}
+>>> leading space before "class"
+  extension type A(int a) {
+}
+<<<
+extension type A(int a) {}
+>>>
+extension type A(int a)  { int meaningOfLife() => 42; }
+<<<
+extension type A(int a) {
+  int meaningOfLife() => 42;
+}
+>>>
+extension   type   A  (  int  a  )  {
+  }
+<<<
+extension type A(int a) {}
+>>> comments everywhere, all retained
+/*a*/ extension /*b*/ type /*c*/ A
+/*d*/ ( /*e*/ @ /*f*/ override /*g*/ int /*h*/ a /*i*/ ) /*j*/
+implements /*k*/ I1 /*l*/ , /*m*/ I2 /*n*/ { /*o*/ } /*p*/
+<<<
+/*a*/ extension /*b*/ type /*c*/ A /*d*/ (
+    /*e*/ @ /*f*/ override /*g*/
+    int /*h*/ a /*i*/) /*j*/
+    implements /*k*/
+        I1 /*l*/,
+        /*m*/ I2 /*n*/ {/*o*/} /*p*/
+>>> eol comments everywhere
+// 0
+@patch // a
+extension // b
+type // c
+const // d
+A // e
+< // f
+T // g
+> // h
+. // i
+name // j
+( // k
+@ // l
+required // m
+int // n
+a // o
+) // p
+implements // q
+I // r
+{ // s
+} // t
+<<<
+// 0
+@patch // a
+extension // b
+    type // c
+    const // d
+    A // e
+    < // f
+        T // g
+        > // h
+    . // i
+    name // j
+    (
+    // k
+    @ // l
+    required // m
+    int // n
+        a // o
+    ) // p
+    implements // q
+        I // r
+{
+  // s
+} // t
+>>> eats newlines
+extension
+
+type
+
+
+
+A(int a){}
+<<<
+extension type A(int a) {}


### PR DESCRIPTION
Attempt to format extension types. Since they are experimental, the syntax and formatting can still change before launch,but this should make it *possible* to format code containing extension type declarations.

Which will make writing tests much nicer.