### PR TITLE
Format function types.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -361,31 +361,25 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitFormalParameterList(FormalParameterList node) {
-    // Find the parameter immediately preceding the optional parameters (if
-    // there are any).
-    FormalParameter? lastRequired;
-    for (var i = 0; i < node.parameters.length; i++) {
-      if (node.parameters[i] is DefaultFormalParameter) {
-        if (i > 0) lastRequired = node.parameters[i - 1];
-        break;
-      }
-    }
+    // Find the first non-mandatory parameter (if there are any).
+    var firstOptional =
+        node.parameters.indexWhere((p) => p is DefaultFormalParameter);
 
     // If all parameters are optional, put the `[` or `{` right after `(`.
     var builder = DelimitedListBuilder(this);
-    if (node.parameters.isNotEmpty &&
-        node.parameters.first is DefaultFormalParameter) {
+    if (node.parameters.isNotEmpty && firstOptional == 0) {
       builder.leftBracket(node.leftParenthesis, delimiter: node.leftDelimiter);
     } else {
       builder.leftBracket(node.leftParenthesis);
     }
 
-    for (var parameter in node.parameters) {
-      builder.add(parameter);
+    for (var i = 0; i < node.parameters.length; i++) {
+      // If this is the first optional parameter, put the delimiter before it.
+      if (firstOptional > 0 && i == firstOptional) {
+        builder.leftDelimiter(node.leftDelimiter!);
+      }
 
-      // If the optional parameters start after this one, put the delimiter
-      // at the end of its line.
-      if (parameter == lastRequired) builder.leftDelimiter(node.leftDelimiter!);
+      builder.add(node.parameters[i]);
     }
 
     builder.rightBracket(node.rightParenthesis, delimiter: node.rightDelimiter);

--- a/lib/src/front_end/comment_writer.dart
+++ b/lib/src/front_end/comment_writer.dart
@@ -263,7 +263,7 @@ class CommentSequence extends ListBase<SourceComment> {
     // Doc comments and non-inline `/* ... */` comments are always pushed to
     // the next line.
     var type = _comments[commentIndex].type;
-    return type != CommentType.doc && type != CommentType.block;
+    return type == CommentType.inlineBlock || type == CommentType.line;
   }
 
   /// Whether the comment at [commentIndex] should be attached to the following

--- a/lib/src/front_end/comment_writer.dart
+++ b/lib/src/front_end/comment_writer.dart
@@ -85,7 +85,9 @@ mixin CommentWriter {
         writer.writeComment(comment);
       }
 
-      if (comment.type == CommentType.line) writer.writeNewline();
+      if (comment.type == CommentType.line || comment.type == CommentType.doc) {
+        writer.writeNewline();
+      }
     }
 
     if (comments.isNotEmpty && _needsSpaceAfterComment(token.lexeme)) {
@@ -130,6 +132,10 @@ mixin CommentWriter {
       } else if (comment.type == TokenType.SINGLE_LINE_COMMENT) {
         type = CommentType.line;
       } else if (commentLine == previousLine || commentLine == tokenLine) {
+        // TODO(tall): I'm not sure if it makes sense to distinguish block
+        // comments with newlines around them from other block comments in the
+        // new Piece representation. Consider merging CommentType.inlineBlock
+        // and CommentType.block into a single type.
         type = CommentType.inlineBlock;
       } else {
         type = CommentType.block;
@@ -191,8 +197,10 @@ class SourceComment {
   SourceComment(this.text, this.type, {required this.flushLeft});
 
   /// Whether this comment contains a mandatory newline, either because it's a
-  /// line comment or a multi-line block comment.
-  bool get containsNewline => type == CommentType.line || text.contains('\n');
+  /// comment that should be on its own line or a lexeme with a newline inside
+  /// it (i.e. multi-line block comment, multi-line string).
+  bool get containsNewline =>
+      type != CommentType.inlineBlock || text.contains('\n');
 
   @override
   String toString() =>
@@ -261,7 +269,8 @@ class CommentSequence extends ListBase<SourceComment> {
     if (linesBefore(commentIndex) != 0) return false;
 
     // Doc comments and non-inline `/* ... */` comments are always pushed to
-    // the next line.
+    // the next line. Only inline block comments and line comments are allowed
+    // to hang at the end of a line.
     var type = _comments[commentIndex].type;
     return type == CommentType.inlineBlock || type == CommentType.line;
   }

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -31,7 +31,7 @@ class DelimitedListBuilder {
 
   late final Piece _rightBracket;
 
-  bool _trailingComma = true;
+  bool _isTypeList = false;
 
   DelimitedListBuilder(this._visitor);
 
@@ -40,24 +40,63 @@ class DelimitedListBuilder {
   CommentSequence _commentsBeforeComma = CommentSequence.empty;
 
   ListPiece build() => ListPiece(
-      _leftBracket, _elements, _blanksAfter, _rightBracket, _trailingComma);
+      _leftBracket, _elements, _blanksAfter, _rightBracket, _isTypeList);
 
   /// Adds the opening [bracket] to the built list.
-  void leftBracket(Token bracket) {
+  ///
+  /// If [delimiter] is given, it is a second bracket occurring immediately
+  /// after [bracket]. This is used for parameter lists where all parameters
+  /// are optional or named, as in:
+  ///
+  /// ```
+  /// function([parameter]);
+  /// ```
+  ///
+  /// Here, [bracket] will be `(` and [delimiter] will be `[`.
+  void leftBracket(Token bracket, {Token? delimiter}) {
     _visitor.token(bracket);
+    _visitor.token(delimiter);
     _leftBracket = _visitor.writer.pop();
     _visitor.writer.split();
 
     // No trailing commas in type argument and type parameter lists.
-    if (bracket.type == TokenType.LT) _trailingComma = false;
+    if (bracket.type == TokenType.LT) _isTypeList = true;
   }
 
   /// Adds the closing [bracket] to the built list along with any comments that
   /// precede it.
-  void rightBracket(Token bracket) {
+  ///
+  /// If [delimiter] is given, it is a second bracket occurring immediately
+  /// after [bracket]. This is used for parameter lists with optional or named
+  /// parameters, like:
+  ///
+  /// ```
+  /// function(mandatory, {named});
+  /// ```
+  ///
+  /// Here, [bracket] will be `)` and [delimiter] will be `}`.
+  void rightBracket(Token bracket, {Token? delimiter}) {
     // Handle comments after the last element.
-    _addComments(bracket, hasElementAfter: false);
 
+    // Merge the comments before the delimiter (if there is one) and the
+    // bracket. If there is a delimiter, this will move comments between it and
+    // the bracket to before the delimiter, as in:
+    //
+    // ```
+    // // Before:
+    // f([parameter] /* comment */) {}
+    //
+    // // After:
+    // f([parameter /* comment */]) {}
+    // ```
+    var commentsBefore = _visitor.takeCommentsBefore(bracket);
+    if (delimiter != null) {
+      commentsBefore =
+          _visitor.takeCommentsBefore(delimiter).concatenate(commentsBefore);
+    }
+    _addComments(commentsBefore, hasElementAfter: false);
+
+    _visitor.token(delimiter);
     _visitor.token(bracket);
     _rightBracket = _visitor.writer.pop();
   }
@@ -67,8 +106,9 @@ class DelimitedListBuilder {
   /// Includes any comments that appear before element. Also includes the
   /// subsequent comma, if any, and any comments that precede the comma.
   void add(AstNode element) {
-    // Handle comments between the preceding argument and this one.
-    _addComments(element.beginToken, hasElementAfter: true);
+    // Handle comments between the preceding element and this one.
+    var commentsBeforeElement = _visitor.takeCommentsBefore(element.beginToken);
+    _addComments(commentsBeforeElement, hasElementAfter: true);
 
     // Traverse the element itself.
     _visitor.visit(element);
@@ -83,27 +123,68 @@ class DelimitedListBuilder {
     }
   }
 
-  /// Adds any comments preceding [token] the list.
+  /// Inserts an inner left delimiter between two elements.
+  ///
+  /// This is used for parameter lists when there are both mandatory and
+  /// optional or named parameters to insert the `[` or `{`, respectively.
+  ///
+  /// This should not be used if [delimiter] appears before all elements. In
+  /// that case, pass it to [leftBracket].
+  void leftDelimiter(Token delimiter) {
+    assert(_elements.isNotEmpty);
+
+    // Preserve any comments before the delimiter. Treat them as occurring
+    // before the previous element's comma. This means that:
+    //
+    // ```
+    // function(p1, /* comment */ [p1]);
+    // ```
+    //
+    // Will be formatted as:
+    //
+    // ```
+    // function(p1 /* comment */, [p1]);
+    // ```
+    //
+    // (In practice, it's such an unusual place for a comment that it doesn't
+    // matter that much where it goes and this seems to be simple and
+    // reasonable looking.)
+    _commentsBeforeComma = _commentsBeforeComma
+        .concatenate(_visitor.takeCommentsBefore(delimiter));
+
+    // Attach the delimiter to the previous element.
+    _elements.last = _elements.last.withDelimiter(delimiter.lexeme);
+  }
+
+  /// Adds [comments] to the list.
   ///
   /// If [hasElementAfter] is `true` then another element will be written after
   /// these comments. Otherwise, we are at the comments after the last element
   /// before the closing delimiter.
-  void _addComments(Token token, {required bool hasElementAfter}) {
-    var commentsBeforeElement = _visitor.takeCommentsBefore(token);
-
+  void _addComments(CommentSequence comments, {required bool hasElementAfter}) {
     // Early out if there's nothing to do.
-    if (_commentsBeforeComma.isEmpty && commentsBeforeElement.isEmpty) return;
+    if (_commentsBeforeComma.isEmpty && comments.isEmpty) return;
 
     // Figure out which comments are anchored to the preceding element, which
     // are freestanding, and which are attached to the next element.
     var (
+      inline: inlineComments,
       hanging: hangingComments,
       separate: separateComments,
       leading: leadingComments
-    ) = _splitCommaComments(commentsBeforeElement,
-        hasElementAfter: hasElementAfter);
+    ) = _splitCommaComments(comments, hasElementAfter: hasElementAfter);
 
-    // Add any hanging comments to the previous argument.
+    // Add any hanging inline block comments to the previous element before the
+    // subsequent ",".
+    if (inlineComments.isNotEmpty) {
+      for (var comment in inlineComments) {
+        _visitor.writer.space();
+        _visitor.writer.writeComment(comment, hanging: true);
+      }
+    }
+
+    // Add any remaining hanging line comments to the previous element after
+    // the ",".
     if (hangingComments.isNotEmpty) {
       for (var comment in hangingComments) {
         _visitor.writer.space();
@@ -137,9 +218,12 @@ class DelimitedListBuilder {
   /// Given the comments that followed the previous element before its comma
   /// and [commentsBeforeElement], the comments before the element we are about
   /// to write (and after the preceding element's comma), splits them into to
-  /// three comment sequences:
+  /// four comment sequences:
   ///
-  /// * The comments that should hang off the end of the preceding element.
+  /// * The inline block comments that should hang off the preceding element
+  ///   before its comma.
+  /// * The line comments that should hang off the end of the preceding element
+  ///   after its comma.
   /// * The comments that should be formatted like separate elements.
   /// * The comments that should lead the beginning of the next element we are
   ///   about to write.
@@ -148,9 +232,9 @@ class DelimitedListBuilder {
   ///
   /// ```
   /// function(
-  ///   argument /* hanging */,
+  ///   argument /* inline */, // hanging
   ///   // separate
-  ///   /* leading */
+  ///   /* leading */ nextArgument
   /// );
   /// ```
   ///
@@ -160,9 +244,13 @@ class DelimitedListBuilder {
   /// If [hasElementAfter] is `true` then another element will be written after
   /// these comments. Otherwise, we are at the comments after the last element
   /// before the closing delimiter.
-  ({CommentSequence hanging, CommentSequence separate, CommentSequence leading})
-      _splitCommaComments(CommentSequence commentsBeforeElement,
-          {required bool hasElementAfter}) {
+  ({
+    CommentSequence inline,
+    CommentSequence hanging,
+    CommentSequence separate,
+    CommentSequence leading
+  }) _splitCommaComments(CommentSequence commentsBeforeElement,
+      {required bool hasElementAfter}) {
     // If we're on the final comma after the last argument, the comma isn't
     // meaningful because there can't be leading comments after it.
     if (!hasElementAfter) {
@@ -181,8 +269,8 @@ class DelimitedListBuilder {
       commentsBeforeElement = remaining;
     }
 
-    // Inline block comments on the same line as a preceding element hang
-    // on that same line, as in:
+    // Inline block comments before the `,` stay with the preceding element, as
+    // in:
     //
     // ```
     // function(
@@ -190,18 +278,35 @@ class DelimitedListBuilder {
     //   argument,
     // );
     // ```
+    var inlineCommentCount = 0;
+    if (_elements.isNotEmpty) {
+      while (inlineCommentCount < _commentsBeforeComma.length) {
+        // Once we hit a single non-inline comment, the rest won't be either.
+        if (!_commentsBeforeComma.isHanging(inlineCommentCount) ||
+            _commentsBeforeComma[inlineCommentCount].type !=
+                CommentType.inlineBlock) {
+          break;
+        }
+
+        inlineCommentCount++;
+      }
+    }
+
+    var (inlineComments, remainingCommentsBeforeComma) =
+        _commentsBeforeComma.splitAt(inlineCommentCount);
+
     var hangingCommentCount = 0;
     if (_elements.isNotEmpty) {
-      while (hangingCommentCount < _commentsBeforeComma.length) {
+      while (hangingCommentCount < remainingCommentsBeforeComma.length) {
         // Once we hit a single non-hanging comment, the rest won't be either.
-        if (!_commentsBeforeComma.isHanging(hangingCommentCount)) break;
+        if (!remainingCommentsBeforeComma.isHanging(hangingCommentCount)) break;
 
         hangingCommentCount++;
       }
     }
 
     var (hangingComments, separateCommentsBeforeComma) =
-        _commentsBeforeComma.splitAt(hangingCommentCount);
+        remainingCommentsBeforeComma.splitAt(hangingCommentCount);
 
     // Inline block comments on the same line as the next element lead at the
     // beginning of that line, as in:
@@ -243,6 +348,7 @@ class DelimitedListBuilder {
         separateCommentsBeforeComma.concatenate(separateCommentsAfterComma);
 
     return (
+      inline: inlineComments,
       hanging: hangingComments,
       separate: separateComments,
       leading: leadingComments

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -31,6 +31,14 @@ class DelimitedListBuilder {
 
   late final Piece _rightBracket;
 
+  /// Whether this list is a list of type arguments or type parameters, versus
+  /// any other kind of list.
+  ///
+  /// Type arguments/parameters are different because:
+  ///
+  /// *   The language doesn't allow a trailing comma in them.
+  /// *   Splitting in them looks aesthetically worse, so we increase the cost
+  ///     of doing so.
   bool _isTypeList = false;
 
   DelimitedListBuilder(this._visitor);
@@ -176,11 +184,9 @@ class DelimitedListBuilder {
 
     // Add any hanging inline block comments to the previous element before the
     // subsequent ",".
-    if (inlineComments.isNotEmpty) {
-      for (var comment in inlineComments) {
-        _visitor.writer.space();
-        _visitor.writer.writeComment(comment, hanging: true);
-      }
+    for (var comment in inlineComments) {
+      _visitor.writer.space();
+      _visitor.writer.writeComment(comment, hanging: true);
     }
 
     // Add any remaining hanging line comments to the previous element after

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -374,7 +374,7 @@ mixin PieceFactory implements CommentWriter {
   }
 
   /// Writes the parts of a formal parameter shared by all formal parameter
-  /// types: metadata, `coviariant`, etc.
+  /// types: metadata, `covariant`, etc.
   void startFormalParameter(FormalParameter parameter) {
     if (parameter.metadata.isNotEmpty) throw UnimplementedError();
 

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import '../ast_extensions.dart';
 import '../piece/assign.dart';
 import '../piece/block.dart';
+import '../piece/function.dart';
 import '../piece/if.dart';
 import '../piece/import.dart';
 import '../piece/infix.dart';
@@ -101,9 +102,6 @@ mixin PieceFactory implements CommentWriter {
     modifier(literal.constKeyword);
     visit(literal.typeArguments);
 
-    var builder = DelimitedListBuilder(this);
-    builder.leftBracket(leftBracket);
-
     // TODO(tall): Support a line comment inside a collection literal as a
     // signal to preserve internal newlines. So if you have:
     //
@@ -117,8 +115,15 @@ mixin PieceFactory implements CommentWriter {
     // The formatter will preserve the newline after element 3 and the lack of
     // them after the other elements.
 
-    elements.forEach(builder.add);
+    createDelimited(leftBracket, elements, rightBracket);
+  }
 
+  /// Creates a [ListPiece] for the given bracket-delimited set of elements.
+  void createDelimited(
+      Token leftBracket, Iterable<AstNode> elements, Token rightBracket) {
+    var builder = DelimitedListBuilder(this);
+    builder.leftBracket(leftBracket);
+    elements.forEach(builder.add);
     builder.rightBracket(rightBracket);
     writer.push(builder.build());
   }
@@ -140,6 +145,32 @@ mixin PieceFactory implements CommentWriter {
       }
 
       visit(component);
+    }
+  }
+
+  /// Creates a function type or function-typed formal.
+  void createFunctionType(
+      TypeAnnotation? returnType,
+      Token? functionKeywordOrName,
+      TypeParameterList? typeParameters,
+      FormalParameterList parameters,
+      Token? question) {
+    Piece? returnTypePiece;
+    if (returnType != null) {
+      visit(returnType);
+      returnTypePiece = writer.pop();
+      writer.split();
+    }
+
+    token(functionKeywordOrName);
+    visit(typeParameters);
+    visit(parameters);
+    token(question);
+
+    // Allow splitting after the return type.
+    if (returnTypePiece != null) {
+      var parametersPiece = writer.pop();
+      writer.push(FunctionTypePiece(returnTypePiece, parametersPiece));
     }
   }
 
@@ -340,6 +371,15 @@ mixin PieceFactory implements CommentWriter {
     traverse(node);
 
     writer.push(InfixPiece(operands));
+  }
+
+  /// Writes the parts of a formal parameter shared by all formal parameter
+  /// types: metadata, `coviariant`, etc.
+  void startFormalParameter(FormalParameter parameter) {
+    if (parameter.metadata.isNotEmpty) throw UnimplementedError();
+
+    modifier(parameter.requiredKeyword);
+    if (parameter.covariantKeyword != null) throw UnimplementedError();
   }
 
   /// Creates a [Piece] for some code followed by an `=` and an expression in

--- a/lib/src/piece/function.dart
+++ b/lib/src/piece/function.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import '../back_end/code_writer.dart';
+import 'piece.dart';
+
+/// Piece for a function type or function-typed parameter.
+///
+/// Handles splitting between the return type and the rest of the function type.
+class FunctionTypePiece extends Piece {
+  /// The return type annotation.
+  final Piece _returnType;
+
+  /// The rest of the function type signature: name, type parameters,
+  /// parameters, etc.
+  final Piece _signature;
+
+  FunctionTypePiece(this._returnType, this._signature);
+
+  @override
+  List<State> get states => const [State.split];
+
+  @override
+  void format(CodeWriter writer, State state) {
+    // A split inside the return type forces splitting after the return type.
+    writer.setAllowNewlines(state == State.split);
+    writer.format(_returnType);
+
+    // A split in the type parameters or parameters does not force splitting
+    // after the return type.
+    writer.setAllowNewlines(true);
+    writer.splitIf(state == State.split);
+
+    writer.format(_signature);
+  }
+
+  @override
+  void forEachChild(void Function(Piece piece) callback) {
+    callback(_returnType);
+    callback(_signature);
+  }
+
+  @override
+  String toString() => 'FnType';
+}

--- a/lib/src/string_compare.dart
+++ b/lib/src/string_compare.dart
@@ -2,13 +2,20 @@
 /// source code.
 ///
 /// This mostly follows the same rules as `String.trim()` because that's what
-/// dart_style uses to trim trailing whitespace as well as considering `,` to
-/// be a whitespace character since the formatter will add and remove trailing
-/// commas.
+/// dart_style uses to trim trailing whitespace.
+///
+/// This function treats `,` as a whitespace character since the formatter will
+/// add and remove trailing commas. It treats, `[`, `]`, `{`, and `}` as
+/// whitespace characters because the formatter may move a comment if it
+/// appears near the closing delimiter of an optional parameter section.
 bool _isWhitespace(int c) {
   // Not using a set or something more elegant because this code is on the hot
   // path and this large expression is significantly faster than a set lookup.
   return c == 0x002c || // Treat commas as "whitespace".
+      c == 0x005b || // Treat `[` as "whitespace".
+      c == 0x005d || // Treat `]` as "whitespace".
+      c == 0x007b || // Treat `{` as "whitespace".
+      c == 0x007d || // Treat `}` as "whitespace".
       c >= 0x0009 && c <= 0x000d || // Control characters.
       c == 0x0020 || // SPACE.
       c == 0x0085 || // Control characters.

--- a/lib/src/string_compare.dart
+++ b/lib/src/string_compare.dart
@@ -1,3 +1,14 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// TODO(tall): Now that the formatter may add and remove trailing commas and
+// reposition comments relative to `,`, `[`, `]`, `{`, and `}`, this function
+// is getting less and less precise. (For example, a bug in the formatter that
+// dropped all `[` tokens on the floor would still pass.) Consider a more
+// sophisticated approach for determining that the formatter preserved all of
+// the original code.
+
 /// Returns `true` if [c] represents a whitespace code unit allowed in Dart
 /// source code.
 ///

--- a/test/expression/list_comment.stmt
+++ b/test/expression/list_comment.stmt
@@ -18,7 +18,7 @@ var list = [
 var list = [  /* comment */  ];
 <<<
 var list = [/* comment */];
->>> Collapse all whitespace on single-line block comments in empty lists.
+>>> Remove blank lines around block comments in empty lists.
 var list = [
 
 
@@ -27,7 +27,9 @@ var list = [
 
 ];
 <<<
-var list = [/* comment */];
+var list = [
+  /* comment */
+];
 >>> Multiple inline block comments.
 var list = [  /* 1 */   /* 2 */   /* 3 */  ];
 <<<

--- a/test/expression/list_comment.stmt
+++ b/test/expression/list_comment.stmt
@@ -140,4 +140,4 @@ var list = [
 >>> Space between block comment and ",".
 var list = [1,/* a */ 2 /* b */  , 3];
 <<<
-var list = [1, /* a */ 2, /* b */ 3];
+var list = [1, /* a */ 2 /* b */, 3];

--- a/test/invocation/comma_comment.stmt
+++ b/test/invocation/comma_comment.stmt
@@ -16,7 +16,7 @@ function(veryLongArgument, veryLongArgument /* before */, argument);
 <<<
 function(
   veryLongArgument,
-  veryLongArgument, /* before */
+  veryLongArgument /* before */,
   argument,
 );
 >>> Block comment after non-trailing comma.
@@ -32,7 +32,7 @@ function(veryLongArgument, argument /* before */ , /* after */ argument);
 <<<
 function(
   veryLongArgument,
-  argument, /* before */
+  argument /* before */,
   /* after */ argument,
 );
 >>> Block comment before preserved trailing comma.
@@ -40,35 +40,35 @@ function(veryLongArgument, veryLongArgument /* before */,);
 <<<
 function(
   veryLongArgument,
-  veryLongArgument, /* before */
+  veryLongArgument /* before */,
 );
 >>> Block comment after preserved trailing comma.
 function(veryLongArgument, veryLongArgument, /* after */);
 <<<
 function(
   veryLongArgument,
-  veryLongArgument, /* after */
+  veryLongArgument /* after */,
 );
 >>> Block comment before and after preserved trailing comma.
 function(veryLongArgument, argument /* before */ , /* after */);
 <<<
 function(
   veryLongArgument,
-  argument, /* before */ /* after */
+  argument /* before */ /* after */,
 );
 >>> Block comment at inserted comma.
 function(veryLongArgument, veryLongArgument /* at */);
 <<<
 function(
   veryLongArgument,
-  veryLongArgument, /* at */
+  veryLongArgument /* at */,
 );
 >>> Block comments at inserted comma.
 function(veryLongArgument, veryLongArgument /* 1 */ /* 2 */);
 <<<
 function(
   veryLongArgument,
-  veryLongArgument, /* 1 */ /* 2 */
+  veryLongArgument /* 1 */ /* 2 */,
 );
 >>> Block comment after comma on different line is leading when unsplit.
 function(argument, /* c */

--- a/test/statement/block_comment.stmt
+++ b/test/statement/block_comment.stmt
@@ -10,7 +10,7 @@
 {   /* comment */  }
 <<<
 {/* comment */}
->>>
+>>> Empty block containing non-inline block comment.
 {
 
   /* comment */
@@ -18,7 +18,9 @@
 
 }
 <<<
-{/* comment */}
+{
+  /* comment */
+}
 >>> Empty block containing multi-line block comment.
 {   /* comment
 line */  }

--- a/test/statement/variable.stmt
+++ b/test/statement/variable.stmt
@@ -118,6 +118,13 @@ someLongVariableName =
 another = short,
 thirdLongVariable =
     anotherLongInitializer;
+>>> Split in type name does not split before variable.
+Generic<LongTypeArgument, AnotherLongTypeName> variable;
+<<<
+Generic<
+  LongTypeArgument,
+  AnotherLongTypeName
+> variable;
 >>> Prefer to split at "=" over infix operator.
 int variableName = argument * argument + argument;
 <<<

--- a/test/string_compare_test.dart
+++ b/test/string_compare_test.dart
@@ -32,7 +32,7 @@ void main() {
     expect(equalIgnoringWhitespace('foobar', 'foo\nbar'), isTrue);
   });
 
-  test('wdentical strings', () {
+  test('identical strings', () {
     expect(equalIgnoringWhitespace('foo bar', 'foo bar'), isTrue);
     expect(equalIgnoringWhitespace('', ''), isTrue);
   });
@@ -68,5 +68,25 @@ void main() {
     expect(equalIgnoringWhitespace('oo bar', 'foo bar'), isFalse);
     expect(equalIgnoringWhitespace('', 'foo bar'), isFalse);
     expect(equalIgnoringWhitespace('foo bar', ''), isFalse);
+  });
+
+  test('ignore differences from commas', () {
+    expect(equalIgnoringWhitespace('fn(a,)', 'fn(a)'), isTrue);
+    expect(equalIgnoringWhitespace('a,b,,,c,,,,', 'abc'), isTrue);
+    expect(equalIgnoringWhitespace('a,b,,,c,,,,', 'cba'), isFalse);
+  });
+
+  test('ignore differences from "[" and "]"', () {
+    expect(equalIgnoringWhitespace('f([a]/* c */)', 'f([a /* c */])'), isTrue);
+    expect(equalIgnoringWhitespace('f(/* c */[a])', 'f([/* c */ a])'), isTrue);
+    expect(equalIgnoringWhitespace('a]b][c][[]', 'abc'), isTrue);
+    expect(equalIgnoringWhitespace('a]b][c][[]', 'cba'), isFalse);
+  });
+
+  test('ignore differences from "{" and "}"', () {
+    expect(equalIgnoringWhitespace('f({a}/* c */)', 'f({a /* c */})'), isTrue);
+    expect(equalIgnoringWhitespace('f(/* c */{a})', 'f({/* c */ a})'), isTrue);
+    expect(equalIgnoringWhitespace('a}b}{c}{{}', 'abc'), isTrue);
+    expect(equalIgnoringWhitespace('a}b}{c}{{}', 'cba'), isFalse);
   });
 }

--- a/test/type/function.stmt
+++ b/test/type/function.stmt
@@ -1,0 +1,198 @@
+40 columns                              |
+>>> Empty.
+Function  (  )  f;
+<<<
+Function() f;
+>>> Parameter and return types.
+void  Function  (  int  i  ,  String  s)  f;
+<<<
+void Function(int i, String s) f;
+>>> All optional parameters.
+Function  (  [  int  i  ,  String  s  ,  bool  b  ]  )  f;
+<<<
+Function([int i, String s, bool b]) f;
+>>> All named parameters.
+Function  (  {  int  i  ,  String  s  ,  bool  b  }  )  f;
+<<<
+Function({int i, String s, bool b}) f;
+>>> Mandatory and optional parameters.
+Function  (  int  i  ,  [  String  s  ,  bool  b  ]  )  f;
+<<<
+Function(int i, [String s, bool b]) f;
+>>> Mandatory and named parameters.
+Function  (  int  i  ,  {  String  s  ,  bool  b  }  )  f;
+<<<
+Function(int i, {String s, bool b}) f;
+>>> Required named parameter.
+Function  (  {  required  int  i  }  )  f;
+<<<
+Function({required int i}) f;
+>>> Type parameters.
+Function  <  A  ,  T  extends  S  >  (  x  ,  y  )  f;
+<<<
+Function<A, T extends S>(x, y) f;
+>>> Split value parameters.
+Function<T, R>(longParameterName, anotherLongParameter) f;
+<<<
+Function<T, R>(
+  longParameterName,
+  anotherLongParameter,
+) f;
+>>> Split type parameters.
+Function<LongTypeName, AnotherLongTypeName>(parameter) f;
+<<<
+Function<
+  LongTypeName,
+  AnotherLongTypeName
+>(parameter) f;
+>>> Split type parameters and value parameters.
+Function<LongTypeName, AnotherLongTypeName>(longParameterName, anotherLongParameter) f;
+<<<
+Function<
+  LongTypeName,
+  AnotherLongTypeName
+>(
+  longParameterName,
+  anotherLongParameter,
+) f;
+>>> Nullable types.
+int  ?  Function  (  int  ?  i  , {  String  ?  s  }  )  ?  f;
+<<<
+int? Function(int? i, {String? s})? f;
+>>> Split parameters.
+void Function(first, second, third, fourth) f;
+<<<
+void Function(
+  first,
+  second,
+  third,
+  fourth,
+) f;
+>>> Split parameters all optional.
+void Function([first, second, third, fourth]) f;
+<<<
+void Function([
+  first,
+  second,
+  third,
+  fourth,
+]) f;
+>>> Split parameters all named.
+void Function({bool first, double second, int third}) f;
+<<<
+void Function({
+  bool first,
+  double second,
+  int third,
+}) f;
+>>> Split parameters with optional.
+void Function(first, second, [third, fourth]) f;
+<<<
+void Function(
+  first,
+  second, [
+  third,
+  fourth,
+]) f;
+>>> Split parameters with named.
+void Function(first, second, {bool third, double fourth}) f;
+<<<
+void Function(
+  first,
+  second, {
+  bool third,
+  double fourth,
+}) f;
+>>> Remove trailing comma from mandatory if unsplit.
+Function(
+  first,
+  second,
+  third,
+) f;
+<<<
+Function(first, second, third) f;
+>>> Remove trailing comma from optional if unsplit.
+Function([
+  first,
+  second,
+  third,
+]) f;
+<<<
+Function([first, second, third]) f;
+>>> Remove trailing comma from named if unsplit.
+Function({
+  bool first,
+  int second,
+}) f;
+<<<
+Function({bool first, int second}) f;
+>>> Unsplit function typed parameter.
+Function(parameter1, void printFn(param1, param2)) f;
+<<<
+Function(
+  parameter1,
+  void printFn(param1, param2),
+) f;
+>>> Split function typed parameter.
+Function(int callback(parameter1, parameter2, parameter3, parameter4)) f;
+<<<
+Function(
+  int callback(
+    parameter1,
+    parameter2,
+    parameter3,
+    parameter4,
+  ),
+) f;
+>>> Required function typed formal.
+Function  (  {  required  void  callback  (  )  }  )  f  ;
+<<<
+Function({required void callback()}) f;
+>>> Split between parameter type and name.
+Function(VerylongParameterType longParameterName) f;
+<<<
+Function(
+  VerylongParameterType
+  longParameterName,
+) f;
+>>> Split in parameter type does not split before parameter.
+Function(Generic<LongTypeArgument, AnotherLongTypeName> parameter) f;
+<<<
+Function(
+  Generic<
+    LongTypeArgument,
+    AnotherLongTypeName
+  > parameter,
+) f;
+>>> Split in nested function type forces outer split.
+Function(int, String, Function(parameter1, parameter2, parameter3)) f;
+<<<
+Function(
+  int,
+  String,
+  Function(
+    parameter1,
+    parameter2,
+    parameter3,
+  ),
+) f;
+>>> Split in type arguments.
+Function<Parameter1, Parameter2, Parameter3>() f;
+<<<
+Function<
+  Parameter1,
+  Parameter2,
+  Parameter3
+>() f;
+>>> Split after return type.
+GenericClass<Parameter1, Parameter2> Function() f;
+<<<
+GenericClass<Parameter1, Parameter2>
+Function() f;
+>>> Chained return types.
+Function<Argument>(String) Function<Argument>(num) Function<Argument>(int) Function<Argument>(bool) longVariable;
+<<<
+Function<Argument>(String)
+Function<Argument>(num)
+Function<Argument>(int)
+Function<Argument>(bool) longVariable;

--- a/test/type/function_comment.stmt
+++ b/test/type/function_comment.stmt
@@ -1,0 +1,202 @@
+40 columns                              |
+>>> Block comment before first parameter.
+Function(/* c */a,b) x;
+<<<
+Function(/* c */ a, b) x;
+>>> Block comment before ",".
+Function(a/* c */,b) x;
+<<<
+Function(a /* c */, b) x;
+>>> Block comment after ",".
+Function(a,/* c */b) x;
+<<<
+Function(a, /* c */ b) x;
+>>> Block comment before "[".
+Function(a /* c */, [b]) x;
+<<<
+Function(a /* c */, [b]) x;
+>>> Block comment after "[".
+Function([/* c */ arg]) x;
+<<<
+Function([/* c */ arg]) x;
+>>> Block comment before "]".
+Function([arg/* c */]) x;
+<<<
+Function([arg /* c */]) x;
+>>> Block comment after "]".
+Function([arg]/* c */) x;
+<<<
+Function([arg /* c */]) x;
+>>> Block comment before "{".
+Function(a,/* c */{int b}) x;
+<<<
+Function(a /* c */, {int b}) x;
+>>> Block comment after "{".
+Function({/* c */int arg}) x;
+<<<
+Function({/* c */ int arg}) x;
+>>> Block comment before "}".
+Function({int arg/* c */}) x;
+<<<
+Function({int arg /* c */}) x;
+>>> Block comment after "{".
+Function({int arg}/* c */) x;
+<<<
+Function({int arg /* c */}) x;
+>>> Line comment before first parameter.
+Function(// c
+a,b) x;
+<<<
+Function(
+  // c
+  a,
+  b,
+) x;
+>>> Line comment before ",".
+Function(a// c
+,b) x;
+<<<
+Function(
+  a, // c
+  b,
+) x;
+>>> Line comment after ",".
+Function(a,// c
+b) x;
+<<<
+Function(
+  a, // c
+  b,
+) x;
+>>> Line comment before "[".
+Function(a,// c
+[b]) x;
+<<<
+### Note: Moves comment after `[`.
+Function(
+  a, [ // c
+  b,
+]) x;
+>>> Line comment after "[".
+Function([// c
+arg]) x;
+<<<
+Function([
+  // c
+  arg,
+]) x;
+>>> Line comment before "]".
+Function([arg// c
+]) x;
+<<<
+Function([
+  arg, // c
+]) x;
+>>> Line comment after "]".
+Function([arg]// c
+) x;
+<<<
+Function([
+  arg, // c
+]) x;
+>>> Line comment before "{".
+Function(a,// c
+{int b}) x;
+<<<
+Function(
+  a, { // c
+  int b,
+}) x;
+>>> Line comment after "{".
+Function({// c
+int arg}) x;
+<<<
+Function({
+  // c
+  int arg,
+}) x;
+>>> Line comment before "}".
+Function({int arg// c
+}) x;
+<<<
+Function({
+  int arg, // c
+}) x;
+>>> Line comment after "{".
+Function({int arg}// c
+) x;
+<<<
+Function({
+  int arg, // c
+}) x;
+>>> Comment before removed mandatory trailing comma.
+Function(a/* c */,) x;
+<<<
+Function(a /* c */) x;
+>>> Comment after removed mandatory trailing comma.
+Function(a,/* c */) x;
+<<<
+Function(a /* c */) x;
+>>> Comments before and after removed mandatory trailing comma.
+Function(a/* c1 */,/* c2 */) x;
+<<<
+Function(a /* c1 */ /* c2 */) x;
+>>> Comment at inserted mandatory trailing comma.
+Function(veryLongParameterName/* c */) x;
+<<<
+Function(
+  veryLongParameterName /* c */,
+) x;
+>>> Comment before removed optional trailing comma.
+Function([a/* c */,]) x;
+<<<
+Function([a /* c */]) x;
+>>> Comment after removed optional trailing comma.
+Function([a,/* c */]) x;
+<<<
+Function([a /* c */]) x;
+>>> Comments before and after removed optional trailing comma.
+Function([a/* c1 */,/* c2 */]) x;
+<<<
+Function([a /* c1 */ /* c2 */]) x;
+>>> Comment at inserted optional trailing comma.
+Function([veryLongParameterName/* c */]) x;
+<<<
+Function([
+  veryLongParameterName /* c */,
+]) x;
+>>> Comment before removed named trailing comma.
+Function({int a/* c */,}) x;
+<<<
+Function({int a /* c */}) x;
+>>> Comment after removed named trailing comma.
+Function({int a,/* c */}) x;
+<<<
+Function({int a /* c */}) x;
+>>> Comments before and after removed named trailing comma.
+Function({int a/* c1 */,/* c2 */}) x;
+<<<
+Function({int a /* c1 */ /* c2 */}) x;
+>>> Comment at inserted named trailing comma.
+Function({int veryLongParameterName/* c */}) x;
+<<<
+Function({
+  int veryLongParameterName /* c */,
+}) x;
+>>> Wrap inline block comment.
+Function(/* a very long block comment */) x;
+<<<
+Function(
+  /* a very long block comment */
+) x;
+>>> Before parameter.
+Function(
+    /* comment */ int a, int b, int c,
+    [direction]) x;
+<<<
+Function(
+  /* comment */ int a,
+  int b,
+  int c, [
+  direction,
+]) x;

--- a/test/type/function_comment.stmt
+++ b/test/type/function_comment.stmt
@@ -1,48 +1,152 @@
 40 columns                              |
->>> Block comment before first parameter.
+>>> Inline block comment before first parameter.
 Function(/* c */a,b) x;
 <<<
 Function(/* c */ a, b) x;
->>> Block comment before ",".
+>>> Inline block comment before ",".
 Function(a/* c */,b) x;
 <<<
 Function(a /* c */, b) x;
->>> Block comment after ",".
+>>> Inline block comment after ",".
 Function(a,/* c */b) x;
 <<<
 Function(a, /* c */ b) x;
->>> Block comment before "[".
+>>> Inline block comment before "[".
 Function(a /* c */, [b]) x;
 <<<
 Function(a /* c */, [b]) x;
->>> Block comment after "[".
+>>> Inline block comment after "[".
 Function([/* c */ arg]) x;
 <<<
 Function([/* c */ arg]) x;
->>> Block comment before "]".
+>>> Inline block comment before "]".
 Function([arg/* c */]) x;
 <<<
 Function([arg /* c */]) x;
->>> Block comment after "]".
+>>> Inline block comment after "]".
 Function([arg]/* c */) x;
 <<<
 Function([arg /* c */]) x;
->>> Block comment before "{".
+>>> Inline block comment before "{".
 Function(a,/* c */{int b}) x;
 <<<
 Function(a /* c */, {int b}) x;
->>> Block comment after "{".
+>>> Inline block comment after "{".
 Function({/* c */int arg}) x;
 <<<
 Function({/* c */ int arg}) x;
->>> Block comment before "}".
+>>> Inline block comment before "}".
 Function({int arg/* c */}) x;
 <<<
 Function({int arg /* c */}) x;
->>> Block comment after "{".
+>>> Inline block comment after "{".
 Function({int arg}/* c */) x;
 <<<
 Function({int arg /* c */}) x;
+>>> Non-inline block comment before first parameter.
+Function(
+/* c */
+a,b) x;
+<<<
+Function(
+  /* c */
+  a,
+  b,
+) x;
+>>> Non-inline block comment before ",".
+Function(a
+/* c */
+,b) x;
+<<<
+Function(
+  a,
+  /* c */
+  b,
+) x;
+>>> Non-inline block comment after ",".
+Function(a,
+/* c */
+b) x;
+<<<
+Function(
+  a,
+  /* c */
+  b,
+) x;
+>>> Non-inline block comment before "[".
+Function(a
+/* c */
+, [b]) x;
+<<<
+Function(
+  a, [
+  /* c */
+  b,
+]) x;
+>>> Non-inline block comment after "[".
+Function([
+/* c */
+arg]) x;
+<<<
+Function([
+  /* c */
+  arg,
+]) x;
+>>> Non-inline block comment before "]".
+Function([arg
+/* c */
+]) x;
+<<<
+Function([
+  arg,
+  /* c */
+]) x;
+>>> Non-inline block comment after "]".
+Function([arg]
+/* c */
+) x;
+<<<
+Function([
+  arg,
+  /* c */
+]) x;
+>>> Non-inline block comment before "{".
+Function(a,
+/* c */
+{int b}) x;
+<<<
+Function(
+  a, {
+  /* c */
+  int b,
+}) x;
+>>> Non-inline block comment after "{".
+Function({
+/* c */
+int arg}) x;
+<<<
+Function({
+  /* c */
+  int arg,
+}) x;
+>>> Non-inline block comment before "}".
+Function({int arg
+/* c */
+}) x;
+<<<
+Function({
+  int arg,
+  /* c */
+}) x;
+>>> Non-inline block comment after "{".
+Function({int arg}
+/* c */
+) x;
+<<<
+Function({
+  int arg,
+  /* c */
+}) x;
 >>> Line comment before first parameter.
 Function(// c
 a,b) x;
@@ -129,6 +233,108 @@ Function({int arg}// c
 Function({
   int arg, // c
 }) x;
+>>> Doc comment before first parameter.
+Function(/// c
+a,b) x;
+<<<
+Function(
+  /// c
+  a,
+  b,
+) x;
+>>> Doc comment before ",".
+Function(a/// c
+,b) x;
+<<<
+Function(
+  a,
+
+  /// c
+  b,
+) x;
+>>> Doc comment after ",".
+Function(a,/// c
+b) x;
+<<<
+Function(
+  a,
+
+  /// c
+  b,
+) x;
+>>> Doc comment before "[".
+Function(a,/// c
+[b]) x;
+<<<
+### Note: Moves comment after `[`.
+Function(
+  a, [
+
+  /// c
+  b,
+]) x;
+>>> Doc comment after "[".
+Function([/// c
+arg]) x;
+<<<
+Function([
+  /// c
+  arg,
+]) x;
+>>> Doc comment before "]".
+Function([arg/// c
+]) x;
+<<<
+Function([
+  arg,
+
+  /// c
+]) x;
+>>> Doc comment after "]".
+Function([arg]/// c
+) x;
+<<<
+Function([
+  arg,
+
+  /// c
+]) x;
+>>> Doc comment before "{".
+Function(a,/// c
+{int b}) x;
+<<<
+Function(
+  a, {
+
+  /// c
+  int b,
+}) x;
+>>> Doc comment after "{".
+Function({/// c
+int arg}) x;
+<<<
+Function({
+  /// c
+  int arg,
+}) x;
+>>> Doc comment before "}".
+Function({int arg/// c
+}) x;
+<<<
+Function({
+  int arg,
+
+  /// c
+}) x;
+>>> Doc comment after "{".
+Function({int arg}/// c
+) x;
+<<<
+Function({
+  int arg,
+
+  /// c
+}) x;
 >>> Comment before removed mandatory trailing comma.
 Function(a/* c */,) x;
 <<<
@@ -183,11 +389,11 @@ Function({int veryLongParameterName/* c */}) x;
 Function({
   int veryLongParameterName /* c */,
 }) x;
->>> Wrap inline block comment.
-Function(/* a very long block comment */) x;
+>>> Wrap inline Inline block comment.
+Function(/* a very long Inline block comment */) x;
 <<<
 Function(
-  /* a very long block comment */
+  /* a very long Inline block comment */
 ) x;
 >>> Before parameter.
 Function(


### PR DESCRIPTION
This involves formatting parameter lists which is a big piece of work. They work similar to argument lists and collection literals... except for the special syntax around `[ ... ]` and `{ ... }` for optional parameters.

Getting that working right involved adding some more functionality to DelimitedListBuilder and ListPiece.

Getting comments working with that syntax was particularly difficult. I ended up deciding that the formatter can move comments before or after the optional parameter delimiters if it needs to. Doing so produces better looking output, as in:

```
// Before:
f(// weird comment location
[param] // another
);

// After:
f([
  // weird comment location
  param, // another
]);
```

It also, I think is cleaner to implement than trying to laboriously keep the comment where the user authored it.

In the process of reworking how comments are handled in lists, I also tweaked how inline block comments are handled before commas. Previously, they would get moved after the comma, like:

```
// Before:
[element /* comment */, another];

// After:
[element, /* comment */ another];
```

Now, they stay where they were, which is I think what users want. A common use case for block comments in argument/collection lists is describing the meaning of a preceding null argument and this keeps that.

Line after an element but before the comma continue to be moved after the comma:

```
// Before:
f(param // comment
,);

// After:
f(
  param, // comment
);
```

Also:

- Added tests for the loosened behavior of equalIgnoringWhitespace().
- Added a test for a corner case of variable splitting that I ran into with parameters, which use the same VariablePiece.
