### PR TITLE
Revamp the PieceWriter API some.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -85,7 +85,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     // Write any comments at the end of the code.
     sequence.addCommentsBefore(node.endToken.next!);
 
-    pieces.push(sequence.build());
+    pieces.give(sequence.build());
 
     // Finish writing and return the complete result.
     return pieces.finish();
@@ -228,7 +228,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     token(node.colon);
     space();
     visit(node.elseExpression);
-    var elseBranch = pieces.pop();
+    var elseBranch = pieces.take();
 
     var piece = InfixPiece([condition, thenBranch, elseBranch]);
 
@@ -240,7 +240,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
       piece.pin(State.split);
     }
 
-    pieces.push(piece);
+    pieces.give(piece);
   }
 
   @override
@@ -318,9 +318,9 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     visit(node.condition);
     token(node.rightParenthesis);
     token(node.semicolon);
-    var condition = pieces.pop();
+    var condition = pieces.take();
 
-    pieces.push(DoWhilePiece(body, condition));
+    pieces.give(DoWhilePiece(body, condition));
   }
 
   @override
@@ -413,7 +413,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     }
 
     builder.rightBracket(node.rightParenthesis, delimiter: node.rightDelimiter);
-    pieces.push(builder.build());
+    pieces.give(builder.build());
   }
 
   @override
@@ -484,9 +484,9 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
     pieces.split();
     visit(node.body);
-    var body = pieces.pop();
+    var body = pieces.take();
 
-    pieces.push(ForPiece(forKeyword, forPartsPiece, body,
+    pieces.give(ForPiece(forKeyword, forPartsPiece, body,
         hasBlockBody: node.body is Block));
   }
 
@@ -644,7 +644,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     }
 
     sequence.visit(node.statement);
-    pieces.push(sequence.build());
+    pieces.give(sequence.build());
   }
 
   @override
@@ -946,9 +946,9 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
       var typePiece = pieces.split();
 
       token(name);
-      var namePiece = pieces.pop();
+      var namePiece = pieces.take();
 
-      pieces.push(VariablePiece(typePiece, [namePiece], hasType: true));
+      pieces.give(VariablePiece(typePiece, [namePiece], hasType: true));
     } else {
       // Only one of name or type so just write whichever there is.
       visit(node.type);
@@ -1006,7 +1006,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     }
 
     list.rightBracket(node.rightBracket);
-    pieces.push(list.build());
+    pieces.give(list.build());
   }
 
   @override
@@ -1070,9 +1070,9 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     sequence.addCommentsBefore(node.rightBracket);
 
     token(node.rightBracket);
-    var rightBracketPiece = pieces.pop();
+    var rightBracketPiece = pieces.take();
 
-    pieces.push(BlockPiece(switchPiece, sequence.build(), rightBracketPiece,
+    pieces.give(BlockPiece(switchPiece, sequence.build(), rightBracketPiece,
         alwaysSplit: node.members.isNotEmpty));
   }
 
@@ -1148,17 +1148,17 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     // argument list or a function type's parameter list) affect the indentation
     // and splitting of the surrounding variable declaration.
     visit(node.type);
-    var header = pieces.pop();
+    var header = pieces.take();
 
     var variables = <Piece>[];
     for (var variable in node.variables) {
       pieces.split();
       visit(variable);
       commaAfter(variable);
-      variables.add(pieces.pop());
+      variables.add(pieces.take());
     }
 
-    pieces.push(VariablePiece(header, variables, hasType: node.type != null));
+    pieces.give(VariablePiece(header, variables, hasType: node.type != null));
   }
 
   @override
@@ -1177,11 +1177,11 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     var condition = pieces.split();
 
     visit(node.body);
-    var body = pieces.pop();
+    var body = pieces.take();
 
     var piece = IfPiece();
     piece.add(condition, body, isBlock: node.body is Block);
-    pieces.push(piece);
+    pieces.give(piece);
   }
 
   @override

--- a/lib/src/front_end/comment_writer.dart
+++ b/lib/src/front_end/comment_writer.dart
@@ -43,7 +43,7 @@ import 'piece_writer.dart';
 // TODO(tall): When argument lists and their comment handling is supported,
 // mention that here.
 mixin CommentWriter {
-  PieceWriter get writer;
+  PieceWriter get pieces;
 
   LineInfo get lineInfo;
 
@@ -78,20 +78,20 @@ mixin CommentWriter {
 
       if (comments.isHanging(i)) {
         // Attach the comment to the previous token.
-        writer.space();
-        writer.writeComment(comment, hanging: true);
+        pieces.writeSpace();
+        pieces.writeComment(comment, hanging: true);
       } else {
-        writer.writeNewline();
-        writer.writeComment(comment);
+        pieces.writeNewline();
+        pieces.writeComment(comment);
       }
 
       if (comment.type == CommentType.line || comment.type == CommentType.doc) {
-        writer.writeNewline();
+        pieces.writeNewline();
       }
     }
 
     if (comments.isNotEmpty && _needsSpaceAfterComment(token.lexeme)) {
-      writer.space();
+      pieces.writeSpace();
     }
   }
 

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -60,8 +60,7 @@ class DelimitedListBuilder {
   void leftBracket(Token bracket, {Token? delimiter}) {
     _visitor.token(bracket);
     _visitor.token(delimiter);
-    _leftBracket = _visitor.writer.pop();
-    _visitor.writer.split();
+    _leftBracket = _visitor.pieces.split();
   }
 
   /// Adds the closing [bracket] to the built list along with any comments that
@@ -99,7 +98,7 @@ class DelimitedListBuilder {
 
     _visitor.token(delimiter);
     _visitor.token(bracket);
-    _rightBracket = _visitor.writer.pop();
+    _rightBracket = _visitor.pieces.pop();
   }
 
   /// Adds [piece] to the built list.
@@ -128,8 +127,7 @@ class DelimitedListBuilder {
 
     // Traverse the element itself.
     _visitor.visit(element);
-    _visitor.writer.split();
-    add(_visitor.writer.pop());
+    add(_visitor.pieces.split());
 
     var nextToken = element.endToken.next!;
     if (nextToken.lexeme == ',') {
@@ -191,20 +189,19 @@ class DelimitedListBuilder {
     // Add any hanging inline block comments to the previous element before the
     // subsequent ",".
     for (var comment in inlineComments) {
-      _visitor.writer.space();
-      _visitor.writer.writeComment(comment, hanging: true);
+      _visitor.space();
+      _visitor.pieces.writeComment(comment, hanging: true);
     }
 
     // Add any remaining hanging line comments to the previous element after
     // the ",".
     if (hangingComments.isNotEmpty) {
       for (var comment in hangingComments) {
-        _visitor.writer.space();
-        _visitor.writer.writeComment(comment);
+        _visitor.space();
+        _visitor.pieces.writeComment(comment);
       }
 
-      _elements.last = _elements.last.withComment(_visitor.writer.pop());
-      _visitor.writer.split();
+      _elements.last = _elements.last.withComment(_visitor.pieces.split());
     }
 
     // Comments that are neither hanging nor leading are treated like their own
@@ -215,15 +212,14 @@ class DelimitedListBuilder {
         _blanksAfter.add(_elements.last);
       }
 
-      _visitor.writer.writeComment(comment);
-      _elements.add(ListElement.comment(_visitor.writer.pop()));
-      _visitor.writer.split();
+      _visitor.pieces.writeComment(comment);
+      _elements.add(ListElement.comment(_visitor.pieces.split()));
     }
 
     // Leading comments are written before the next element.
     for (var comment in leadingComments) {
-      _visitor.writer.writeComment(comment);
-      _visitor.writer.space();
+      _visitor.pieces.writeComment(comment);
+      _visitor.space();
     }
   }
 

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -98,7 +98,7 @@ class DelimitedListBuilder {
 
     _visitor.token(delimiter);
     _visitor.token(bracket);
-    _rightBracket = _visitor.pieces.pop();
+    _rightBracket = _visitor.pieces.take();
   }
 
   /// Adds [piece] to the built list.

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -60,8 +60,7 @@ mixin PieceFactory implements CommentWriter {
   /// ```
   void createBlock(Block block, {bool forceSplit = false}) {
     token(block.leftBracket);
-    var leftBracketPiece = writer.pop();
-    writer.split();
+    var leftBracketPiece = pieces.split();
 
     var sequence = SequenceBuilder(this);
     for (var node in block.statements) {
@@ -72,9 +71,9 @@ mixin PieceFactory implements CommentWriter {
     sequence.addCommentsBefore(block.rightBracket);
 
     token(block.rightBracket);
-    var rightBracketPiece = writer.pop();
+    var rightBracketPiece = pieces.pop();
 
-    writer.push(BlockPiece(
+    pieces.push(BlockPiece(
         leftBracketPiece, sequence.build(), rightBracketPiece,
         alwaysSplit: forceSplit || block.statements.isNotEmpty));
   }
@@ -83,7 +82,7 @@ mixin PieceFactory implements CommentWriter {
   void createBreak(Token keyword, SimpleIdentifier? label, Token semicolon) {
     token(keyword);
     if (label != null) {
-      writer.space();
+      space();
       visit(label);
     }
     token(semicolon);
@@ -141,8 +140,7 @@ mixin PieceFactory implements CommentWriter {
     Piece? returnTypePiece;
     if (returnType != null) {
       visit(returnType);
-      returnTypePiece = writer.pop();
-      writer.split();
+      returnTypePiece = pieces.split();
     }
 
     token(functionKeywordOrName);
@@ -152,8 +150,8 @@ mixin PieceFactory implements CommentWriter {
 
     // Allow splitting after the return type.
     if (returnTypePiece != null) {
-      var parametersPiece = writer.pop();
-      writer.push(FunctionTypePiece(returnTypePiece, parametersPiece));
+      var parametersPiece = pieces.pop();
+      pieces.push(FunctionTypePiece(returnTypePiece, parametersPiece));
     }
   }
 
@@ -166,12 +164,11 @@ mixin PieceFactory implements CommentWriter {
     // chain handled by a single [IfPiece].
     void traverse(IfStatement node) {
       token(node.ifKeyword);
-      writer.space();
+      space();
       token(node.leftParenthesis);
       visit(node.expression);
       token(node.rightParenthesis);
-      var condition = writer.pop();
-      writer.split();
+      var condition = pieces.split();
 
       // Edge case: When the then branch is a block and there is an else clause
       // after it, we want to force the block to split even if empty, like:
@@ -189,8 +186,7 @@ mixin PieceFactory implements CommentWriter {
         visit(node.thenStatement);
       }
 
-      var thenStatement = writer.pop();
-      writer.split();
+      var thenStatement = pieces.split();
       piece.add(condition, thenStatement, isBlock: node.thenStatement is Block);
 
       switch (node.elseStatement) {
@@ -198,26 +194,24 @@ mixin PieceFactory implements CommentWriter {
           // Hit an else-if, so flatten it into the chain with the `else`
           // becoming part of the next section's header.
           token(node.elseKeyword);
-          writer.space();
+          space();
           traverse(elseIf);
 
         case var elseStatement?:
           // Any other kind of else body ends the chain, with the header for
           // the last section just being the `else` keyword.
           token(node.elseKeyword);
-          var header = writer.pop();
-          writer.split();
+          var header = pieces.split();
 
           visit(elseStatement);
-          var statement = writer.pop();
-          writer.split();
+          var statement = pieces.pop();
           piece.add(header, statement, isBlock: elseStatement is Block);
       }
     }
 
     traverse(ifStatement);
 
-    writer.push(piece);
+    pieces.push(piece);
   }
 
   /// Creates an [ImportPiece] for an import or export directive.
@@ -225,17 +219,17 @@ mixin PieceFactory implements CommentWriter {
       {Token? deferredKeyword, Token? asKeyword, SimpleIdentifier? prefix}) {
     createDirectiveMetadata(directive);
     token(keyword);
-    writer.space();
+    space();
     visit(directive.uri);
-    var directivePiece = writer.pop();
+    var directivePiece = pieces.pop();
 
     Piece? configurationsPiece;
     if (directive.configurations.isNotEmpty) {
       var configurations = <Piece>[];
       for (var configuration in directive.configurations) {
-        writer.split();
+        pieces.split();
         visit(configuration);
-        configurations.add(writer.pop());
+        configurations.add(pieces.pop());
       }
 
       configurationsPiece = PostfixPiece(configurations);
@@ -243,29 +237,29 @@ mixin PieceFactory implements CommentWriter {
 
     Piece? asClause;
     if (asKeyword != null) {
-      writer.split();
-      token(deferredKeyword, after: writer.space);
+      pieces.split();
+      token(deferredKeyword, after: space);
       token(asKeyword);
-      writer.space();
+      space();
       visit(prefix);
-      asClause = PostfixPiece([writer.pop()]);
+      asClause = PostfixPiece([pieces.pop()]);
     }
 
     var combinators = <ImportCombinator>[];
     for (var combinatorNode in directive.combinators) {
-      writer.split();
+      pieces.split();
       token(combinatorNode.keyword);
-      var combinator = ImportCombinator(writer.pop());
+      var combinator = ImportCombinator(pieces.pop());
       combinators.add(combinator);
 
       switch (combinatorNode) {
         case HideCombinator(hiddenNames: var names):
         case ShowCombinator(shownNames: var names):
           for (var name in names) {
-            writer.split();
+            pieces.split();
             token(name.token);
             commaAfter(name);
-            combinator.names.add(writer.pop());
+            combinator.names.add(pieces.pop());
           }
         default:
           throw StateError('Unknown combinator type $combinatorNode.');
@@ -274,7 +268,7 @@ mixin PieceFactory implements CommentWriter {
 
     token(directive.semicolon);
 
-    writer.push(ImportPiece(
+    pieces.push(ImportPiece(
         directivePiece, configurationsPiece, asClause, combinators));
   }
 
@@ -289,24 +283,24 @@ mixin PieceFactory implements CommentWriter {
   void createInfix(AstNode left, Token operator, AstNode right,
       {bool hanging = false, Token? operator2}) {
     var operands = <Piece>[];
+
     visit(left);
-    operands.add(writer.pop());
 
     if (hanging) {
-      writer.space();
+      space();
       token(operator);
       token(operator2);
-      writer.split();
+      operands.add(pieces.split());
     } else {
-      writer.split();
+      operands.add(pieces.split());
       token(operator);
       token(operator2);
-      writer.space();
+      space();
     }
 
     visit(right);
-    operands.add(writer.pop());
-    writer.push(InfixPiece(operands));
+    operands.add(pieces.pop());
+    pieces.push(InfixPiece(operands));
   }
 
   /// Creates a chained infix operation: a binary operator expression, or
@@ -330,30 +324,28 @@ mixin PieceFactory implements CommentWriter {
     var operands = <Piece>[];
 
     void traverse(AstNode e) {
-      if (e is! T) {
-        visit(e);
-        operands.add(writer.pop());
-      } else {
+      // If the node is one if our infix operators, then recurse into the
+      // operands.
+      if (e is T) {
         var (left, operator, right) = destructure(e);
-        if (precedence != null && operator.type.precedence != precedence) {
-          // Binary node, but a different precedence, so don't flatten.
-          visit(e);
-          operands.add(writer.pop());
-        } else {
+        if (precedence == null || operator.type.precedence == precedence) {
           traverse(left);
-
-          writer.space();
+          space();
           token(operator);
-
-          writer.split();
+          pieces.split();
           traverse(right);
+          return;
         }
       }
+
+      // Otherwise, just write the node itself.
+      visit(e);
+      operands.add(pieces.pop());
     }
 
     traverse(node);
 
-    writer.push(InfixPiece(operands));
+    pieces.push(InfixPiece(operands));
   }
 
   /// Creates a [ListPiece] for the given bracket-delimited set of elements.
@@ -365,7 +357,7 @@ mixin PieceFactory implements CommentWriter {
     if (leftBracket != null) builder.leftBracket(leftBracket);
     elements.forEach(builder.visit);
     if (rightBracket != null) builder.rightBracket(rightBracket);
-    writer.push(builder.build());
+    pieces.push(builder.build());
   }
 
   /// Visits the `switch (expr)` part of a switch statement or expression.
@@ -378,13 +370,13 @@ mixin PieceFactory implements CommentWriter {
 
     // Attach the `switch ` as part of the `(`.
     token(switchKeyword);
-    writer.space();
+    space();
 
     builder.leftBracket(leftParenthesis);
     builder.visit(value);
     builder.rightBracket(rightParenthesis);
 
-    writer.push(builder.build());
+    pieces.push(builder.build());
   }
 
   /// Creates a [ListPiece] for a type argument or type parameter list.
@@ -419,15 +411,14 @@ mixin PieceFactory implements CommentWriter {
   /// This method assumes the code to the left of the `=` or `:` has already
   /// been visited.
   void finishAssignment(Token operator, Expression rightHandSide) {
-    if (operator.type == TokenType.EQ) writer.space();
+    if (operator.type == TokenType.EQ) space();
     token(operator);
-    var target = writer.pop();
-    writer.split();
+    var target = pieces.split();
 
     visit(rightHandSide);
 
-    var initializer = writer.pop();
-    writer.push(AssignPiece(target, initializer,
+    var initializer = pieces.pop();
+    pieces.push(AssignPiece(target, initializer,
         isValueDelimited: rightHandSide.isDelimited));
   }
 
@@ -435,8 +426,7 @@ mixin PieceFactory implements CommentWriter {
   /// subclass's initializer clause has been written.
   void finishForParts(ForParts forLoopParts, DelimitedListBuilder partsList) {
     token(forLoopParts.leftSeparator);
-    writer.split();
-    partsList.add(writer.pop());
+    partsList.add(pieces.split());
 
     // The condition clause.
     if (forLoopParts.condition case var conditionExpression?) {
@@ -447,21 +437,25 @@ mixin PieceFactory implements CommentWriter {
     }
 
     token(forLoopParts.rightSeparator);
-    writer.split();
-    partsList.add(writer.pop());
+    partsList.add(pieces.split());
 
     // The update clauses.
     if (forLoopParts.updaters.isNotEmpty) {
       partsList.addCommentsBefore(forLoopParts.updaters.first.beginToken);
       createList(forLoopParts.updaters,
           style: const ListStyle(commas: Commas.nonTrailing));
-      partsList.add(writer.pop());
+      partsList.add(pieces.split());
     }
   }
 
   /// Writes an optional modifier that precedes other code.
   void modifier(Token? keyword) {
-    token(keyword, after: writer.space);
+    token(keyword, after: space);
+  }
+
+  /// Write a single space.
+  void space() {
+    pieces.writeSpace();
   }
 
   /// Emit [token], along with any comments and formatted whitespace that comes
@@ -483,7 +477,7 @@ mixin PieceFactory implements CommentWriter {
   /// Writes the raw [lexeme] to the current text piece.
   void writeLexeme(String lexeme) {
     // TODO(tall): Preserve selection.
-    writer.write(lexeme);
+    pieces.write(lexeme);
   }
 
   /// Writes a comma after [node], if there is one.

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -71,9 +71,9 @@ mixin PieceFactory implements CommentWriter {
     sequence.addCommentsBefore(block.rightBracket);
 
     token(block.rightBracket);
-    var rightBracketPiece = pieces.pop();
+    var rightBracketPiece = pieces.take();
 
-    pieces.push(BlockPiece(
+    pieces.give(BlockPiece(
         leftBracketPiece, sequence.build(), rightBracketPiece,
         alwaysSplit: forceSplit || block.statements.isNotEmpty));
   }
@@ -150,8 +150,8 @@ mixin PieceFactory implements CommentWriter {
 
     // Allow splitting after the return type.
     if (returnTypePiece != null) {
-      var parametersPiece = pieces.pop();
-      pieces.push(FunctionTypePiece(returnTypePiece, parametersPiece));
+      var parametersPiece = pieces.take();
+      pieces.give(FunctionTypePiece(returnTypePiece, parametersPiece));
     }
   }
 
@@ -204,14 +204,14 @@ mixin PieceFactory implements CommentWriter {
           var header = pieces.split();
 
           visit(elseStatement);
-          var statement = pieces.pop();
+          var statement = pieces.take();
           piece.add(header, statement, isBlock: elseStatement is Block);
       }
     }
 
     traverse(ifStatement);
 
-    pieces.push(piece);
+    pieces.give(piece);
   }
 
   /// Creates an [ImportPiece] for an import or export directive.
@@ -221,7 +221,7 @@ mixin PieceFactory implements CommentWriter {
     token(keyword);
     space();
     visit(directive.uri);
-    var directivePiece = pieces.pop();
+    var directivePiece = pieces.take();
 
     Piece? configurationsPiece;
     if (directive.configurations.isNotEmpty) {
@@ -229,7 +229,7 @@ mixin PieceFactory implements CommentWriter {
       for (var configuration in directive.configurations) {
         pieces.split();
         visit(configuration);
-        configurations.add(pieces.pop());
+        configurations.add(pieces.take());
       }
 
       configurationsPiece = PostfixPiece(configurations);
@@ -242,14 +242,14 @@ mixin PieceFactory implements CommentWriter {
       token(asKeyword);
       space();
       visit(prefix);
-      asClause = PostfixPiece([pieces.pop()]);
+      asClause = PostfixPiece([pieces.take()]);
     }
 
     var combinators = <ImportCombinator>[];
     for (var combinatorNode in directive.combinators) {
       pieces.split();
       token(combinatorNode.keyword);
-      var combinator = ImportCombinator(pieces.pop());
+      var combinator = ImportCombinator(pieces.take());
       combinators.add(combinator);
 
       switch (combinatorNode) {
@@ -259,7 +259,7 @@ mixin PieceFactory implements CommentWriter {
             pieces.split();
             token(name.token);
             commaAfter(name);
-            combinator.names.add(pieces.pop());
+            combinator.names.add(pieces.take());
           }
         default:
           throw StateError('Unknown combinator type $combinatorNode.');
@@ -268,7 +268,7 @@ mixin PieceFactory implements CommentWriter {
 
     token(directive.semicolon);
 
-    pieces.push(ImportPiece(
+    pieces.give(ImportPiece(
         directivePiece, configurationsPiece, asClause, combinators));
   }
 
@@ -299,8 +299,8 @@ mixin PieceFactory implements CommentWriter {
     }
 
     visit(right);
-    operands.add(pieces.pop());
-    pieces.push(InfixPiece(operands));
+    operands.add(pieces.take());
+    pieces.give(InfixPiece(operands));
   }
 
   /// Creates a chained infix operation: a binary operator expression, or
@@ -340,12 +340,12 @@ mixin PieceFactory implements CommentWriter {
 
       // Otherwise, just write the node itself.
       visit(e);
-      operands.add(pieces.pop());
+      operands.add(pieces.take());
     }
 
     traverse(node);
 
-    pieces.push(InfixPiece(operands));
+    pieces.give(InfixPiece(operands));
   }
 
   /// Creates a [ListPiece] for the given bracket-delimited set of elements.
@@ -357,7 +357,7 @@ mixin PieceFactory implements CommentWriter {
     if (leftBracket != null) builder.leftBracket(leftBracket);
     elements.forEach(builder.visit);
     if (rightBracket != null) builder.rightBracket(rightBracket);
-    pieces.push(builder.build());
+    pieces.give(builder.build());
   }
 
   /// Visits the `switch (expr)` part of a switch statement or expression.
@@ -376,7 +376,7 @@ mixin PieceFactory implements CommentWriter {
     builder.visit(value);
     builder.rightBracket(rightParenthesis);
 
-    pieces.push(builder.build());
+    pieces.give(builder.build());
   }
 
   /// Creates a [ListPiece] for a type argument or type parameter list.
@@ -417,8 +417,8 @@ mixin PieceFactory implements CommentWriter {
 
     visit(rightHandSide);
 
-    var initializer = pieces.pop();
-    pieces.push(AssignPiece(target, initializer,
+    var initializer = pieces.take();
+    pieces.give(AssignPiece(target, initializer,
         isValueDelimited: rightHandSide.isDelimited));
   }
 

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -37,14 +37,75 @@ import 'comment_writer.dart';
 /// ```
 ///
 /// Note how the infix operator is attached to the preceding piece (which
-/// happens to just be text but could be a more complex piece if the left
-/// operand was a nested expression). Notice also that there is no piece for
-/// the expression statement and instead, the `;` is just appended to the last
-/// piece which is conceptually deeply nested inside the binary expression.
+/// happens to just be an identifier but could be a more complex piece if the
+/// left operand was a nested expression). Notice also that there is no piece
+/// for the expression statement and instead, the `;` is just appended to the
+/// trailing TextPiece which may be deeply nested inside the binary expression.
 ///
 /// This class implements the "slippage" between these two representations. It
 /// has mutable state to allow incrementally building up pieces while traversing
 /// the source AST nodes.
+///
+/// To visit an AST node and translate it to pieces, call [token()] and
+/// [visit()] to process the individual tokens and subnodes of the current
+/// node. Those will ultimately bottom out on calls to [write()], which appends
+/// literal text to the current [TextPiece] being written.
+///
+/// Those [TextPiece]s are aggregated into a tree of composite pieces which
+/// break the code into separate sections for line splitting. The main API for
+/// composing those pieces is [split()], [push()], and [pop()].
+///
+/// Here is a simplified example of how they work:
+///
+/// ```
+/// visitIfStatement(IfStatement node) {
+///   // No split() here. The caller may have code they want to prepend to the
+///   // first piece in this one.
+///   visit(node.condition);
+///
+///   // Call split() because we may want to split between the condition and
+///   // then branches and we know there will be a then branch.
+///   var conditionPiece = pieces.split();
+///
+///   visit(node.thenBranch);
+///   // Call pop() instead of split() because there may not be an else branch.
+///   // If there isn't, then the thenBranch will be the trailing piece created
+///   // by this function and we want to allow the caller to append to its
+///   // innermost TextPiece.
+///   var thenPiece = pieces.pop();
+///
+///   Piece? elsePiece;
+///   if (node.elseBranch case var elseBranch?) {
+///     // Call split() here because it turns out we do have something after
+///     // the thenPiece and we want to be able to split between the then and
+///     // else parts.
+///     pieces.split();
+///     visit(elseBranch);
+///
+///     // Use pop() to capture the else branch while allowing the caller to
+///     // append more code to it.
+///     elsePiece = pieces.pop();
+///   }
+///
+///   // Create a new aggregate piece out of the subpieces and allow the caller
+///   // to get it.
+///   pieces.push(IfPiece(conditionPiece, thenPiece, elsePiece));
+/// }
+/// ```
+///
+/// The basic rules are:
+///
+/// -   Use [split()] to insert a point where a line break can occur and
+///     capture the piece for the code you've just written. You'll usually call
+///     this when you have already traversed some part of an AST node and have
+///     more to traverse after it.
+///
+/// -   Use [pop()] to capture the current piece while allowing further code to
+///     be appended to it. You'll usually call this to grab the last part of an
+///     AST node where there is no more subsequent code.
+///
+/// -   Use [push()] to return the newly created aggregate piece so that the
+///     caller can capture it with a later call to [split()] or [pop()].
 class PieceWriter {
   final DartFormatter _formatter;
 
@@ -57,10 +118,6 @@ class PieceWriter {
 
   /// The most recently pushed piece, waiting to be taken by some surrounding
   /// piece.
-  ///
-  /// Since we traverse the AST in syntax order and pop built pieces on the way
-  /// back up, the "stack" of completed pieces is only ever one deep at the
-  /// most, so we model it with just a single field.
   Piece? _pushed;
 
   /// Whether we should write a space before the next text that is written.
@@ -76,19 +133,31 @@ class PieceWriter {
   PieceWriter(this._formatter, this._source);
 
   /// Gives the builder a newly completed [piece], to be taken by a later call
-  /// to [pop] from some surrounding piece.
+  /// to [pop()] or [split()] from some surrounding piece.
   void push(Piece piece) {
     // Should never push more than one piece.
     assert(_pushed == null);
-
     _pushed = piece;
   }
 
-  /// Captures the most recently created complete [Piece].
+  /// Yields the most recent piece.
   ///
-  /// If the most recent operation was [push], then this returns the piece given
-  /// by that call. Otherwise, returns the piece created by the preceding calls
-  /// to [write] since the last split.
+  /// If a completed piece was added through a call to [push()], then returns
+  /// that piece. A pushed piece will only be returned once from either a call
+  /// to [pop()] or [split()].
+  ///
+  /// If there is no pushed piece to return, returns the most recently created
+  /// [TextPiece]. In this case, it still allows more text to be written to
+  /// that piece. For example, in:
+  ///
+  /// ```
+  /// a + b;
+  /// ```
+  ///
+  /// The code for the infix expression will call [pop()] to capture the second
+  /// `b` operand. Then the surrounding code for the expression statement will
+  /// call [token()] for the `;`, which will correctly append it to the
+  /// [TextPiece] for `b`.
   Piece pop() {
     if (_pushed case var piece?) {
       _pushed = null;
@@ -98,33 +167,38 @@ class PieceWriter {
     return _currentText!;
   }
 
-  /// Ends the current text piece and (lazily) begins a new one.
+  /// Pops the previous piece and begins a new one.
   ///
-  /// The previous text piece should already be taken.
-  void split() {
+  /// Any text written after this will go into a new [TextPiece] instead of
+  /// being appended to the end of the popped one. Call this wherever a line
+  /// break may be inserted by a piece during line splitting.
+  Piece split() {
     _pendingSplit = true;
-  }
-
-  /// Writes a space to the current [TextPiece].
-  void space() {
-    _pendingSpace = true;
+    return pop();
   }
 
   /// Writes [text] raw text to the current innermost [TextPiece]. Starts a new
   /// one if needed.
-  ///
-  /// If [hanging] is `true`, then [text] is appended to the current line even
-  /// if a split is pending. This is used for writing a comment that should be
-  /// on the end of a line.
-  ///
-  /// If [text] internally contains a newline, then [containsNewline] should
-  /// be `true`.
   void write(String text) {
     _write(text);
   }
 
+  /// Writes a space to the current [TextPiece].
+  void writeSpace() {
+    _pendingSpace = true;
+  }
+
+  /// Writes a mandatory newline from a comment to the current [TextPiece].
+  void writeNewline() {
+    _pendingNewline = true;
+  }
+
   /// Write the contents of [comment] to the current innnermost [TextPiece],
   /// handling any newlines that may appear in it.
+  ///
+  /// If [hanging] is `true`, then the comment is appended to the current line
+  /// even if call to [split()] has just happened. This is used for writing a
+  /// comment that should be on the end of a line.
   void writeComment(SourceComment comment, {bool hanging = false}) {
     _write(comment.text,
         containsNewline: comment.containsNewline, hanging: hanging);
@@ -150,11 +224,6 @@ class PieceWriter {
     _pendingSpace = false;
     _pendingNewline = false;
     if (!hanging) _pendingSplit = false;
-  }
-
-  /// Writes a mandatory newline from a comment to the current [TextPiece].
-  void writeNewline() {
-    _pendingNewline = true;
   }
 
   /// Finishes writing and returns a [SourceCode] containing the final output

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -167,7 +167,7 @@ class PieceWriter {
     return _currentText!;
   }
 
-  /// Pops the previous piece and begins a new one.
+  /// Pops the most recent piece and begins a new one.
   ///
   /// Any text written after this will go into a new [TextPiece] instead of
   /// being appended to the end of the popped one. Call this wherever a line

--- a/lib/src/front_end/sequence_builder.dart
+++ b/lib/src/front_end/sequence_builder.dart
@@ -58,8 +58,7 @@ class SequenceBuilder {
 
     addCommentsBefore(token);
     _visitor.visit(node);
-    add(_visitor.writer.pop(), indent: indent);
-    _visitor.writer.split();
+    add(_visitor.pieces.split(), indent: indent);
   }
 
   /// Appends a blank line before the next piece in the sequence.
@@ -96,20 +95,19 @@ class SequenceBuilder {
       var comment = comments[i];
       if (_elements.isNotEmpty && comments.isHanging(i)) {
         // Attach the comment to the previous token.
-        _visitor.writer.space();
+        _visitor.space();
 
-        _visitor.writer.writeComment(comment, hanging: true);
+        _visitor.pieces.writeComment(comment, hanging: true);
       } else {
         // Write the comment as its own sequence piece.
-        _visitor.writer.writeComment(comment);
+        _visitor.pieces.writeComment(comment);
         if (comments.linesBefore(i) > 1) {
           // Always preserve a blank line above sequence-level comments.
           _allowBlank = true;
           addBlank();
         }
 
-        add(_visitor.writer.pop());
-        _visitor.writer.split();
+        add(_visitor.pieces.split());
       }
     }
 


### PR DESCRIPTION
The current API is pretty confusing around when you should use `pop()`, `split()`, or both. If you get it wrong, sometimes it silently works but may leave a bug for later, or sometimes it fails it seemingly unrelated ways. Also, it's not clear whether you should call `pop()` first or `split()`. (It actually didn't matter.)

I tried to simplify the API some. It's still more subtle and brittle than I would like, but it's not clear to me if the complexity is essential. I'm trying to build Piece trees that don't have unnecessary nodes, so some slippage between AST node boundaries and Piece tree boundaries is essential.

I hope this API is better. The changes are:

- Make `split()` implicitly `pop()` the previous piece. This means you never need to call both `split()` and `pop()`. Just call `split()`. You do still have to know when to prefer `pop()` instead of `split()`, but I added some documentation to try to clarify that.

- Rename the main PieceWriter field from `writer` to `pieces`. I think this reads a little better at the callsites and makes it clearer what is being pushed, popped, and split. "Writer" doesn't really mean much.

- Rename `space()` to `writeSpace()`. Then add a helper method in PieceFactory called `space()`. This way, almost all calls on `pieces` deal with pieces and calls that recurse into or write pieces of an AST are bare function calls: `token()`, `visit()`, and `space()`.
