### PR TITLE
Refactor ListPiece and DelimitedListBuilder.

### DIFF
--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -126,13 +126,14 @@ class CodeWriter {
   ///
   /// If [space] is `true` and [condition] is `false`, writes a space.
   ///
+  /// If [blank] is `true`, writes an extra newline to produce a blank line.
+  ///
   /// If [indent] is given, sets the amount of block-level indentation for this
   /// and all subsequent newlines to [indent].
-  void splitIf(bool condition, {bool space = true, int? indent}) {
-    if (indent != null) setIndent(indent);
-
+  void splitIf(bool condition,
+      {bool space = true, bool blank = false, int? indent}) {
     if (condition) {
-      newline();
+      newline(blank: blank, indent: indent);
     } else if (space) {
       this.space();
     }

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -11,6 +11,7 @@ import '../piece/block.dart';
 import '../piece/do_while.dart';
 import '../piece/if.dart';
 import '../piece/infix.dart';
+import '../piece/list.dart';
 import '../piece/piece.dart';
 import '../piece/variable.dart';
 import '../source_code.dart';
@@ -410,7 +411,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
         builder.leftDelimiter(node.leftDelimiter!);
       }
 
-      builder.add(node.parameters[i]);
+      builder.visit(node.parameters[i]);
     }
 
     builder.rightBracket(node.rightParenthesis, delimiter: node.rightDelimiter);
@@ -930,7 +931,8 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitSwitchExpression(SwitchExpression node) {
-    var list = DelimitedListBuilder.switchBody(this);
+    var list = DelimitedListBuilder(this,
+        const ListStyle(spaceWhenUnsplit: true, splitListIfBeforeSplits: true));
 
     createSwitchValue(node.switchKeyword, node.leftParenthesis, node.expression,
         node.rightParenthesis);
@@ -938,7 +940,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     list.leftBracket(node.leftBracket);
 
     for (var member in node.cases) {
-      list.add(member);
+      list.visit(member);
     }
 
     list.rightBracket(node.rightBracket);

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -122,9 +122,6 @@ class DelimitedListBuilder {
   }
 
   /// Adds [element] to the built list.
-  ///
-  /// Includes any comments that appear before element. Also includes the
-  /// subsequent comma, if any, and any comments that precede the comma.
   void visit(AstNode element) {
     // Handle comments between the preceding element and this one.
     addCommentsBefore(element.beginToken);

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -358,8 +358,9 @@ mixin PieceFactory implements CommentWriter {
 
   /// Creates a [ListPiece] for the given bracket-delimited set of elements.
   void createList(
-      Token leftBracket, Iterable<AstNode> elements, Token rightBracket) {
-    var builder = DelimitedListBuilder(this);
+      Token leftBracket, Iterable<AstNode> elements, Token rightBracket,
+      {ListStyle style = const ListStyle()}) {
+    var builder = DelimitedListBuilder(this, style);
     builder.leftBracket(leftBracket);
     elements.forEach(builder.visit);
     builder.rightBracket(rightBracket);
@@ -388,12 +389,8 @@ mixin PieceFactory implements CommentWriter {
   /// Creates a [ListPiece] for a type argument or type parameter list.
   void createTypeList(
       Token leftBracket, Iterable<AstNode> elements, Token rightBracket) {
-    var builder = DelimitedListBuilder(
-        this, const ListStyle(commas: Commas.nonTrailing, splitCost: 2));
-    builder.leftBracket(leftBracket);
-    elements.forEach(builder.visit);
-    builder.rightBracket(rightBracket);
-    writer.push(builder.build());
+    return createList(leftBracket, elements, rightBracket,
+        style: const ListStyle(commas: Commas.nonTrailing, splitCost: 2));
   }
 
   /// Writes the parts of a formal parameter shared by all formal parameter

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -11,6 +11,7 @@ import '../piece/function.dart';
 import '../piece/if.dart';
 import '../piece/import.dart';
 import '../piece/infix.dart';
+import '../piece/list.dart';
 import '../piece/piece.dart';
 import '../piece/postfix.dart';
 import 'ast_node_visitor.dart';
@@ -360,7 +361,7 @@ mixin PieceFactory implements CommentWriter {
       Token leftBracket, Iterable<AstNode> elements, Token rightBracket) {
     var builder = DelimitedListBuilder(this);
     builder.leftBracket(leftBracket);
-    elements.forEach(builder.add);
+    elements.forEach(builder.visit);
     builder.rightBracket(rightBracket);
     writer.push(builder.build());
   }
@@ -370,14 +371,15 @@ mixin PieceFactory implements CommentWriter {
       Expression value, Token rightParenthesis) {
     // Format like an argument list since it is an expression surrounded by
     // parentheses.
-    var builder = DelimitedListBuilder.switchValue(this);
+    var builder = DelimitedListBuilder(
+        this, const ListStyle(commas: Commas.none, splitCost: 2));
 
     // Attach the `switch ` as part of the `(`.
     token(switchKeyword);
     writer.space();
 
     builder.leftBracket(leftParenthesis);
-    builder.add(value);
+    builder.visit(value);
     builder.rightBracket(rightParenthesis);
 
     writer.push(builder.build());
@@ -386,9 +388,10 @@ mixin PieceFactory implements CommentWriter {
   /// Creates a [ListPiece] for a type argument or type parameter list.
   void createTypeList(
       Token leftBracket, Iterable<AstNode> elements, Token rightBracket) {
-    var builder = DelimitedListBuilder.type(this);
+    var builder = DelimitedListBuilder(
+        this, const ListStyle(commas: Commas.nonTrailing, splitCost: 2));
     builder.leftBracket(leftBracket);
-    elements.forEach(builder.add);
+    elements.forEach(builder.visit);
     builder.rightBracket(rightBracket);
     writer.push(builder.build());
   }


### PR DESCRIPTION
These classes started out just supporting argument lists, then grew to collection literals, then parameter lists, then switch expressions, and soon for loop headers.

Each time, I need to tweak how it works a little. (But not enough to not use it completely, since the comment handling is complex and is the same across all of those constructors.)

There was getting to be an unwieldy set of options being passed around. Cleaned that up by defining a separate ListStyle that contains those options and can be shuttled directly from DelimitedListBuilder to ListPiece.

I made the before and after bracket pieces optional since I'll be using ListPiece in a future PR for the updaters list in a for loop, which isn't delimited.

Did a bunch of other minor clean-up.

Also, many of the docs were out of date. Fixed those.

