### PR TITLE
Format switch statements and expressions.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -114,9 +114,9 @@ extension ExpressionExtensions on Expression {
         ListLiteral() => true,
         MethodInvocation() => true,
         SetOrMapLiteral() => true,
+        SwitchExpression() => true,
         // TODO(tall): Record literals.
         // TODO(tall): Instance creation expressions (`new` and `const`).
-        // TODO(tall): Switch expressions.
         _ => false,
       };
 

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -959,7 +959,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     createSwitchValue(node.switchKeyword, node.leftParenthesis, node.expression,
         node.rightParenthesis);
 
-    // Attach the ` {` after the `(` in the [ListPiece] created by
+    // Attach the ` {` after the `)` in the [ListPiece] created by
     // [createSwitchValue()].
     writer.space();
     token(node.leftBracket);

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -959,7 +959,8 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     createSwitchValue(node.switchKeyword, node.leftParenthesis, node.expression,
         node.rightParenthesis);
 
-    // Attach the ` {` as part of the `)` in the switch value ListPiece.
+    // Attach the ` {` after the `(` in the [ListPiece] created by
+    // [createSwitchValue()].
     writer.space();
     token(node.leftBracket);
     writer.split();

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -124,7 +124,9 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitAssignmentExpression(AssignmentExpression node) {
-    throw UnimplementedError();
+    visit(node.leftHandSide);
+    writer.space();
+    finishAssignment(node.operator, node.rightHandSide);
   }
 
   @override

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -42,8 +42,9 @@ class DelimitedListBuilder {
   final int _splitCost;
 
   /// Whether this list should have spaces inside the bracket when it doesn't
-  /// split. This is false for most lists, but true for switch expression
-  /// bodies:
+  /// split.
+  ///
+  /// This is false for most lists, but true for switch expression bodies:
   ///
   /// ```
   /// v = switch (e) { 1 => 'one', 2 => 'two' };

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -13,15 +13,6 @@ import 'piece.dart';
 ///
 /// Usually constructed using [createDelimited()] or a [DelimitedListBuilder].
 class ListPiece extends Piece {
-  /// State used for a split list containing type arguments or type parameters.
-  ///
-  /// Has a higher cost than [State.split] since splitting type arguments and
-  /// type parameters tends to look worse than splitting at other places.
-  // TODO(rnystrom): Having to use a different state for this is a little
-  // cumbersome. Maybe it would be better to most costs out of [State] and
-  // instead have the [Solver] ask each [Piece] for the cost of its state.
-  static const _splitTypes = State(1, cost: 2);
-
   /// The called expression and the subsequent "(".
   final Piece _before;
 
@@ -41,29 +32,85 @@ class ListPiece extends Piece {
   /// The ")" after the arguments.
   final Piece _after;
 
-  /// Whether this list is a list of type arguments or type parameters, versus
-  /// any other kind of list.
+  /// Whether this list should have a trailing comma if it splits.
   ///
-  /// Type arguments/parameters are different because:
-  ///
-  /// *   The language doesn't allow a trailing comma in them.
-  /// *   Splitting in them looks aesthetically worse, so we increase the cost
-  ///     of doing so.
-  final bool _isTypeList;
+  /// This is true for most lists but false for type parameters, type arguments,
+  /// and switch values.
+  final bool _trailingComma;
 
-  ListPiece(this._before, this._arguments, this._blanksAfter, this._after,
-      this._isTypeList);
+  /// The state when the list is split.
+  ///
+  /// We use this instead of [State.split] because the cost is higher for some
+  /// kinds of lists.
+  // TODO(rnystrom): Having to use a different state for this is a little
+  // cumbersome. Maybe it would be better to most costs out of [State] and
+  // instead have the [Solver] ask each [Piece] for the cost of its state.
+  final State _splitState;
+
+  /// Whether this list should have spaces inside the bracket when it doesn't
+  /// split. This is false for most lists, but true for switch expression
+  /// bodies:
+  ///
+  /// ```
+  /// v = switch (e) { 1 => 'one', 2 => 'two' };
+  /// //              ^                      ^
+  /// ```
+  final bool _spaceWhenUnsplit;
+
+  /// Whether a split in the [_before] piece should force the list to split too.
+  /// Most of the time, this isn't relevant because the before part is usually
+  /// just a single bracket character.
+  ///
+  /// For collection literals with explicit type arguments, the [_before] piece
+  /// contains the type arguments. If those split, this is `false` to allow the
+  /// list itself to remain unsplit as in:
+  ///
+  /// ```
+  /// <
+  ///   VeryLongTypeName,
+  ///   AnotherLongTypeName,
+  /// >{a: 1};
+  /// ```
+  ///
+  /// For switch expressions, the `switch (value) {` part is in [_before] and
+  /// the body is the list. In that case, if the value splits, we want to force
+  /// the body to split too:
+  ///
+  /// ```
+  /// // Disallowed:
+  /// e = switch (
+  ///   "a long string that must wrap"
+  /// ) { 0 => "ok" };
+  ///
+  /// // Instead:
+  /// e = switch (
+  ///   "a long string that must wrap"
+  /// ) {
+  ///   0 => "ok",
+  /// };
+  /// ```
+  final bool _splitListIfBeforeSplits;
+
+  ListPiece(
+      this._before,
+      this._arguments,
+      this._blanksAfter,
+      this._after,
+      int cost,
+      this._trailingComma,
+      this._spaceWhenUnsplit,
+      this._splitListIfBeforeSplits)
+      : _splitState = State(1, cost: cost);
 
   @override
-  List<State> get additionalStates => [
-        if (_isTypeList)
-          _splitTypes // Type lists are more expensive to split.
-        else if (_arguments.isNotEmpty)
-          State.split // Don't split between an empty pair of brackets.
-      ];
+  List<State> get additionalStates => [if (_arguments.isNotEmpty) _splitState];
 
   @override
   void format(CodeWriter writer, State state) {
+    if (_splitListIfBeforeSplits && state == State.unsplit) {
+      writer.setAllowNewlines(false);
+    }
+
     writer.format(_before);
 
     // TODO(tall): Should support a third state for argument lists with block
@@ -74,30 +121,31 @@ class ListPiece extends Piece {
     //   ...
     // });
     // ```
-    switch (state) {
-      case State.unsplit:
-        // All arguments on one line with no trailing comma.
-        writer.setAllowNewlines(false);
-        for (var i = 0; i < _arguments.length; i++) {
-          if (i > 0 && _arguments[i - 1]._delimiter.isEmpty) writer.space();
+    if (state == State.unsplit) {
+      writer.setAllowNewlines(false);
+      if (_spaceWhenUnsplit && _arguments.isNotEmpty) writer.space();
 
-          // Don't write a trailing comma.
-          _arguments[i].format(writer, omitComma: i == _arguments.length - 1);
-        }
+      // All arguments on one line with no trailing comma.
+      for (var i = 0; i < _arguments.length; i++) {
+        if (i > 0 && _arguments[i - 1]._delimiter.isEmpty) writer.space();
 
-      case State.split:
-      case _splitTypes:
-        // Each argument on its own line with a trailing comma after the last.
-        writer.newline(indent: Indent.block);
-        for (var i = 0; i < _arguments.length; i++) {
-          var argument = _arguments[i];
-          argument.format(writer,
-              omitComma: _isTypeList && i == _arguments.length - 1);
-          if (i < _arguments.length - 1) {
-            writer.newline(blank: _blanksAfter.contains(argument));
-          }
+        // Don't write a trailing comma.
+        _arguments[i].format(writer, omitComma: i == _arguments.length - 1);
+      }
+
+      if (_spaceWhenUnsplit && _arguments.isNotEmpty) writer.space();
+    } else {
+      // Each argument on its own line with a trailing comma after the last.
+      writer.newline(indent: Indent.block);
+      for (var i = 0; i < _arguments.length; i++) {
+        var argument = _arguments[i];
+        argument.format(writer,
+            omitComma: !_trailingComma && i == _arguments.length - 1);
+        if (i < _arguments.length - 1) {
+          writer.newline(blank: _blanksAfter.contains(argument));
         }
-        writer.newline(indent: Indent.none);
+      }
+      writer.newline(indent: Indent.none);
     }
 
     writer.setAllowNewlines(true);

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -128,8 +128,6 @@ class ListPiece extends Piece {
       // All arguments on one line with no trailing comma.
       for (var i = 0; i < _arguments.length; i++) {
         if (i > 0 && _arguments[i - 1]._delimiter.isEmpty) writer.space();
-
-        // Don't write a trailing comma.
         _arguments[i].format(writer, omitComma: i == _arguments.length - 1);
       }
 

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -11,33 +11,50 @@ import 'piece.dart';
 /// Usually constructed using a [SequenceBuilder].
 class SequencePiece extends Piece {
   /// The series of members or statements.
-  final List<Piece> _contents;
+  final List<SequenceElement> _elements;
 
-  /// The pieces that should have a blank line preserved between them and the
-  /// next piece.
-  final Set<Piece> _blanksAfter;
-
-  SequencePiece(this._contents, this._blanksAfter);
+  SequencePiece(this._elements);
 
   /// Whether this sequence has any contents.
-  bool get isNotEmpty => _contents.isNotEmpty;
+  bool get isNotEmpty => _elements.isNotEmpty;
 
   @override
   void format(CodeWriter writer, State state) {
-    for (var i = 0; i < _contents.length; i++) {
-      writer.format(_contents[i]);
+    for (var i = 0; i < _elements.length; i++) {
+      var element = _elements[i];
+      writer.format(element.piece);
 
-      if (i < _contents.length - 1) {
-        writer.newline(blank: _blanksAfter.contains(_contents[i]));
+      if (i < _elements.length - 1) {
+        writer.newline(
+            blank: element.blankAfter, indent: _elements[i + 1].indent);
       }
     }
   }
 
   @override
   void forEachChild(void Function(Piece piece) callback) {
-    _contents.forEach(callback);
+    for (var element in _elements) {
+      callback(element.piece);
+    }
   }
 
   @override
   String toString() => 'Sequence';
+}
+
+/// An element inside a [SequencePiece].
+///
+/// Tracks the underlying [Piece] along with surrounding whitespace.
+class SequenceElement {
+  /// The number of spaces of indentation on the line before this element,
+  /// relative to the surrounding [Piece].
+  final int indent;
+
+  /// The [Piece] for the element.
+  final Piece piece;
+
+  /// Whether there should be a blank line after this element.
+  bool blankAfter = false;
+
+  SequenceElement(this.indent, this.piece);
 }

--- a/test/expression/assignment.stmt
+++ b/test/expression/assignment.stmt
@@ -1,0 +1,68 @@
+40 columns                              |
+>>> Chained assignment.
+a=b=c;
+<<<
+a = b = c;
+>>> Compound assignment operators.
+a*=b/=c~/=d%=e;
+<<<
+a *= b /= c ~/= d %= e;
+>>>
+a+=b-=c;
+<<<
+a += b -= c;
+>>>
+a<<=b>>>=c>>=d;
+<<<
+a <<= b >>>= c >>= d;
+>>>
+a&=b^=c|=d;
+<<<
+a &= b ^= c |= d;
+>>>
+a??=b;
+<<<
+a ??= b;
+>>> Split after `=`.
+variableName = thisIsReallyQuiteAVeryLongVariableName;
+<<<
+variableName =
+    thisIsReallyQuiteAVeryLongVariableName;
+>>> Prefer to split at "=" over infix operator.
+variableName = argument * argument + argument;
+<<<
+variableName =
+    argument * argument + argument;
+>>> Prefer block-like splitting for collections.
+variableName = [element, element, element];
+<<<
+variableName = [
+  element,
+  element,
+  element,
+];
+>>> Prefer block-like splitting for function calls.
+variableName = function(argument, argument);
+<<<
+variableName = function(
+  argument,
+  argument,
+);
+>>> No block-like splitting for empty argument lists.
+variableNameExactLength____ = function();
+<<<
+variableNameExactLength____ =
+    function();
+>>> No block-like splitting if function name doesn't fit.
+longVariableName = veryLongFunctionName_(argument);
+<<<
+longVariableName =
+    veryLongFunctionName_(argument);
+>>> Indent block if function name doesn't fit and arguments split.
+longVariableName = veryLongFunctionName_(argument, another);
+<<<
+longVariableName =
+    veryLongFunctionName_(
+      argument,
+      another,
+    );

--- a/test/expression/switch.stmt
+++ b/test/expression/switch.stmt
@@ -1,0 +1,113 @@
+40 columns                              |
+>>> Empty.
+e = switch(y) {};
+<<<
+e = switch (y) {};
+>>> All one line.
+e = switch (c) { 0 => a, 1 => b };
+<<<
+e = switch (c) { 0 => a, 1 => b };
+>>> One case per line.
+e = switch (c) { 0 => first, 1 => second };
+<<<
+e = switch (c) {
+  0 => first,
+  1 => second,
+};
+>>> Remove trailing comma if cases fit on one line.
+e = switch (c) { 0 => a, 1 => b, };
+<<<
+e = switch (c) { 0 => a, 1 => b };
+>>> Split some cases at "=>" but not all.
+e = switch (c) {
+  first => a,
+  second => veryLongExpression + thatSplits,
+  third => c
+};
+<<<
+e = switch (c) {
+  first => a,
+  second =>
+      veryLongExpression + thatSplits,
+  third => c,
+};
+>>> Discard newlines between cases.
+e = switch (obj) {
+
+
+  0 => a,
+
+
+  1 => b,
+
+
+
+  2 => c
+
+
+};
+<<<
+e = switch (obj) {
+  0 => a,
+  1 => b,
+  2 => c,
+};
+>>> Split before switch value.
+e = switch ("a long string that must wrap") {
+  0 => "ok"
+};
+<<<
+e = switch (
+  "a long string that must wrap"
+) {
+  0 => "ok",
+};
+>>> Split in delimited value expression.
+e = switch ([veryLongElement,veryLongElement,veryLongElement,]) {
+  0 => "ok"
+};
+<<<
+### TODO(tall): Once block arguments are supported, this should become:
+### e = switch ([
+###   veryLongElement,
+###   veryLongElement,
+###   veryLongElement,
+### ]) {
+e = switch (
+  [
+    veryLongElement,
+    veryLongElement,
+    veryLongElement,
+  ]
+) {
+  0 => "ok",
+};
+>>> Split in case expression.
+e = switch (obj) {
+  1 => veryLongExpression + thatStillMustSplit
+};
+<<<
+e = switch (obj) {
+  1 =>
+      veryLongExpression +
+          thatStillMustSplit,
+};
+>>> Prefer to split after "=>" instead of body.
+e = switch (obj) {
+  longConstant => longExpression + thatMustSplit
+};
+<<<
+e = switch (obj) {
+  longConstant =>
+      longExpression + thatMustSplit,
+};
+>>> Split after "=>" and in body.
+e = switch (obj) {
+  longConstant => veryLongLongExpression + thatMustSplit
+};
+<<<
+e = switch (obj) {
+  longConstant =>
+      veryLongLongExpression +
+          thatMustSplit,
+};

--- a/test/expression/switch_comment.stmt
+++ b/test/expression/switch_comment.stmt
@@ -1,0 +1,87 @@
+40 columns                              |
+>>> Keep one blank line around case comments in switch expression.
+e = switch (n) {
+
+
+  // comment
+  0 => a,
+  // comment
+
+
+  1 => b,
+
+
+  // comment
+
+
+};
+<<<
+e = switch (n) {
+  // comment
+  0 => a,
+  // comment
+  1 => b,
+
+  // comment
+};
+>>> Line comment between cases does not force case to split after `=>`.
+e = switch (n) {
+  0 => zero,
+  // comment
+  1 => one
+};
+<<<
+e = switch (n) {
+  0 => zero,
+  // comment
+  1 => one,
+};
+>>> Line comment at end of case does not force cases to split.
+e = switch (n) {
+  0 => zero, // comment
+  1 => one, // comment
+  2 => two // comment
+};
+<<<
+e = switch (n) {
+  0 => zero, // comment
+  1 => one, // comment
+  2 => two, // comment
+};
+>>> Line comment in empty switch.
+e = switch (n) {
+  // comment
+};
+<<<
+e = switch (n) {
+  // comment
+};
+>>> Line comment on opening line of empty switch.
+e = switch (n) { // comment
+};
+<<<
+e = switch (n) {
+  // comment
+};
+>>> Non-inline block comment with newlines before and after.
+e = switch (n) {
+  /* comment */
+};
+<<<
+e = switch (n) {
+  /* comment */
+};
+>>> Non-inline block comment with trailing newline.
+e = switch (n) {/* comment */
+};
+<<<
+e = switch (n) { /* comment */ };
+>>> Non-inline block comment with leading newline.
+e = switch (n) {
+  /* comment */};
+<<<
+e = switch (n) { /* comment */ };
+>>> Inline block comment.
+e = switch (n) {  /* comment */  };
+<<<
+e = switch (n) { /* comment */ };

--- a/test/statement/switch.stmt
+++ b/test/statement/switch.stmt
@@ -1,0 +1,282 @@
+40 columns                              |
+>>> Separate statements in cases.
+switch (foo) {case 0:a();b();c();}
+<<<
+switch (foo) {
+  case 0:
+    a();
+    b();
+    c();
+}
+>>> Allow a blank line between case statements.
+switch (foo) {case 0:
+  a();
+
+  b();
+  c();
+}
+<<<
+switch (foo) {
+  case 0:
+    a();
+
+    b();
+    c();
+}
+>>> Collapse other newlines in cases.
+switch (foo) {case 0:
+
+
+  a();
+
+
+
+  b();
+
+
+
+  c();
+
+
+}
+<<<
+switch (foo) {
+  case 0:
+    a();
+
+    b();
+
+    c();
+}
+>>> Remove newlines between empty cases.
+switch (foo) {
+  case 1:
+
+
+  case 2:
+
+  case 3:
+
+    body;
+
+  case 4:
+
+
+  default:
+
+
+    body;
+}
+<<<
+switch (foo) {
+  case 1:
+  case 2:
+  case 3:
+    body;
+
+  case 4:
+  default:
+    body;
+}
+>>> Separate statements in the default clause.
+switch (foo) {default:a();b();c();}
+<<<
+switch (foo) {
+  default:
+    a();
+    b();
+    c();
+}
+>>> Allow a blank line between statements in the default clause.
+switch (foo) {default:
+  a();
+
+  b();
+  c();
+}
+<<<
+switch (foo) {
+  default:
+    a();
+
+    b();
+    c();
+}
+>>> Collapse other newlines in the default clause.
+switch (foo) {default:
+
+
+  a();
+
+
+
+  b();
+
+
+
+  c();
+
+
+}
+<<<
+switch (foo) {
+  default:
+    a();
+
+    b();
+
+    c();
+}
+>>> Put cases on their own lines.
+switch (foo) {case 0:case 1:case 2:body();}
+<<<
+switch (foo) {
+  case 0:
+  case 1:
+  case 2:
+    body();
+}
+>>> Allow a blank line between non-empty cases.
+switch (foo) {case 0: body();
+
+  case 1:
+  case 2:body();
+}
+<<<
+switch (foo) {
+  case 0:
+    body();
+
+  case 1:
+  case 2:
+    body();
+}
+>>> Collapse other newlines between cases.
+switch (foo) {
+
+
+  case 0:
+
+
+  case 1:
+
+
+  case 2:
+
+
+    body();
+
+
+
+}
+<<<
+switch (foo) {
+  case 0:
+  case 1:
+  case 2:
+    body();
+}
+>>> Single-statement cases split even when they could fit on one line.
+switch (obj) {
+  case 1: a();
+  case 2: b();
+  default: c();
+}
+<<<
+switch (obj) {
+  case 1:
+    a();
+  case 2:
+    b();
+  default:
+    c();
+}
+>>> Multiple statement cases split even when they could fit on one line.
+switch (obj) {
+  case 1: a(); b();
+  case 2: c(); d();
+  default: d(); e();
+}
+<<<
+switch (obj) {
+  case 1:
+    a();
+    b();
+  case 2:
+    c();
+    d();
+  default:
+    d();
+    e();
+}
+>>> Indentation.
+switch (fruit) {
+case "apple":
+print("delish");
+break;
+case "fig":
+print("bleh");
+break;
+}
+<<<
+switch (fruit) {
+  case "apple":
+    print("delish");
+    break;
+  case "fig":
+    print("bleh");
+    break;
+}
+>>> Labeled cases.
+switch (fruit) {
+  case "apple":
+    print("delish");
+    break;
+  label:case "fig":
+    print("bleh");
+    break;
+  other:default:
+    break;
+}
+<<<
+switch (fruit) {
+  case "apple":
+    print("delish");
+    break;
+  label:
+  case "fig":
+    print("bleh");
+    break;
+  other:
+  default:
+    break;
+}
+>>> Split before the switch expression.
+switch ("a long string that must wrap") {
+  case 0:
+    return "ok";
+}
+<<<
+switch (
+  "a long string that must wrap"
+) {
+  case 0:
+    return "ok";
+}
+>>> Split a delimited expression in the switch expression.
+switch ([veryLongElement,veryLongElement]) {
+  case 0:
+    return "ok";
+}
+<<<
+### TODO(tall): Once block arguments are supported, this should become:
+### switch ([
+###   veryLongElement,
+###   veryLongElement,
+### ]) {
+switch (
+  [veryLongElement, veryLongElement]
+) {
+  case 0:
+    return "ok";
+}

--- a/test/statement/switch_comment.stmt
+++ b/test/statement/switch_comment.stmt
@@ -1,0 +1,119 @@
+40 columns                              |
+>>> Blank lines before comments.
+switch (n) {
+
+
+  // comment
+  case 0:
+
+
+
+  // comment
+
+
+
+  case 1:
+    body;
+
+
+  // comment
+
+
+}
+<<<
+switch (n) {
+  // comment
+  case 0:
+
+  // comment
+
+  case 1:
+    body;
+
+  // comment
+}
+>>> Line comment between cases does not force them to split.
+switch (n) {
+  case 0: zero;
+  // comment
+  case 1: one;
+}
+<<<
+switch (n) {
+  case 0:
+    zero;
+  // comment
+  case 1:
+    one;
+}
+>>> Line comment indentation.
+switch (n) {
+  // before first
+  case 0: zero;
+  // between
+  case 1: one;
+  // after last
+}
+<<<
+switch (n) {
+  // before first
+  case 0:
+    zero;
+  // between
+  case 1:
+    one;
+  // after last
+}
+>>> Line comment in empty cases.
+switch (n) {
+  case 0: // comment 0
+  case 1:
+    // comment 1
+  case 2:
+    // comment 2
+}
+<<<
+switch (n) {
+  case 0: // comment 0
+  case 1:
+  // comment 1
+  case 2:
+  // comment 2
+}
+>>> Line comment in empty switch.
+switch (e) {
+  // comment
+}
+<<<
+switch (e) {
+  // comment
+}
+>>> Line comment on opening line of empty switch.
+switch (e) { // comment
+}
+<<<
+switch (e) {
+  // comment
+}
+>>> Non-inline block comment in empty switch.
+switch (e) {
+  /* comment */
+}
+<<<
+switch (e) {
+  /* comment */
+}
+>>> Block comment with trailing newline.
+switch (e) {/* comment */
+}
+<<<
+switch (e) {/* comment */}
+>>> Block comment with leading newline.
+switch (e) {
+  /* comment */}
+<<<
+switch (e) {/* comment */}
+>>> Inline block comment.
+switch (e) {  /* comment */  }
+<<<
+switch (e) {/* comment */}

--- a/test/statement/variable.stmt
+++ b/test/statement/variable.stmt
@@ -181,6 +181,33 @@ var longVariableName =
       argument,
       another,
     );
+>>> Use block-like splitting for switch expressions.
+var variableName = switch (value) { 1 => 'one', 2 => 'two' };
+<<<
+var variableName = switch (value) {
+  1 => 'one',
+  2 => 'two',
+};
+>>> Use block-like splitting for switch expressions with split values.
+var variableName = switch ([longElement, longElement, longElement])
+{ 1 => 'one', 2 => 'two' };
+<<<
+### TODO(tall): Once block arguments are supported, this should become:
+### var variableName = switch ([
+###   longElement,
+###   longElement,
+###   longElement,
+### ]) {
+var variableName = switch (
+  [
+    longElement,
+    longElement,
+    longElement,
+  ]
+) {
+  1 => 'one',
+  2 => 'two',
+};
 >>> Use block-like splitting for parenthesized expressions whose inner does.
 var variableName = ([element, element, element]);
 <<<


### PR DESCRIPTION
Switch statements build on the existing SequencePiece but need some additional flexibility in there to handle the fact that switch case lines are indented +2 and then case body lines are indented +4.

Switch expressions build on the existing ListPiece since the body is sort of like a collection literal. There are a few tweaks needed here too since an unsplit switch expression body gets spaces inside the curly brackets.

Also, switch values (the part in the leading "( ... )") are formatted using ListPiece as well, since they are formatted essentially like a single-element argument list, except that they don't get a trailing comma.

This does not implement all of the kinds of patterns that can appear in cases. It just implements basic constants needed for the tests. It also doesn't support guard clauses yet. Those will come later.
