### PR TITLE
Actually run the named type tests and then get them passing.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -618,14 +618,14 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitNamedType(NamedType node) {
-    // TODO(tall): Handle import prefix.
-    if (node.importPrefix != null) throw UnimplementedError();
+    if (node.importPrefix case var importPrefix?) {
+      token(importPrefix.name);
+      token(importPrefix.period);
+    }
 
     token(node.name2);
     visit(node.typeArguments);
-
-    // TODO(tall): Handle nullable types.
-    if (node.question != null) throw UnimplementedError();
+    token(node.question);
   }
 
   @override

--- a/test/tall_format_test.dart
+++ b/test/tall_format_test.dart
@@ -14,6 +14,7 @@ void main() async {
   await testDirectory('invocation', tall: true);
   await testDirectory('statement', tall: true);
   await testDirectory('top_level', tall: true);
+  await testDirectory('type', tall: true);
 
   // TODO(tall): The old formatter_test.dart has tests here for things like
   // trailing newlines. Port those over to the new style once it supports all

--- a/test/type/named.stmt
+++ b/test/type/named.stmt
@@ -14,7 +14,8 @@ library_prefix.TypeName x;
 >>> Don't split on prefix.
 very_long_library_prefix  .  VeryLongTypeName  x  ;
 <<<
-very_long_library_prefix.VeryLongTypeName x;
+very_long_library_prefix.VeryLongTypeName
+x;
 >>> Prefixed nullable type.
 prefix  .  TypeName  ?  x  ;
 <<<
@@ -31,13 +32,13 @@ Generic<
   AnotherLongType,
   ThirdOne
 > g;
->>> Splitting in type argument forces type argument list to split.
-Generic<Map<LongTypeName, AnotherType>, ThirdOne> g;
+>>> Splitting in type argument forces outer type argument list to split.
+Generic<Map<LongTypeName, AnotherReallyLongType>, ThirdOne> g;
 <<<
 Generic<
   Map<
     LongTypeName,
-    AnotherType
+    AnotherReallyLongType
   >,
   ThirdOne
 > g;


### PR DESCRIPTION
In #1281, I forgot that adding a new test subdirectory doesn't actually run its tests so they weren't being run. That in turn meant that I forgot to actually implement support for library prefixes and nullable types.

Oops.
