### PR TITLE
Format fields and methods.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -415,7 +415,12 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitFieldDeclaration(FieldDeclaration node) {
-    throw UnimplementedError();
+    modifier(node.externalKeyword);
+    modifier(node.staticKeyword);
+    modifier(node.abstractKeyword);
+    modifier(node.covariantKeyword);
+    visit(node.fields);
+    token(node.semicolon);
   }
 
   @override
@@ -556,19 +561,14 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
-    modifier(node.externalKeyword);
-
-    Piece? returnType;
-    if (node.returnType case var returnTypeNode?) {
-      visit(returnTypeNode);
-      returnType = pieces.split();
-    }
-
-    // TODO(tall): Get or set keywords for getters and setters.
-    if (node.propertyKeyword != null) throw UnimplementedError();
-    token(node.name);
-
-    finishFunction(returnType, node.functionExpression);
+    createFunction(
+        externalKeyword: node.externalKeyword,
+        returnType: node.returnType,
+        propertyKeyword: node.propertyKeyword,
+        name: node.name,
+        typeParameters: node.functionExpression.typeParameters,
+        parameters: node.functionExpression.parameters,
+        body: node.functionExpression.body);
   }
 
   @override
@@ -578,7 +578,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitFunctionExpression(FunctionExpression node) {
-    finishFunction(null, node);
+    finishFunction(null, node.typeParameters, node.parameters, node.body);
   }
 
   @override
@@ -786,7 +786,16 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
-    throw UnimplementedError();
+    createFunction(
+        externalKeyword: node.externalKeyword,
+        modifierKeyword: node.modifierKeyword,
+        returnType: node.returnType,
+        operatorKeyword: node.operatorKeyword,
+        propertyKeyword: node.propertyKeyword,
+        name: node.name,
+        typeParameters: node.typeParameters,
+        parameters: node.parameters,
+        body: node.body);
   }
 
   @override
@@ -1209,6 +1218,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
+    modifier(node.externalKeyword);
     visit(node.variables);
     token(node.semicolon);
   }

--- a/lib/src/piece/function.dart
+++ b/lib/src/piece/function.dart
@@ -9,6 +9,8 @@ import 'piece.dart';
 ///
 /// Handles splitting between the return type and the rest of the function.
 class FunctionPiece extends Piece {
+  static const _splitAfterReturnType = State(1, cost: 2);
+
   /// The return type annotation, if any.
   final Piece? _returnType;
 
@@ -22,20 +24,21 @@ class FunctionPiece extends Piece {
   FunctionPiece(this._returnType, this._signature, [this._body]);
 
   @override
-  List<State> get additionalStates => [if (_returnType != null) State.split];
+  List<State> get additionalStates =>
+      [if (_returnType != null) _splitAfterReturnType];
 
   @override
   void format(CodeWriter writer, State state) {
     if (_returnType case var returnType?) {
       // A split inside the return type forces splitting after the return type.
-      writer.setAllowNewlines(state == State.split);
+      writer.setAllowNewlines(state == _splitAfterReturnType);
 
       writer.format(returnType);
 
       // A split in the type parameters or parameters does not force splitting
       // after the return type.
       writer.setAllowNewlines(true);
-      writer.splitIf(state == State.split);
+      writer.splitIf(state == _splitAfterReturnType);
     }
 
     writer.format(_signature);

--- a/test/README.md
+++ b/test/README.md
@@ -63,10 +63,12 @@ These tests are all run by `short_format_test.dart`.
 The newer tall style tests are:
 
 ```
-declaration/  - Typedef, class, enum, and extension declarations.
+declaration/  - Typedef, class, enum, extension, mixin, and member declarations.
+                Includes constructors, getters, setters, methods, and fields,
+                but not functions and variables, which are in their own
+                directories below.
 expression/   - Expressions.
 invocation/   - Function and member invocations.
-member/       - Constructor, method, field, getter, and setter declarations.
 selection/    - Test preserving selection information.
 statement/    - Statements.
 top_level/    - Top-level directives.

--- a/test/declaration/external.unit
+++ b/test/declaration/external.unit
@@ -1,0 +1,84 @@
+40 columns                              |
+>>> Top-level variable.
+  external   final   a ,  b  ;
+  external   final    Set < int  >  a ,  b  ;
+  external   var   a  ;
+  external   List < int >   a  ;
+<<<
+external final a, b;
+external final Set<int> a, b;
+external var a;
+external List<int> a;
+>>> Static field.
+class C {
+  external  static    final   a ,  b  ;
+external    static  final    Set < int  >  a ,  b  ;
+   external   static   var   a  ;
+  external  static    List < int >   a  ;
+}
+<<<
+class C {
+  external static final a, b;
+  external static final Set<int> a, b;
+  external static var a;
+  external static List<int> a;
+}
+>>> Instance field.
+class C {
+  external   final   a ,  b  ;
+  external   final    Set < String  >  a ,  b  ;
+  external   var   a  ;
+  external   List < int >   a  ;
+}
+<<<
+class C {
+  external final a, b;
+  external final Set<String> a, b;
+  external var a;
+  external List<int> a;
+}
+>>> Top-level function.
+external  int  function();
+external  int  get getter;
+external  void  set setter(int value);
+<<<
+external int function();
+external int get getter;
+external void set setter(int value);
+>>> Instance member.
+class A {
+  external  int  function();
+  external  int  get getter;
+  external  void  set setter(int value);
+}
+<<<
+class A {
+  external int function();
+  external int get getter;
+  external void set setter(int value);
+}
+>>> Static member.
+class A {
+  external  static  int function();
+  external  static  int get getter;
+  external  static  void set setter(int value);
+}
+<<<
+class A {
+  external static int function();
+  external static int get getter;
+  external static void set setter(
+    int value,
+  );
+}
+>>> Don't split after `external`.
+class Foo {
+  external var soMuchSoVeryLongFieldNameHere;
+  external SuperLongTypeAnnotation field;
+}
+<<<
+class Foo {
+  external var soMuchSoVeryLongFieldNameHere;
+  external SuperLongTypeAnnotation
+  field;
+}

--- a/test/declaration/field.unit
+++ b/test/declaration/field.unit
@@ -1,0 +1,67 @@
+40 columns                              |
+>>> Covariant.
+class Foo {
+ covariant    var bar;
+  covariant    int baz;
+}
+<<<
+class Foo {
+  covariant var bar;
+  covariant int baz;
+}
+>>> Late.
+class Foo {
+static    late    final int i;
+static    late   int i;
+static    late   var i;
+covariant    late   var i;
+covariant    late   int i;
+    late    final int i;
+    late   int i;
+    late   var i;
+}
+<<<
+class Foo {
+  static late final int i;
+  static late int i;
+  static late var i;
+  covariant late var i;
+  covariant late int i;
+  late final int i;
+  late int i;
+  late var i;
+}
+>>> Abstract.
+class Foo {
+abstract  covariant     var  a  , b   ;
+    abstract    final   int   c;
+  abstract   int i;
+}
+<<<
+class Foo {
+  abstract covariant var a, b;
+  abstract final int c;
+  abstract int i;
+}
+>>> Don't split after `covariant`.
+class Foo {
+  covariant var soMuchSoVeryLongFieldNameHere;
+  covariant VeryLongTypeAnnotation field;
+}
+<<<
+class Foo {
+  covariant var soMuchSoVeryLongFieldNameHere;
+  covariant VeryLongTypeAnnotation
+  field;
+}
+>>> Don't split after `abstract`.
+class Foo {
+  abstract var soMuchSoVeryLongFieldNameHere;
+  abstract SuperLongTypeAnnotation field;
+}
+<<<
+class Foo {
+  abstract var soMuchSoVeryLongFieldNameHere;
+  abstract SuperLongTypeAnnotation
+  field;
+}

--- a/test/declaration/field.unit
+++ b/test/declaration/field.unit
@@ -65,3 +65,19 @@ class Foo {
   abstract SuperLongTypeAnnotation
   field;
 }
+>>> Constant.
+class Foo {
+  static  const  uptyped  =  123  ;
+  static  const  String  typed  =  'string'  ;
+
+  const  uptypedInstance  =  123  ;
+  const  StringInstance  typed  =  'string'  ;
+}
+<<<
+class Foo {
+  static const uptyped = 123;
+  static const String typed = 'string';
+
+  const uptypedInstance = 123;
+  const StringInstance typed = 'string';
+}

--- a/test/declaration/member.unit
+++ b/test/declaration/member.unit
@@ -1,0 +1,41 @@
+40 columns                              |
+### Tests of mixed kinds of members in a declaration.
+>>> Insert a blank line after non-empty block-bodied members.
+class Foo {
+var a = 1; b() {;} c() => null; get d {;} get e => null; set f(value) {;
+} set g(value) => null; var h = 1;}
+<<<
+class Foo {
+  var a = 1;
+  b() {
+    ;
+  }
+
+  c() => null;
+  get d {
+    ;
+  }
+
+  get e => null;
+  set f(value) {
+    ;
+  }
+
+  set g(value) => null;
+  var h = 1;
+}
+>>> No blank line required after empty block-bodied members.
+class Foo {
+var a = 1; b() {} c() => null; get d {} get e => null; set f(value) {
+} set g(value) => null; var h = 1;}
+<<<
+class Foo {
+  var a = 1;
+  b() {}
+  c() => null;
+  get d {}
+  get e => null;
+  set f(value) {}
+  set g(value) => null;
+  var h = 1;
+}

--- a/test/declaration/method.unit
+++ b/test/declaration/method.unit
@@ -1,0 +1,123 @@
+40 columns                              |
+### Methods are formatted using the same code as function declarations, so most
+### of the tests are in function/. These tests just ensure that everything still
+### works inside a type declaration and test the features that can only be used
+### inside a type, like `covariant`.
+>>> Empty block body.
+class A {void x(){}}
+<<<
+class A {
+  void x() {}
+}
+>>> Non-empty block body.
+class A {void x(){body;}}
+<<<
+class A {
+  void x() {
+    body;
+  }
+}
+>>> Expression body.
+class A{int x()=>42+3;}
+<<<
+class A {
+  int x() => 42 + 3;
+}
+>>> Static method.
+class A{static bool x(){return true;}}
+<<<
+class A {
+  static bool x() {
+    return true;
+  }
+}
+>>> Covariant.
+class A {
+  pos(    covariant  int a,covariant    b  );
+  opt([ covariant int a,covariant    b  ]);
+  named({ covariant int a,covariant    b  });
+  fn(     covariant  int f(bool b));
+}
+<<<
+class A {
+  pos(covariant int a, covariant b);
+  opt([covariant int a, covariant b]);
+  named({covariant int a, covariant b});
+  fn(covariant int f(bool b));
+}
+>>> Split before `covariant`.
+class A {
+  longMethod(covariant parameterNameHere) {}
+}
+<<<
+class A {
+  longMethod(
+    covariant parameterNameHere,
+  ) {}
+}
+>>> Split before `covariant` with multiple parameters.
+class A {
+  longMethod(covariant first, second, covariant int third(parameter), fourth) {}
+}
+<<<
+class A {
+  longMethod(
+    covariant first,
+    second,
+    covariant int third(parameter),
+    fourth,
+  ) {}
+}
+>>> Don't split after `covariant`.
+class A {
+  longMethod(covariant int veryLongParameterNameWow) {}
+}
+<<<
+class A {
+  longMethod(
+    covariant int
+    veryLongParameterNameWow,
+  ) {}
+}
+>>> Required covariant parameter.
+class A {
+f({   required    covariant   int a}) {}
+}
+<<<
+class A {
+  f({required covariant int a}) {}
+}
+>>> Don't split between `required` and `covariant`.
+class A {
+  longMethod({required covariant int veryLongParameterNameWow}) {}
+}
+<<<
+class A {
+  longMethod({
+    required covariant int
+    veryLongParameterNameWow,
+  }) {}
+}
+>>> Getter in type.
+class A {
+  int get instanceProperty => 1;
+  static String get classProperty => "value";
+}
+<<<
+class A {
+  int get instanceProperty => 1;
+  static String get classProperty =>
+      "value";
+}
+>>> Setter in type.
+class A {
+  set instanceProperty(int value) {}
+  static set classProperty(String value) {}
+}
+<<<
+class A {
+  set instanceProperty(int value) {}
+  static set classProperty(
+    String value,
+  ) {}
+}

--- a/test/function/expression_body.unit
+++ b/test/function/expression_body.unit
@@ -69,3 +69,14 @@ function(
   longElement,
   longElement,
 ];
+>>> Prefer splitting parameters instead of after `=>`.
+LongReturnType function(parameter) => longFunctionBody;
+<<<
+LongReturnType function(
+  parameter,
+) => longFunctionBody;
+>>> Prefer splitting after `=>` instead of after return type.
+LongReturnType function() => longFunctionBody;
+<<<
+LongReturnType function() =>
+    longFunctionBody;

--- a/test/function/getter.unit
+++ b/test/function/getter.unit
@@ -1,0 +1,6 @@
+40 columns                              |
+>>> Split before `get`.
+VeryLongTypeAnnotation get veryLongGetter => null;
+<<<
+VeryLongTypeAnnotation
+get veryLongGetter => null;

--- a/test/function/operator.unit
+++ b/test/function/operator.unit
@@ -1,0 +1,20 @@
+40 columns                              |
+>>> Operator declaration.
+class A {
+  bool  operator  ==  (  Object  other  )  =>  true  ;
+  int  operator  +  (  int  other  )  {  return  value  +  other  ;  }
+  int  operator  -  (    )  {  return  -  value  ;  }
+}
+<<<
+class A {
+  bool operator ==(
+    Object other,
+  ) => true;
+  int operator +(int other) {
+    return value + other;
+  }
+
+  int operator -() {
+    return -value;
+  }
+}

--- a/test/function/parameter.unit
+++ b/test/function/parameter.unit
@@ -34,3 +34,7 @@ function(
   final y,
   final String z,
 ) {}
+>>> Required old style function typed parameter.
+f({   required    callback()}) {}
+<<<
+f({required callback()}) {}

--- a/test/function/setter.unit
+++ b/test/function/setter.unit
@@ -1,0 +1,6 @@
+40 columns                              |
+>>> Split after `set`.
+VeryLongTypeAnnotation set veryLongSetter(v) {}
+<<<
+VeryLongTypeAnnotation
+set veryLongSetter(v) {}

--- a/test/type/function.stmt
+++ b/test/type/function.stmt
@@ -196,3 +196,25 @@ Function<Argument>(String)
 Function<Argument>(num)
 Function<Argument>(int)
 Function<Argument>(bool) longVariable;
+>>> Split before `required`.
+longMethod({required parameterNameHere}) {}
+<<<
+longMethod({
+  required parameterNameHere,
+}) {}
+>>> Split before `required` with multiple parameters.
+longMethod({required first, second, required int third(parameter), fourth}) {}
+<<<
+longMethod({
+  required first,
+  second,
+  required int third(parameter),
+  fourth,
+}) {}
+>>> Never split after `required`.
+longMethod({required int reallyLongParameterNameWow}) {}
+<<<
+longMethod({
+  required int
+  reallyLongParameterNameWow,
+}) {}

--- a/test/variable/local.stmt
+++ b/test/variable/local.stmt
@@ -263,3 +263,13 @@ var a = 1,
       element,
       element,
     ];
+>>> Late local variable.
+{
+  late var x = 1;
+  late int y = 2;
+}
+<<<
+{
+  late var x = 1;
+  late int y = 2;
+}

--- a/test/variable/local.stmt
+++ b/test/variable/local.stmt
@@ -273,3 +273,11 @@ var a = 1,
   late var x = 1;
   late int y = 2;
 }
+>>> Constant.
+const  uptyped  =  123  ;
+<<<
+const uptyped = 123;
+>>>
+const  String  typed  =  'string'  ;
+<<<
+const String typed = 'string';

--- a/test/variable/top_level.unit
+++ b/test/variable/top_level.unit
@@ -13,3 +13,9 @@ SomeLongTypeName longVariable = longInitializer;
 <<<
 SomeLongTypeName longVariable =
     longInitializer;
+>>> Late top level variable.
+late var x = 1;
+late int y = 2;
+<<<
+late var x = 1;
+late int y = 2;

--- a/test/variable/top_level.unit
+++ b/test/variable/top_level.unit
@@ -19,3 +19,11 @@ late int y = 2;
 <<<
 late var x = 1;
 late int y = 2;
+>>> Constant.
+const  uptyped  =  123  ;
+<<<
+const uptyped = 123;
+>>>
+const  String  typed  =  'string'  ;
+<<<
+const String typed = 'string';


### PR DESCRIPTION
Almost all of the real work was already done to handle variables and functions, so this just extends that to fields and methods defined in classes and covers a few loose ends:

- External declarations in their various forms.
- The covariant modifier on parameters and fields.
- Operator declarations (which apparently were never tested on the old style!).
- Getters and setters.
- The `static`, `abstract`, and `late` modifiers.

I also tweaked the cost heuristics around splitting between return types, parameter lists, and `=>` expression bodies. It looks pretty weird to split after a return type, so I made that more costly than splitting at the body or parameter list. That in turn led me to tweaking the cost to split a type parameter list since those also look bad when split.

I also decided to put the tests for member declarations inside declaration/ instead of member/. My impression is that there won't be a huge number of separate files in declaration/ and member/, so it's easier to just merge them together. Let me know what you think about that.
