### PR TITLE
Format function declarations and expressions.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -110,9 +110,10 @@ extension ExpressionExtensions on Expression {
   /// ];
   /// ```
   bool get isDelimited => switch (this) {
-        ParenthesizedExpression(:var expression) => expression.isDelimited,
+        FunctionExpression() => true,
         ListLiteral() => true,
         MethodInvocation() => true,
+        ParenthesizedExpression(:var expression) => expression.isDelimited,
         SetOrMapLiteral() => true,
         SwitchExpression() => true,
         // TODO(tall): Record literals.

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -147,12 +147,9 @@ mixin PieceFactory implements CommentWriter {
     visit(typeParameters);
     visit(parameters);
     token(question);
+    var parametersPiece = pieces.take();
 
-    // Allow splitting after the return type.
-    if (returnTypePiece != null) {
-      var parametersPiece = pieces.take();
-      pieces.give(FunctionTypePiece(returnTypePiece, parametersPiece));
-    }
+    pieces.give(FunctionPiece(returnTypePiece, parametersPiece));
   }
 
   // TODO(tall): Generalize this to work with if elements too.
@@ -398,6 +395,14 @@ mixin PieceFactory implements CommentWriter {
     if (parameter.covariantKeyword != null) throw UnimplementedError();
   }
 
+  /// Handles the `async`, `sync*`, or `async*` modifiers on a function body.
+  void functionBodyModifiers(FunctionBody body) {
+    // The `async` or `sync` keyword.
+    token(body.keyword);
+    token(body.star);
+    if (body.keyword != null) space();
+  }
+
   /// Creates a [Piece] for some code followed by an `=` and an expression in
   /// any place where an `=` appears:
   ///
@@ -446,6 +451,29 @@ mixin PieceFactory implements CommentWriter {
           style: const ListStyle(commas: Commas.nonTrailing));
       partsList.add(pieces.split());
     }
+  }
+
+  /// Finishes writing a named function declaration or anonymous function
+  /// expression after the return type (if any) and name (if any) has been
+  /// written.
+  void finishFunction(Piece? returnType, FunctionExpression function) {
+    visit(function.typeParameters);
+    visit(function.parameters);
+
+    Piece parameters;
+    Piece? body;
+    if (function.body case EmptyFunctionBody body) {
+      // If the body is just `;`, then don't allow a space or split before the
+      // semicolon by making it part of the parameters piece.
+      token(body.semicolon);
+      parameters = pieces.split();
+    } else {
+      parameters = pieces.split();
+      visit(function.body);
+      body = pieces.take();
+    }
+
+    pieces.give(FunctionPiece(returnType, parameters, body));
   }
 
   /// Writes an optional modifier that precedes other code.

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -74,14 +74,33 @@ class AssignPiece extends Piece {
   //
   // ```
   // var value = operand +
-  //    operand +
-  //    operand;
+  //     operand +
+  //     operand;
   // ```
   //
   // For now, we do not implement this special case behavior. Once more of the
   // language is implemented in the new back end and we can run the formatter
   // on a large corpus of code, we can try it out and see if the special case
   // behavior is worth it.
+  //
+  // If we don't do that, consider at least not adding another level of
+  // indentation for subsequent operands in an infix operator chain. So prefer:
+  //
+  // ```
+  // var value =
+  //     operand +
+  //     operand +
+  //     operand;
+  // ```
+  //
+  // Over:
+  //
+  // ```
+  // var value =
+  //     operand +
+  //         operand +
+  //         operand;
+  // ```
 
   @override
   List<State> get additionalStates =>

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -78,7 +78,7 @@ class AssignPiece extends Piece {
   //    operand;
   // ```
   //
-  // For now, we not implement this special case behavior. Once more of the
+  // For now, we do not implement this special case behavior. Once more of the
   // language is implemented in the new back end and we can run the formatter
   // on a large corpus of code, we can try it out and see if the special case
   // behavior is worth it.

--- a/lib/src/piece/function.dart
+++ b/lib/src/piece/function.dart
@@ -4,42 +4,54 @@
 import '../back_end/code_writer.dart';
 import 'piece.dart';
 
-/// Piece for a function type or function-typed parameter.
+/// Piece for a function declaration, function type, or function-typed
+/// parameter.
 ///
-/// Handles splitting between the return type and the rest of the function type.
-class FunctionTypePiece extends Piece {
-  /// The return type annotation.
-  final Piece _returnType;
+/// Handles splitting between the return type and the rest of the function.
+class FunctionPiece extends Piece {
+  /// The return type annotation, if any.
+  final Piece? _returnType;
 
   /// The rest of the function type signature: name, type parameters,
   /// parameters, etc.
   final Piece _signature;
 
-  FunctionTypePiece(this._returnType, this._signature);
+  /// If this is a function declaration with a (non-empty `;`) body, the body.
+  final Piece? _body;
+
+  FunctionPiece(this._returnType, this._signature, [this._body]);
 
   @override
-  List<State> get additionalStates => const [State.split];
+  List<State> get additionalStates => [if (_returnType != null) State.split];
 
   @override
   void format(CodeWriter writer, State state) {
-    // A split inside the return type forces splitting after the return type.
-    writer.setAllowNewlines(state == State.split);
-    writer.format(_returnType);
+    if (_returnType case var returnType?) {
+      // A split inside the return type forces splitting after the return type.
+      writer.setAllowNewlines(state == State.split);
 
-    // A split in the type parameters or parameters does not force splitting
-    // after the return type.
-    writer.setAllowNewlines(true);
-    writer.splitIf(state == State.split);
+      writer.format(returnType);
+
+      // A split in the type parameters or parameters does not force splitting
+      // after the return type.
+      writer.setAllowNewlines(true);
+      writer.splitIf(state == State.split);
+    }
 
     writer.format(_signature);
+    if (_body case var body?) {
+      writer.space();
+      writer.format(body);
+    }
   }
 
   @override
   void forEachChild(void Function(Piece piece) callback) {
-    callback(_returnType);
+    if (_returnType case var returnType?) callback(returnType);
     callback(_signature);
+    if (_body case var body?) callback(body);
   }
 
   @override
-  String toString() => 'FnType';
+  String toString() => 'Fn';
 }

--- a/test/function/block_body.unit
+++ b/test/function/block_body.unit
@@ -1,0 +1,35 @@
+40 columns                              |
+>>> Empty block body.
+f  (  )  {  }
+<<<
+f() {}
+>>> Collapse empty body.
+void main() {    }
+<<<
+void main() {}
+>>>
+void main() {
+
+
+
+}
+<<<
+void main() {}
+>>> Non-empty block body.
+f  (  )  {  body  ;  }
+<<<
+f() {
+  body;
+}
+>>> Async.
+f  (  )  async  {  }
+<<<
+f() async {}
+>>> Sync*.
+f  (  )  sync  *  {  }
+<<<
+f() sync* {}
+>>> Async*.
+f  (  )  async  *  {  }
+<<<
+f() async* {}

--- a/test/function/default_value.unit
+++ b/test/function/default_value.unit
@@ -1,0 +1,48 @@
+40 columns                              |
+>>> Named parameter.
+f(  {  optional  =  null  }  ) {}
+<<<
+f({optional = null}) {}
+>>> Named parameter with old separator.
+### This syntax is no longer supported by new versions of Dart, but we want to
+### support formatting older versions if possible.
+f(  {  optional  :  1  +  2  }  ) {}
+<<<
+f({optional: 1 + 2}) {}
+>>> Optional positional parameter.
+f(  [  optional  =  1  +  2  ]  ) {}
+<<<
+f([optional = 1 + 2]) {}
+>>> Split on positional default.
+doStuff([parameter = veryLongDefaultValueThatSplits, another =
+veryLongDefaultValue, third = alsoQuiteLongDefaultValue]) {}
+<<<
+doStuff([
+  parameter =
+      veryLongDefaultValueThatSplits,
+  another = veryLongDefaultValue,
+  third = alsoQuiteLongDefaultValue,
+]) {}
+>>> Split on named default.
+doStuff({parameter = veryLongDefaultValueThatSplits, another =
+veryLongDefaultValue, third = alsoAQuiteLongDefaultValue}) {}
+<<<
+doStuff({
+  parameter =
+      veryLongDefaultValueThatSplits,
+  another = veryLongDefaultValue,
+  third = alsoAQuiteLongDefaultValue,
+}) {}
+>>> Prefer block-like splitting for collection default values.
+function([param = [element, element, element, element]]) { body; }
+<<<
+function([
+  param = [
+    element,
+    element,
+    element,
+    element,
+  ],
+]) {
+  body;
+}

--- a/test/function/expression.stmt
+++ b/test/function/expression.stmt
@@ -1,0 +1,39 @@
+40 columns                              |
+### Tests for anonymous function expressions: "lambdas".
+>>> Generic.
+f = <  T  ,  S  extends  T  >  (  T  param  )  {  }  ;
+<<<
+f = <T, S extends T>(T param) {};
+>>> Async with block body.
+f = (  )  async  {  }  ;
+<<<
+f = () async {};
+>>> Async with expression body.
+f = (  )  async  =>  1;
+<<<
+f = () async => 1;
+>>> Sync* with block body.
+f = (  )  sync  *  {  }  ;
+<<<
+f = () sync* {};
+>>> Sync* with expression body.
+f = (  )  sync  *  =>  1;
+<<<
+f = () sync* => 1;
+>>> Aync* with block body.
+f = (  )  async  *  {  }  ;
+<<<
+f = () async* {};
+>>> Aync* with expression body.
+f = (  )  async  *  =>  1;
+<<<
+f = () async* => 1;
+>>> Split parameter list.
+function = (int firstArgument, int secondArgument) { print('42'); };
+<<<
+function = (
+  int firstArgument,
+  int secondArgument,
+) {
+  print('42');
+};

--- a/test/function/expression_body.unit
+++ b/test/function/expression_body.unit
@@ -1,0 +1,71 @@
+40 columns                              |
+### Tests for named function declarations whose body is `=>`.
+>>> Unsplit body.
+f  (  )  =>  body  ;
+<<<
+f() => body;
+>>> Async.
+f  (  )  async  =>  body  ;
+<<<
+f() async => body;
+>>> Sync*.
+f  (  )  sync  *  =>  body  ;
+<<<
+f() sync* => body;
+>>> Async*.
+f  (  )  async  *  =>  body  ;
+<<<
+f() async* => body;
+>>> Split at `=>`.
+myFunction() => argument + anotherArgument;
+<<<
+myFunction() =>
+    argument + anotherArgument;
+>>> Split inside expression forces split at `=>`.
+veryLongFunction() => argument + anotherArgument + aThirdArgument;
+<<<
+veryLongFunction() =>
+    argument +
+        anotherArgument +
+        aThirdArgument;
+>>> Prefer block-like splitting for lists.
+function() => [element, element, element];
+<<<
+function() => [
+  element,
+  element,
+  element,
+];
+>>> Prefer block-like splitting for maps.
+function() => {1: element, 2: element, 3: element};
+<<<
+function() => {
+  1: element,
+  2: element,
+  3: element,
+};
+>>> Prefer block-like splitting for function calls.
+function() => another(argument, argument);
+<<<
+function() => another(
+  argument,
+  argument,
+);
+>>> Use block-like splitting for switch expressions.
+function() => switch (value) { 1 => 'one', 2 => 'two' };
+<<<
+function() => switch (value) {
+  1 => 'one',
+  2 => 'two',
+};
+>>> Don't indent block-like body when parameters split.
+function(longParameter, anotherParameter) => [longElement, longElement, longElement];
+<<<
+function(
+  longParameter,
+  anotherParameter,
+) => [
+  longElement,
+  longElement,
+  longElement,
+];

--- a/test/function/generic.unit
+++ b/test/function/generic.unit
@@ -1,0 +1,42 @@
+40 columns                              |
+>>> Unsplit type parameters.
+f  <  T  ,  R  extends  T  >  (  T  t  ,  R  r  )  => body;
+<<<
+f<T, R extends T>(T t, R r) => body;
+>>> Split type parameters with block body.
+longFunctionName<LongTypeParameterT, LongTypeParameterS>() { body; }
+<<<
+longFunctionName<
+  LongTypeParameterT,
+  LongTypeParameterS
+>() {
+  body;
+}
+>>> Split type parameters and value parameters, with block body.
+longFunctionName<LongTypeParameterT, LongTypeParameterS>(
+longParameter1, longParameter2) { body; }
+<<<
+longFunctionName<
+  LongTypeParameterT,
+  LongTypeParameterS
+>(longParameter1, longParameter2) {
+  body;
+}
+>>> Split type parameters with expression body.
+longFunctionName<LongTypeParameterT, LongTypeParameterS>() => body;
+<<<
+longFunctionName<
+  LongTypeParameterT,
+  LongTypeParameterS
+>() => body;
+>>> Split type parameters and value parameters, with expression body.
+longFunctionName<LongTypeParameterT, LongTypeParameterS>(
+longParameter1, longParameter2) => body;
+<<<
+longFunctionName<
+  LongTypeParameterT,
+  LongTypeParameterS
+>(
+  longParameter1,
+  longParameter2,
+) => body;

--- a/test/function/local.stmt
+++ b/test/function/local.stmt
@@ -1,0 +1,14 @@
+40 columns                              |
+### The code for formatting function declarations is the same across top-level
+### and local functions. This just tests that local function declaration
+### statements work as expected.
+>>>
+main() {
+  int localFunction(String parameter) { body; }
+}
+<<<
+main() {
+  int localFunction(String parameter) {
+    body;
+  }
+}

--- a/test/function/other.unit
+++ b/test/function/other.unit
@@ -1,0 +1,5 @@
+40 columns                              |
+>>> External function.
+external  void  printToConsole  (  line  )  ;
+<<<
+external void printToConsole(line);

--- a/test/function/parameter.unit
+++ b/test/function/parameter.unit
@@ -1,0 +1,36 @@
+40 columns                              |
+### Most tests of parameter list formatting are handled by type/function.stmt.
+>>> Old style function typed parameter.
+bool doStuff(parameter1, void callback(int i, bool b)) {}
+<<<
+bool doStuff(
+  parameter1,
+  void callback(int i, bool b),
+) {}
+>>> Split inside old style function typed parameter.
+bool doStuff(parameter1,
+void callback(LongTypeName parameter1, AnotherLongType parameter2)) {}
+<<<
+bool doStuff(
+  parameter1,
+  void callback(
+    LongTypeName parameter1,
+    AnotherLongType parameter2,
+  ),
+) {}
+>>> Generic old style function typed parameter.
+function(int   foo  <  T  ,S >(T t, S s)) {}
+<<<
+function(int foo<T, S>(T t, S s)) {}
+>>> Nullable old style function typed parameter.
+function(int? callback()    ?  ) {}
+<<<
+function(int? callback()?) {}
+>>> `var` and `final` keywords on parameters.
+function(var x, final y, final String z) {}
+<<<
+function(
+  var x,
+  final y,
+  final String z,
+) {}

--- a/test/tall_format_test.dart
+++ b/test/tall_format_test.dart
@@ -11,6 +11,7 @@ import 'utils.dart';
 
 void main() async {
   await testDirectory('expression', tall: true);
+  await testDirectory('function', tall: true);
   await testDirectory('invocation', tall: true);
   await testDirectory('selection', tall: true);
   await testDirectory('statement', tall: true);

--- a/test/variable/local.stmt
+++ b/test/variable/local.stmt
@@ -208,6 +208,24 @@ var variableName = switch (
   1 => 'one',
   2 => 'two',
 };
+>>> Use block-like splitting for block-bodied function expressions.
+var variableName = (parameter, parameter, parameter) { body; };
+<<<
+var variableName = (
+  parameter,
+  parameter,
+  parameter,
+) {
+  body;
+};
+>>> Use block-like splitting for expression-bodied function expressions.
+var variableName = (parameter, parameter, parameter) => body;
+<<<
+var variableName = (
+  parameter,
+  parameter,
+  parameter,
+) => body;
 >>> Use block-like splitting for parenthesized expressions whose inner does.
 var variableName = ([element, element, element]);
 <<<


### PR DESCRIPTION
This covers:

- Top-level function declarations
- Local function declaration statements
- Anonymous function expressions

It handles all three kinds of bodies: `;`, `{ ... }`, and `=> ... ;`.

Most of the implementation work for functions is in:

- Their parameter lists, which is most already handled by the existing support (and tests) for function type annotations.
- Their `{ ... }` bodies, which are just block statements and are already implemented and tested.
- Their `=> ...` bodies, which are formatted like assignments so need little additional implementation.

This PR mostly just stitches that together, adds tests, and covers some of the bits that can't appear in those existing constructs:

- The `external` modifier on function declarations.
- Function names.
- Default values.
- The `var` and `final` modifiers on parameters.

This PR does not do getters and setters. That will come later.
