### PR TITLE
Format record literals.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -115,7 +115,7 @@ extension ExpressionExtensions on Expression {
         MethodInvocation() => true,
         SetOrMapLiteral() => true,
         SwitchExpression() => true,
-        // TODO(tall): Record literals.
+        RecordLiteral() => true,
         // TODO(tall): Instance creation expressions (`new` and `const`).
         _ => false,
       };

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -113,9 +113,9 @@ extension ExpressionExtensions on Expression {
         ParenthesizedExpression(:var expression) => expression.isDelimited,
         ListLiteral() => true,
         MethodInvocation() => true,
+        RecordLiteral() => true,
         SetOrMapLiteral() => true,
         SwitchExpression() => true,
-        RecordLiteral() => true,
         // TODO(tall): Instance creation expressions (`new` and `const`).
         _ => false,
       };

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -664,10 +664,10 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
   void visitListLiteral(ListLiteral node) {
     createCollection(
       node.constKeyword,
+      typeArguments: node.typeArguments,
       node.leftBracket,
       node.elements,
       node.rightBracket,
-      typeArguments: node.typeArguments,
     );
   }
 
@@ -865,8 +865,9 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
   @override
   void visitRecordLiteral(RecordLiteral node) {
     ListStyle style;
-    if (node.fields.length == 1) {
-      // Single-element records always have a trailing comma.
+    if (node.fields.length == 1 && node.fields[0] is! NamedExpression) {
+      // Single-element records always have a trailing comma, unless the single
+      // element is a named field.
       style = const ListStyle(commas: Commas.alwaysTrailing);
     } else {
       style = const ListStyle(commas: Commas.trailing);
@@ -943,10 +944,10 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
   void visitSetOrMapLiteral(SetOrMapLiteral node) {
     createCollection(
       node.constKeyword,
+      typeArguments: node.typeArguments,
       node.leftBracket,
       node.elements,
       node.rightBracket,
-      typeArguments: node.typeArguments,
     );
   }
 

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -662,7 +662,13 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitListLiteral(ListLiteral node) {
-    createCollection(node, node.leftBracket, node.elements, node.rightBracket);
+    createCollection(
+      node.constKeyword,
+      node.leftBracket,
+      node.elements,
+      node.rightBracket,
+      typeArguments: node.typeArguments,
+    );
   }
 
   @override
@@ -858,7 +864,20 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitRecordLiteral(RecordLiteral node) {
-    throw UnimplementedError();
+    ListStyle style;
+    if (node.fields.length == 1) {
+      // Single-element records always have a trailing comma.
+      style = const ListStyle(commas: Commas.alwaysTrailing);
+    } else {
+      style = const ListStyle(commas: Commas.trailing);
+    }
+    createCollection(
+      node.constKeyword,
+      node.leftParenthesis,
+      node.fields,
+      node.rightParenthesis,
+      style: style,
+    );
   }
 
   @override
@@ -922,7 +941,13 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitSetOrMapLiteral(SetOrMapLiteral node) {
-    createCollection(node, node.leftBracket, node.elements, node.rightBracket);
+    createCollection(
+      node.constKeyword,
+      node.leftBracket,
+      node.elements,
+      node.rightBracket,
+      typeArguments: node.typeArguments,
+    );
   }
 
   @override

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -89,10 +89,11 @@ mixin PieceFactory implements CommentWriter {
   }
 
   /// Creates a [ListPiece] for a collection literal.
-  void createCollection(TypedLiteral literal, Token leftBracket,
-      List<AstNode> elements, Token rightBracket) {
-    modifier(literal.constKeyword);
-    visit(literal.typeArguments);
+  void createCollection(Token? constKeyword, Token leftBracket,
+      List<AstNode> elements, Token rightBracket,
+      {TypeArgumentList? typeArguments, ListStyle style = const ListStyle()}) {
+    modifier(constKeyword);
+    visit(typeArguments);
 
     // TODO(tall): Support a line comment inside a collection literal as a
     // signal to preserve internal newlines. So if you have:
@@ -107,7 +108,12 @@ mixin PieceFactory implements CommentWriter {
     // The formatter will preserve the newline after element 3 and the lack of
     // them after the other elements.
 
-    createList(leftBracket: leftBracket, elements, rightBracket: rightBracket);
+    createList(
+      leftBracket: leftBracket,
+      elements,
+      rightBracket: rightBracket,
+      style: style,
+    );
   }
 
   /// Creates metadata annotations for a directive.

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -80,6 +80,8 @@ class ListPiece extends Piece {
     for (var i = 0; i < _elements.length; i++) {
       var isLast = i == _elements.length - 1;
       var appendComma = switch (_style.commas) {
+        // Has a comma after every element.
+        Commas.alwaysTrailing => true,
         // Trailing comma after the last element if split but not otherwise.
         Commas.trailing => !(state == State.unsplit && isLast),
         // Never a trailing comma after the last element.
@@ -209,11 +211,14 @@ final class ListElement {
 
 /// Where commas should be added in a [ListPiece].
 enum Commas {
+  /// Add a comma after every element, regardless of whether or not it is split.
+  alwaysTrailing,
+
   /// Add a comma after every element when the elements split, including the
   /// last. When not split, omit the trailing comma.
   trailing,
 
-  /// Add a comme after every element except for the last, regardless of whether
+  /// Add a comma after every element except for the last, regardless of whether
   /// or not it is split.
   nonTrailing,
 

--- a/test/expression/record.stmt
+++ b/test/expression/record.stmt
@@ -1,0 +1,183 @@
+40 columns                              |
+>>> Empty record.
+var record = (   );
+<<<
+var record = ();
+>>> Single-element records don't split after ",".
+var record = (   value  ,  );
+<<<
+var record = (value,);
+>>> Multi-element record.
+var record = (   first  ,  second  ,  third  );
+<<<
+var record = (first, second, third);
+>>> Named record fields.
+var record = (   first  :  1  ,  2 ,  third : 3 );
+<<<
+var record = (first: 1, 2, third: 3);
+>>> Const record.
+var record = const   (  1 ,   2 );
+<<<
+var record = const (1, 2);
+>>> Empty records don't split.
+var longVariableName_______________ = ();
+<<<
+var longVariableName_______________ =
+    ();
+>>> Single-element record.
+var record = (veryLongRecordField________________,);
+<<<
+var record = (
+  veryLongRecordField________________,
+);
+>>> Single-element named record.
+var record = (longFieldName: longRecordFieldValue);
+<<<
+var record = (
+  longFieldName: longRecordFieldValue,
+);
+>>> Single-element named record splits at name.
+var record = (longFieldName: veryLongRecordFieldValue);
+<<<
+var record = (
+  longFieldName:
+      veryLongRecordFieldValue,
+);
+>>> Exactly 40 characters.
+(first, second, third, fourth, seventh);
+<<<
+(first, second, third, fourth, seventh);
+>>> Split with multiple elements.
+(first, second, third, fourth, fifth, sixth);
+<<<
+(
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+  sixth,
+);
+>>> Don't force outer record to split.
+((first,), (second, third));
+<<<
+((first,), (second, third));
+>>> Don't force outer list to split.
+[(first,), (second, third)];
+<<<
+[(first,), (second, third)];
+>>> inner list doesn't force split
+([first], [second, third]);
+<<<
+([first], [second, third]);
+>>> Nested split record.
+(first, (second, third, fourth), fifth, (sixth, seventh, eighth, nine, tenth,
+    eleventh));
+<<<
+(
+  first,
+  (second, third, fourth),
+  fifth,
+  (
+    sixth,
+    seventh,
+    eighth,
+    nine,
+    tenth,
+    eleventh,
+  ),
+);
+>>> Trailing comma in single-element does not split.
+(1,);
+<<<
+(1,);
+>>> Trailing comma in multi-element does force split.
+(1,2,);
+<<<
+(1, 2);
+>>> Ignore line comment after the "]".
+(
+  a,b,c,
+  d
+) // comment
+;
+<<<
+(a, b, c, d) // comment
+;
+>>> Preserve blank lines between comments and elements.
+(
+
+
+  element,
+
+
+
+  // comment
+  element,
+
+
+
+  element
+
+
+);
+<<<
+(
+  element,
+
+  // comment
+  element,
+  element,
+);
+>>> Format on one line in an argument list.
+longFunctionName((element, element), (element, element, element, element));
+<<<
+longFunctionName(
+  (element, element),
+  (element, element, element, element),
+);
+>>> Format like a block in an argument list.
+longFunctionName((element, element), (element, element, element, element, element));
+<<<
+longFunctionName(
+  (element, element),
+  (
+    element,
+    element,
+    element,
+    element,
+    element,
+  ),
+);
+>>> Format on one line in an argument list.
+longFunctionName((element, element, element, element));
+<<<
+longFunctionName(
+  (element, element, element, element),
+);
+>>> Don't allow splitting between field name and record.
+var record = (argument, argument, argument, recordFieldName: (veryLongElement__________,));
+<<<
+var record = (
+  argument,
+  argument,
+  argument,
+  recordFieldName: (
+    veryLongElement__________,
+  ),
+);
+>>> Don't allow splitting between argument name and record.
+longFunctionName(argument, argument, argument, argument, argument, argument,
+argumentName: (veryLongElement__________,));
+<<<
+longFunctionName(
+  argument,
+  argument,
+  argument,
+  argument,
+  argument,
+  argument,
+  argumentName: (
+    veryLongElement__________,
+  ),
+);

--- a/test/expression/record.stmt
+++ b/test/expression/record.stmt
@@ -11,6 +11,13 @@ var record = (value,);
 var record = (   first  ,  second  ,  third  );
 <<<
 var record = (first, second, third);
+>>> Remove trailing comma from record if unsplit
+var record = (
+  1,
+  2,
+);
+<<<
+var record = (1, 2);
 >>> Named record fields.
 var record = (   first  :  1  ,  2 ,  third : 3 );
 <<<
@@ -30,13 +37,21 @@ var record = (veryLongRecordField________________,);
 var record = (
   veryLongRecordField________________,
 );
->>> Single-element named record.
+>>> Single-element named record doesn't have comma added.
+var record = (a: b);
+<<<
+var record = (a: b);
+>>> Single-element named record with comma removed.
+var record = (a: b,);
+<<<
+var record = (a: b);
+>>> Long single-element named record that splits.
 var record = (longFieldName: longRecordFieldValue);
 <<<
 var record = (
   longFieldName: longRecordFieldValue,
 );
->>> Single-element named record splits at name.
+>>> Long single-element named record splits at name.
 var record = (longFieldName: veryLongRecordFieldValue);
 <<<
 var record = (
@@ -91,70 +106,6 @@ var record = (
 (1,);
 <<<
 (1,);
->>> Trailing comma in multi-element does force split.
-(1,2,);
-<<<
-(1, 2);
->>> Ignore line comment after the "]".
-(
-  a,b,c,
-  d
-) // comment
-;
-<<<
-(a, b, c, d) // comment
-;
->>> Preserve blank lines between comments and elements.
-(
-
-
-  element,
-
-
-
-  // comment
-  element,
-
-
-
-  element
-
-
-);
-<<<
-(
-  element,
-
-  // comment
-  element,
-  element,
-);
->>> Format on one line in an argument list.
-longFunctionName((element, element), (element, element, element, element));
-<<<
-longFunctionName(
-  (element, element),
-  (element, element, element, element),
-);
->>> Format like a block in an argument list.
-longFunctionName((element, element), (element, element, element, element, element));
-<<<
-longFunctionName(
-  (element, element),
-  (
-    element,
-    element,
-    element,
-    element,
-    element,
-  ),
-);
->>> Format on one line in an argument list.
-longFunctionName((element, element, element, element));
-<<<
-longFunctionName(
-  (element, element, element, element),
-);
 >>> Don't allow splitting between field name and record.
 var record = (argument, argument, argument, recordFieldName: (veryLongElement__________,));
 <<<
@@ -163,21 +114,6 @@ var record = (
   argument,
   argument,
   recordFieldName: (
-    veryLongElement__________,
-  ),
-);
->>> Don't allow splitting between argument name and record.
-longFunctionName(argument, argument, argument, argument, argument, argument,
-argumentName: (veryLongElement__________,));
-<<<
-longFunctionName(
-  argument,
-  argument,
-  argument,
-  argument,
-  argument,
-  argument,
-  argumentName: (
     veryLongElement__________,
   ),
 );

--- a/test/expression/record_comment.stmt
+++ b/test/expression/record_comment.stmt
@@ -1,0 +1,70 @@
+40 columns                              |
+>>> Empty record block comment.
+var record = (  /* comment */  );
+<<<
+var record = (/* comment */);
+>>> Empty record line comment.
+var record = (  // comment
+);
+<<<
+var record = (
+  // comment
+);
+>>> Single-element record block comment, after comma.
+var record = ( element , /* comment */  );
+<<<
+var record = (element /* comment */,);
+>>> Single-element record block comment, before comma.
+var record = ( element /* comment */ , );
+<<<
+var record = (element /* comment */,);
+>>> Long single-element record block comment, before comma.
+var record = ( element /* very long adhered to element */ , );
+<<<
+var record = (
+  element /* very long adhered to element */,
+);
+>>> Long single-element record block comment, after comma.
+var record = ( element, /* very long adhered to element */ );
+<<<
+var record = (
+  element /* very long adhered to element */,
+);
+>>> Single-element record line comment, before comma.
+var record = ( element , // comment
+);
+<<<
+var record = (
+  element, // comment
+);
+>>> Single-element record line comment, after comma.
+var record = ( element // comment
+,);
+<<<
+var record = (
+  element, // comment
+);
+>>> Multi-element record block comment, before comma.
+var record = ( 1 /* comment */ , 2  );
+<<<
+var record = (1 /* comment */, 2);
+>>> Multi-element record block comment, after comma.
+var record = ( 1 , /* comment */ 2  );
+<<<
+var record = (1, /* comment */ 2);
+>>> Multi-element record line comment, before comma.
+var record = ( 1 // comment
+, 2  );
+<<<
+var record = (
+  1, // comment
+  2,
+);
+>>> Multi-element record line comment, after comma.
+var record = ( 1, // comment
+2  );
+<<<
+var record = (
+  1, // comment
+  2,
+);

--- a/test/expression/record_comment.stmt
+++ b/test/expression/record_comment.stmt
@@ -68,3 +68,37 @@ var record = (
   1, // comment
   2,
 );
+>>> Ignore line comment after the ")".
+(
+  a,b,c,
+  d
+) // comment
+;
+<<<
+(a, b, c, d) // comment
+;
+>>> Preserve blank lines between comments and elements.
+(
+
+
+  element,
+
+
+
+  // comment
+  element,
+
+
+
+  element
+
+
+);
+<<<
+(
+  element,
+
+  // comment
+  element,
+  element,
+);


### PR DESCRIPTION
Essentially the same piece logic used for other iterables.

- The `TypeLiteral` in `createCollection` has been broken down into its components for record literal re-use.
- Added a new `Comma` style which essentially describes that we need to preserve the comma after each element, regardless of splitting or not.
- Basic record tests.