### PR TITLE
Format instance creation expressions (constructor calls).

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -111,13 +111,13 @@ extension ExpressionExtensions on Expression {
   /// ```
   bool get isDelimited => switch (this) {
         FunctionExpression() => true,
+        InstanceCreationExpression() => true,
         ListLiteral() => true,
         MethodInvocation() => true,
         ParenthesizedExpression(:var expression) => expression.isDelimited,
         RecordLiteral() => true,
         SetOrMapLiteral() => true,
         SwitchExpression() => true,
-        // TODO(tall): Instance creation expressions (`new` and `const`).
         _ => false,
       };
 

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -625,12 +625,13 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     // splitting before the `.`. This doesn't look good, but is consistent with
     // constructor calls that don't have `new` or `const`. We allow splitting
     // in the latter because there is no way to distinguish syntactically
-    // between a named constructor call and any other kind of method call.
-    var calls = <Piece>[];
+    // between a named constructor call and any other kind of method call or
+    // property access.
+    var operations = <Piece>[];
 
     if (node.constructorName.type.importPrefix case var importPrefix?) {
       token(importPrefix.name);
-      calls.add(pieces.split());
+      operations.add(pieces.split());
       token(importPrefix.period);
     }
 
@@ -639,7 +640,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     token(node.constructorName.type.question);
 
     if (node.constructorName.name != null) {
-      calls.add(pieces.split());
+      operations.add(pieces.split());
       token(node.constructorName.period);
       visit(node.constructorName.name);
     }
@@ -647,9 +648,9 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     finishCall(node.argumentList);
 
     // If there was a prefix or constructor name, then make a splittable piece.
-    if (calls.isNotEmpty) {
-      calls.add(pieces.take());
-      pieces.give(ChainPiece(calls));
+    if (operations.isNotEmpty) {
+      operations.add(pieces.take());
+      pieces.give(ChainPiece(operations));
     }
   }
 

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -629,20 +629,24 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
     // property access.
     var operations = <Piece>[];
 
-    if (node.constructorName.type.importPrefix case var importPrefix?) {
+    var constructor = node.constructorName;
+    if (constructor.type.importPrefix case var importPrefix?) {
       token(importPrefix.name);
       operations.add(pieces.split());
       token(importPrefix.period);
     }
 
-    token(node.constructorName.type.name2);
-    visit(node.constructorName.type.typeArguments);
-    token(node.constructorName.type.question);
+    // The name of the type being constructed.
+    var type = constructor.type;
+    token(type.name2);
+    visit(type.typeArguments);
+    token(type.question);
 
-    if (node.constructorName.name != null) {
+    // If this is a named constructor call, the name.
+    if (constructor.name != null) {
       operations.add(pieces.split());
-      token(node.constructorName.period);
-      visit(node.constructorName.name);
+      token(constructor.period);
+      visit(constructor.name);
     }
 
     finishCall(node.argumentList);

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -433,6 +433,15 @@ mixin PieceFactory implements CommentWriter {
         isValueDelimited: rightHandSide.isDelimited));
   }
 
+  /// Writes the argument list part of a constructor, function, or method call
+  /// after the name has been written.
+  void finishCall(ArgumentList argumentList) {
+    createList(
+        leftBracket: argumentList.leftParenthesis,
+        argumentList.arguments,
+        rightBracket: argumentList.rightParenthesis);
+  }
+
   /// Writes the condition and updaters parts of a [ForParts] after the
   /// subclass's initializer clause has been written.
   void finishForParts(ForParts forLoopParts, DelimitedListBuilder partsList) {

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import '../back_end/code_writer.dart';
+import '../constants.dart';
+import 'piece.dart';
+
+// TODO(tall): This will probably become more elaborate when full method chains
+// with interesting argument lists are supported. Right now, it's just the
+// basics needed for instance creation expressions which may have method-like
+// `.` in them.
+
+/// A series of property access or method calls, like:
+///
+/// ```
+/// target.getter.method().another.method();
+/// ```
+///
+/// This piece handles splitting before the `.`.
+class ChainPiece extends Piece {
+  /// The series of calls.
+  ///
+  /// The first piece in this is the target, and the rest are calls.
+  final List<Piece> _calls;
+
+  ChainPiece(this._calls);
+
+  @override
+  List<State> get additionalStates => const [State.split];
+
+  @override
+  void format(CodeWriter writer, State state) {
+    if (state == State.unsplit) {
+      writer.setAllowNewlines(false);
+    } else {
+      writer.setNesting(Indent.expression);
+    }
+
+    for (var i = 0; i < _calls.length; i++) {
+      if (i > 0) writer.splitIf(state == State.split, space: false);
+      writer.format(_calls[i]);
+    }
+  }
+
+  @override
+  void forEachChild(void Function(Piece piece) callback) {
+    _calls.forEach(callback);
+  }
+
+  @override
+  String toString() => 'Chain';
+}

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -10,7 +10,7 @@ import 'piece.dart';
 // basics needed for instance creation expressions which may have method-like
 // `.` in them.
 
-/// A series of property access or method calls, like:
+/// A dotted series of property access or method calls, like:
 ///
 /// ```
 /// target.getter.method().another.method();
@@ -18,12 +18,12 @@ import 'piece.dart';
 ///
 /// This piece handles splitting before the `.`.
 class ChainPiece extends Piece {
-  /// The series of calls.
+  /// The series of operations.
   ///
-  /// The first piece in this is the target, and the rest are calls.
-  final List<Piece> _calls;
+  /// The first piece in this is the target, and the rest are operations.
+  final List<Piece> _operations;
 
-  ChainPiece(this._calls);
+  ChainPiece(this._operations);
 
   @override
   List<State> get additionalStates => const [State.split];
@@ -36,15 +36,15 @@ class ChainPiece extends Piece {
       writer.setNesting(Indent.expression);
     }
 
-    for (var i = 0; i < _calls.length; i++) {
+    for (var i = 0; i < _operations.length; i++) {
       if (i > 0) writer.splitIf(state == State.split, space: false);
-      writer.format(_calls[i]);
+      writer.format(_operations[i]);
     }
   }
 
   @override
   void forEachChild(void Function(Piece piece) callback) {
-    _calls.forEach(callback);
+    _operations.forEach(callback);
   }
 
   @override

--- a/test/invocation/constructor.stmt
+++ b/test/invocation/constructor.stmt
@@ -1,0 +1,50 @@
+40 columns                              |
+### Constructor invocations are handled identically to function calls, so just
+### test the basics and make sure that we handle the keywords correctly.
+>>> Empty argument list.
+new  Foo  (  )  ;
+<<<
+new Foo();
+>>> Inline arguments.
+new  SomeType  ( argument , another ) ;
+<<<
+new SomeType(argument, another);
+>>> Split argument list.
+const  SomeType  ( argument , another , third ) ;
+<<<
+const SomeType(
+  argument,
+  another,
+  third,
+);
+>>> With type arguments.
+new  Map  <  int  ,  String  >  (  1  ,  2  ,  3  );
+<<<
+new Map<int, String>(1, 2, 3);
+>>> Named constructor.
+new  Thing  .  name  (  argument  )  ;
+<<<
+new Thing.name(argument);
+>>> Named constructor on class with type arguments.
+const  List  <  int  >  .  filled  (  1  ,  2  );
+<<<
+const List<int>.filled(1, 2);
+>>> Prefixed.
+new  prefix  .  TypeName  (  argument  )  ;
+<<<
+new prefix.TypeName(argument);
+>>> Prefix named constructor.
+const  prefix  .  Thing  .  name  (  argument  )  ;
+<<<
+const prefix.Thing.name(argument);
+>>> Split at name.
+new VeryLongClassName.veryLongNamedConstructor();
+<<<
+new VeryLongClassName
+    .veryLongNamedConstructor();
+>>> Split at name on prefixed named constructor.
+new prefix.VeryLongClassName.veryLongNamedConstructor();
+<<<
+new prefix
+    .VeryLongClassName
+    .veryLongNamedConstructor();

--- a/test/variable/local.stmt
+++ b/test/variable/local.stmt
@@ -173,6 +173,20 @@ var longVariableName = veryLongFunctionName(argument);
 <<<
 var longVariableName =
     veryLongFunctionName(argument);
+>>> Prefer block-like splitting for constructor calls.
+var variableName = new Thing(argument, argument);
+<<<
+var variableName = new Thing(
+  argument,
+  argument,
+);
+>>> Prefer block-like splitting for const constructor calls.
+var variableName = const Thing(argument, argument);
+<<<
+var variableName = const Thing(
+  argument,
+  argument,
+);
 >>> Indent block if function name doesn't fit and arguments split.
 var longVariableName = veryLongFunctionName(argument, another);
 <<<


### PR DESCRIPTION
Simple constructor calls behave exactly like normal function calls and use the same formatting code for their argument list.

Prefixed and/or named constructor calls are formatted sort of like method/property chains where they may split at the ".". We don't have full support for method/property chains yet, but this starts sketching that out enough to get the instance creation expression tests passing.
