### PR TITLE
Format await statements.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -147,7 +147,9 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitAwaitExpression(AwaitExpression node) {
-    throw UnimplementedError();
+    token(node.awaitKeyword);
+    space();
+    visit(node.expression);
   }
 
   @override

--- a/test/statement/other.stmt
+++ b/test/statement/other.stmt
@@ -47,3 +47,11 @@ Stream<int> i(int n) async* {
 Stream<int> i(int n) async* {
   yield* i(n - 1);
 }
+>>> Await.
+foo() async {
+  await i (  1 + 2   )   ;
+}
+<<<
+foo() async {
+  await i(1 + 2);
+}

--- a/test/statement/other_comment.stmt
+++ b/test/statement/other_comment.stmt
@@ -51,3 +51,11 @@ Stream<int> i(int n) async* {
 Stream<int> i(int n) async* {
   yield* i(x); // comment
 }
+>>> Await with comment after semicolon.
+foo() async {
+  await i (  1 + 2   )   ;     // comment
+}
+<<<
+foo() async {
+  await i(1 + 2); // comment
+}


### PR DESCRIPTION
Even smaller CL to handle await statements.
Await fors are handled in https://github.com/dart-lang/dart_style/pull/1314 which made this even simpler.

Also, there are no other existing tests for `await` because it's honestly too small of a piece. So no tests have been migrated.

I added one test to test the basic await + one for await with a comment.