### PR TITLE
Format trivial expressions: null, doubles, this, symbols.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -193,18 +193,17 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitComment(Comment node) {
-    throw UnimplementedError();
+    assert(false, 'Comments should be handled elsewhere.');
   }
 
   @override
   void visitCommentReference(CommentReference node) {
-    throw UnimplementedError();
+    assert(false, 'Comments should be handled elsewhere.');
   }
 
   @override
   void visitCompilationUnit(CompilationUnit node) {
-    throw UnsupportedError(
-        'CompilationUnit should be handled directly by format().');
+    assert(false, 'CompilationUnit should be handled directly by format().');
   }
 
   @override
@@ -281,7 +280,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitDoubleLiteral(DoubleLiteral node) {
-    throw UnimplementedError();
+    token(node.literal);
   }
 
   @override
@@ -432,7 +431,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitHideCombinator(HideCombinator node) {
-    throw UnimplementedError();
+    assert(false, 'Combinators are handled by createImport().');
   }
 
   @override
@@ -501,13 +500,11 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
   @override
   void visitLabeledStatement(LabeledStatement node) {
     var sequence = SequenceBuilder(this);
-
     for (var label in node.labels) {
       sequence.add(label);
     }
 
     sequence.add(node.statement);
-
     writer.push(sequence.build());
   }
 
@@ -629,7 +626,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitNullLiteral(NullLiteral node) {
-    throw UnimplementedError();
+    token(node.literal);
   }
 
   @override
@@ -789,7 +786,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitShowCombinator(ShowCombinator node) {
-    throw UnimplementedError();
+    assert(false, 'Combinators are handled by createImport().');
   }
 
   @override
@@ -849,12 +846,18 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitSymbolLiteral(SymbolLiteral node) {
-    throw UnimplementedError();
+    token(node.poundSign);
+    var components = node.components;
+    for (var component in components) {
+      // The '.' separator.
+      if (component != components.first) token(component.previous);
+      token(component);
+    }
   }
 
   @override
   void visitThisExpression(ThisExpression node) {
-    throw UnimplementedError();
+    token(node.thisKeyword);
   }
 
   @override

--- a/test/expression/other.stmt
+++ b/test/expression/other.stmt
@@ -1,4 +1,12 @@
 40 columns                              |
+>>> Null literal.
+null  ;
+<<<
+null;
+>>> Double literal.
+12.34;
+<<<
+12.34;
 >>> Parenthesized.
 (  (
 
@@ -9,3 +17,19 @@ expression
 )  );
 <<<
 ((expression));
+>>> This.
+this  ;
+<<<
+this;
+>>> Unqualified symbol.
+#  foo  ;
+<<<
+#foo;
+>>> Qualified symbol
+#  foo  .  bar  .  baz  ;
+<<<
+#foo.bar.baz;
+>>> Long qualified symbols do not split.
+#longComponent.anotherLongComponent.third;
+<<<
+#longComponent.anotherLongComponent.third;


### PR DESCRIPTION
Also use asserts() in some visit methods that we don't expect to be reachable because those AST nodes and handled at a higher level.
