### PR TITLE
Update test running code in example script.

### DIFF
--- a/example/format.dart
+++ b/example/format.dart
@@ -1,15 +1,10 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-library dart_style.example.format;
-
-import 'dart:io';
-import 'dart:mirrors';
-
 import 'package:dart_style/dart_style.dart';
 import 'package:dart_style/src/constants.dart';
 import 'package:dart_style/src/debug.dart' as debug;
-import 'package:path/path.dart' as p;
+import 'package:dart_style/src/testing/test_file.dart';
 
 void main(List<String> args) {
   // Enable debugging so you can see some of the formatter's internal state.
@@ -21,7 +16,7 @@ void main(List<String> args) {
   debug.tracePieceBuilder = true;
   debug.traceSolver = true;
 
-  formatUnit("import 'a.dart';", tall: true);
+  runTest('selection/selection.stmt', 2);
 }
 
 void formatStmt(String source, {required bool tall, int pageWidth = 80}) {
@@ -62,105 +57,40 @@ void drawRuler(String label, int width) {
 
 /// Runs the formatter test starting on [line] at [path] inside the "test"
 /// directory.
-void runTest(String path, int line) {
-  var indentPattern = RegExp(r'^\(indent (\d+)\)\s*');
+Future<void> runTest(String path, int line,
+    {int pageWidth = 40, bool tall = true}) async {
+  var testFile = await TestFile.read(path);
+  var formatTest = testFile.tests.firstWhere((test) => test.line == line);
 
-  // Locate the "test" directory. Use mirrors so that this works with the test
-  // package, which loads this suite into an isolate.
-  var testDir = p.join(
-      p.dirname(currentMirrorSystem()
-          .findLibrary(#dart_style.example.format)
-          .uri
-          .path),
-      '../test');
+  var formatter = DartFormatter(
+      pageWidth: testFile.pageWidth,
+      indent: formatTest.leadingIndent,
+      fixes: formatTest.fixes,
+      experimentFlags: tall
+          ? const ['inline-class', tallStyleExperimentFlag]
+          : const ['inline-class']);
 
-  var lines = File(p.join(testDir, path)).readAsLinesSync();
+  var actual = formatter.formatSource(formatTest.input);
 
-  // The first line may have a "|" to indicate the page width.
-  var pageWidth = 80;
-  if (lines[0].endsWith('|')) {
-    pageWidth = lines[0].indexOf('|');
-    lines = lines.skip(1).toList();
+  // The test files always put a newline at the end of the expectation.
+  // Statements from the formatter (correctly) don't have that, so add
+  // one to line up with the expected result.
+  var actualText = actual.textWithSelectionMarkers;
+  if (!testFile.isCompilationUnit) actualText += '\n';
+
+  var expectedText = formatTest.output.textWithSelectionMarkers;
+
+  print('$path ${formatTest.description}');
+  drawRuler('before', pageWidth);
+  print(formatTest.input.textWithSelectionMarkers);
+  if (actualText == expectedText) {
+    drawRuler('result', pageWidth);
+    print(actualText);
+  } else {
+    print('FAIL');
+    drawRuler('expected', pageWidth);
+    print(expectedText);
+    drawRuler('actual', pageWidth);
+    print(actualText);
   }
-
-  var i = 0;
-  while (i < lines.length) {
-    var description = lines[i++].replaceAll('>>>', '').trim();
-
-    // Let the test specify a leading indentation. This is handy for
-    // regression tests which often come from a chunk of nested code.
-    var leadingIndent = 0;
-    var indentMatch = indentPattern.firstMatch(description);
-    if (indentMatch != null) {
-      leadingIndent = int.parse(indentMatch[1]!);
-      description = description.substring(indentMatch.end);
-    }
-
-    if (description == '') {
-      description = 'line ${i + 1}';
-    } else {
-      description = 'line ${i + 1}: $description';
-    }
-    var startLine = i + 1;
-
-    var input = '';
-    while (!lines[i].startsWith('<<<')) {
-      input += '${lines[i++]}\n';
-    }
-
-    var expectedOutput = '';
-    while (++i < lines.length && !lines[i].startsWith('>>>')) {
-      expectedOutput += '${lines[i]}\n';
-    }
-
-    if (line != startLine) continue;
-
-    var isCompilationUnit = p.extension(path) == '.unit';
-
-    var inputCode =
-        _extractSelection(input, isCompilationUnit: isCompilationUnit);
-
-    var expected =
-        _extractSelection(expectedOutput, isCompilationUnit: isCompilationUnit);
-
-    var formatter = DartFormatter(pageWidth: pageWidth, indent: leadingIndent);
-
-    var actual = formatter.formatSource(inputCode);
-
-    // The test files always put a newline at the end of the expectation.
-    // Statements from the formatter (correctly) don't have that, so add
-    // one to line up with the expected result.
-    var actualText = actual.text;
-    if (!isCompilationUnit) actualText += '\n';
-
-    print('$path $description');
-    drawRuler('before', pageWidth);
-    print(input);
-    if (actualText == expected.text) {
-      drawRuler('result', pageWidth);
-      print(actualText);
-    } else {
-      print('FAIL');
-      drawRuler('expected', pageWidth);
-      print(expected.text);
-      drawRuler('actual', pageWidth);
-      print(actualText);
-    }
-  }
-}
-
-/// Given a source string that contains ‹ and › to indicate a selection, returns
-/// a [SourceCode] with the text (with the selection markers removed) and the
-/// correct selection range.
-SourceCode _extractSelection(String source, {bool isCompilationUnit = false}) {
-  var start = source.indexOf('‹');
-  source = source.replaceAll('‹', '');
-
-  var end = source.indexOf('›');
-  source = source.replaceAll('›', '');
-
-  return SourceCode(source,
-      isCompilationUnit: isCompilationUnit,
-      selectionStart: start == -1 ? null : start,
-      selectionLength: end == -1 ? null : end - start);
 }

--- a/lib/src/testing/test_file.dart
+++ b/lib/src/testing/test_file.dart
@@ -169,6 +169,17 @@ class FormatTest {
   }
 }
 
+extension SourceCodeExtensions on SourceCode {
+  /// If the source code has a selection, returns its text with `‹` and `›`
+  /// inserted at the selection begin and end points.
+  ///
+  /// Otherwise, returns the code as-is.
+  String get textWithSelectionMarkers {
+    if (selectionStart == null) return text;
+    return '$textBeforeSelection‹$selectedText›$textAfterSelection';
+  }
+}
+
 /// Given a source string that contains ‹ and › to indicate a selection, returns
 /// a [SourceCode] with the text (with the selection markers removed) and the
 /// correct selection range.


### PR DESCRIPTION
The example script in example/format.dart has long been my sandbox script for debugging the formatter. One thing it has is a little helper function to run one of the format tests.

That helper code was copy/pasted from an ancient version of the test running code. Cleaned it up here to actually use the TestFile class now that there is some abstraction for running tests.

Also added support to example/format.dart to handle selections in tests.

(I'm starting to work on handling selections in the new formatter.)
