### PR TITLE
Format map and set literals.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -113,7 +113,7 @@ extension ExpressionExtensions on Expression {
         ParenthesizedExpression(:var expression) => expression.isDelimited,
         ListLiteral() => true,
         MethodInvocation() => true,
-        // TODO(tall): Map and set literals.
+        SetOrMapLiteral() => true,
         // TODO(tall): Record literals.
         // TODO(tall): Instance creation expressions (`new` and `const`).
         // TODO(tall): Switch expressions.

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -152,7 +152,7 @@ class PieceWriter {
     if (!hanging) _pendingSplit = false;
   }
 
-  /// Writes a mandatory newline from a comment in the current [TextPiece].
+  /// Writes a mandatory newline from a comment to the current [TextPiece].
   void writeNewline() {
     _pendingNewline = true;
   }

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -6,8 +6,13 @@ import '../constants.dart';
 import 'piece.dart';
 
 /// A piece for any construct where `=` is followed by an expression: variable
-/// initializer, assignment, constructor initializer, etc. Assignments can be
-/// formatted three ways:
+/// initializer, assignment, constructor initializer, etc.
+///
+/// This piece is also used for map entries and named arguments where `:` is
+/// followed by an expression or element because those also want to support the
+/// "block-like" formatting of delimited expressions on the right.
+///
+/// These constructs can be formatted three ways:
 ///
 /// [State.initial] No split at all:
 ///
@@ -59,14 +64,14 @@ class AssignPiece extends Piece {
 
   @override
   void format(CodeWriter writer, State state) {
-    writer.format(target);
-
-    // A split inside the value forces splitting at the "=" unless it's a
-    // delimited expression.
+    // A split in either child piece forces splitting after the "=" unless it's
+    // a delimited expression.
     if (state == State.initial) writer.setAllowNewlines(false);
 
     // Don't indent a split delimited expression.
     if (state != _insideValue) writer.setIndent(Indent.expression);
+
+    writer.format(target);
 
     writer.splitIf(state == _atEquals);
     writer.format(value);

--- a/test/expression/list.stmt
+++ b/test/expression/list.stmt
@@ -3,6 +3,10 @@
 [];
 <<<
 [];
+>>> Const.
+const  [  1  ,  2  ,  3  ]  ;
+<<<
+const [1, 2, 3];
 >>> Exactly page width.
 [  first  ,  second  ,  third  ,  fourth  ,  seventh  ]  ;
 <<<
@@ -69,6 +73,15 @@
 <  int  >  [  1  ,  2  ,  3  ];
 <<<
 <int>[1, 2, 3];
+>>> Split list but not type arguments.
+<Map<int, String>>
+[firstElement, secondElement, thirdElement];
+<<<
+<Map<int, String>>[
+  firstElement,
+  secondElement,
+  thirdElement,
+];
 >>> Split type arguments but not list.
 <Map<VeryLongTypeName, AnotherLongTypeName>>[1, 2, 3];
 <<<

--- a/test/expression/map.stmt
+++ b/test/expression/map.stmt
@@ -1,0 +1,141 @@
+40 columns                              |
+>>> Empty.
+(  {  }  );
+<<<
+({});
+>>> Const.
+const  {  first  :  1  ,  second  :  2  }  ;
+<<<
+const {first: 1, second: 2};
+>>> Exactly page width.
+(  {  first  :  1  ,  second  :  2  ,  third  :  3  ,  f  :  4  }  );
+<<<
+({first: 1, second: 2, third: 3, f: 4});
+>>> Split.
+({first: 1, second: 2, third: 3, fourth: 4,});
+<<<
+({
+  first: 1,
+  second: 2,
+  third: 3,
+  fourth: 4,
+});
+>>> Add trailing comma if split.
+({first: 1, second: 2, third: 3, fourth: 4});
+<<<
+({
+  first: 1,
+  second: 2,
+  third: 3,
+  fourth: 4,
+});
+>>> Remove trailing comma if unsplit.
+({first: 1, second: 2, third: 3,});
+<<<
+({first: 1, second: 2, third: 3});
+>>> Prefer to split entry instead of key.
+({
+  first + second + third + fourth: fifth
+});
+<<<
+({
+  first + second + third + fourth:
+      fifth,
+});
+>>> Prefer to split entry instead of value.
+({
+  first: second + third + fourth + fifth
+});
+<<<
+({
+  first:
+      second + third + fourth + fifth,
+});
+>>> Split in key forces entry to split.
+({
+  first + second + third + fourth + fifth: sixth
+});
+<<<
+({
+  first +
+          second +
+          third +
+          fourth +
+          fifth:
+      sixth,
+});
+>>> Split in value forces entry to split.
+({
+  first: second + third + fourth + fifth + sixth
+});
+<<<
+({
+  first:
+      second +
+          third +
+          fourth +
+          fifth +
+          sixth,
+});
+>>> Remove blank lines around entries.
+({
+
+
+  firstElement: 1,
+
+
+
+  secondElement: 2,
+
+
+
+  thirdElement: 3
+
+
+});
+<<<
+({
+  firstElement: 1,
+  secondElement: 2,
+  thirdElement: 3,
+});
+>>> With type arguments.
+<  int  ,  String  >  {  1  :  'one'  ,  2  :  'two'  };
+<<<
+<int, String>{1: 'one', 2: 'two'};
+>>> Split map but not type arguments.
+<int, String>{firstElement: 'one', secondElement: 'two'};
+<<<
+<int, String>{
+  firstElement: 'one',
+  secondElement: 'two',
+};
+>>> Split type arguments but not map.
+<VeryLongTypeName, AnotherReallyLongTypeName>{1: 'one', 2: 'two'};
+<<<
+<
+  VeryLongTypeName,
+  AnotherReallyLongTypeName
+>{1: 'one', 2: 'two'};
+>>> Split type arguments and map.
+<VeryLongTypeName, AnotherReallyLongTypeName>
+{1: 'value one', 2: 'value two', 3: 'value three'};
+<<<
+<
+  VeryLongTypeName,
+  AnotherReallyLongTypeName
+>{
+  1: 'value one',
+  2: 'value two',
+  3: 'value three',
+};
+>>> Split in nested type argument.
+<List<NotSplit>, Map<VeryLongTypeName, AnotherLongTypeName>>{1: 'one', 2: 'two'};
+<<<
+<
+  List<NotSplit>,
+  Map<
+    VeryLongTypeName,
+    AnotherLongTypeName
+  >
+>{1: 'one', 2: 'two'};

--- a/test/expression/map_comment.stmt
+++ b/test/expression/map_comment.stmt
@@ -1,0 +1,72 @@
+40 columns                              |
+### Maps use most of the same formatting code as lists, so we don't test
+### all of the edge cases here, just the basics and map-specific stuff.
+>>> Line comment in empty map.
+var map = {
+// comment
+};
+<<<
+var map = {
+  // comment
+};
+>>> Inline block comment.
+var map = {  /* comment */  };
+<<<
+var map = {/* comment */};
+>>> After entry.
+({key: value // comment
+});
+<<<
+({
+  key: value, // comment
+});
+>>> Preserve blank lines between comments and entries.
+({
+  // comment
+  element: 1,
+
+
+
+  noComment: 2,
+
+
+  // comment
+
+
+  // another
+
+
+
+  yesComment: 3
+
+
+});
+<<<
+({
+  // comment
+  element: 1,
+  noComment: 2,
+
+  // comment
+
+  // another
+  yesComment: 3,
+});
+>>> Comment after key.
+({key // comment
+: value});
+<<<
+### This looks weird, but users don't usually put comments here.
+({
+  key // comment
+      :
+      value,
+});
+>>> Comment after `:`.
+({key : // comment
+value});
+<<<
+({
+  key: // comment
+      value,
+});

--- a/test/expression/set.stmt
+++ b/test/expression/set.stmt
@@ -1,0 +1,22 @@
+40 columns                              |
+### Sets use most of the same formatting code as lists, so we don't test
+### all of the edge cases here, just the basics.
+>>> Const.
+const  {  first  ,  second  }  ;
+<<<
+const {first, second};
+>>> Split.
+({first, second, third, fourth, fifth, sixth});
+<<<
+({
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+  sixth,
+});
+>>> With type argument.
+<  int  >  {  1  ,  2  };
+<<<
+<int>{1, 2};

--- a/test/expression/set_comment.stmt
+++ b/test/expression/set_comment.stmt
@@ -1,0 +1,22 @@
+40 columns                              |
+### Sets use most of the same formatting code as lists, so we don't test
+### all of the edge cases here, just the basics.
+>>> Line comment in empty set.
+var set = {
+// comment
+};
+<<<
+var set = {
+  // comment
+};
+>>> Inline block comment.
+var set = {  /* comment */  };
+<<<
+var set = {/* comment */};
+>>> After element.
+({element // comment
+});
+<<<
+({
+  element, // comment
+});

--- a/test/invocation/named_argument.stmt
+++ b/test/invocation/named_argument.stmt
@@ -24,3 +24,32 @@ function(
   two: 2,
   "itional",
 );
+>>> Split after argument name.
+function(veryLongParameterName: veryLong + argument + expression);
+<<<
+function(
+  veryLongParameterName:
+      veryLong + argument + expression,
+);
+>>> Use block-like formatting for arguments that are delimited expressions.
+function(list: [element1, element2, element3, element4],
+map: {entry1: valueOne, entry2: valueTwo},
+call: function(argument1, argument2, argument3));
+<<<
+function(
+  list: [
+    element1,
+    element2,
+    element3,
+    element4,
+  ],
+  map: {
+    entry1: valueOne,
+    entry2: valueTwo,
+  },
+  call: function(
+    argument1,
+    argument2,
+    argument3,
+  ),
+);

--- a/test/statement/variable.stmt
+++ b/test/statement/variable.stmt
@@ -136,6 +136,19 @@ var variableNameWithExactLength____ = [];
 <<<
 var variableNameWithExactLength____ =
     [];
+>>> Prefer block-like splitting for maps.
+var variableName = {1: element, 2: element, 3: element};
+<<<
+var variableName = {
+  1: element,
+  2: element,
+  3: element,
+};
+>>> No block-like splitting for empty maps.
+var variableNameWithExactLength____ = {};
+<<<
+var variableNameWithExactLength____ =
+    {};
 >>> Prefer block-like splitting for function calls.
 var variableName = function(argument, argument);
 <<<

--- a/test/statement/variable_comment.stmt
+++ b/test/statement/variable_comment.stmt
@@ -24,3 +24,17 @@ var variableName = [ /* some long comment */ ];
 var variableName = [
   /* some long comment */
 ];
+>>> Line comment before `=`.
+var variable // comment
+= value;
+<<<
+### This looks weird, but users don't usually put comments here.
+var variable // comment
+    =
+    value;
+>>> Line comment after `=`.
+var variable = // comment
+value;
+<<<
+var variable = // comment
+    value;


### PR DESCRIPTION
I'm formatting map entries the same way that assignments and variable declarations are handled, so that we get nice "block-like" formatting for delimited expressions, as in:

```
var map = {
  list: [
    1,
    2,
  ]
};
```

While I was at it, I also updated named arguments to do the same thing:

```
function(
  list: [
    1,
    2,
  ]
);
```

Also handle the "const" keyword on lists. I missed that when adding initial support for lists.
