### PR TITLE
Turn top-library comment into non-dartdoc.

### DIFF
--- a/lib/src/debug.dart
+++ b/lib/src/debug.dart
@@ -2,7 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Internal debugging utilities.
+/// Internal debugging utilities.
+library;
+
 import 'dart:math' as math;
 
 import 'chunk.dart';

--- a/lib/src/debug.dart
+++ b/lib/src/debug.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Internal debugging utilities.
+// Internal debugging utilities.
 import 'dart:math' as math;
 
 import 'chunk.dart';


### PR DESCRIPTION
Prepare for lints 3.0.0 (PR #1289), which will report this as a dangling library comment, when it's probably just not intended a doc comment at all.
