### PR TITLE
Format enums

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -5,6 +5,21 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 
 extension AstNodeExtensions on AstNode {
+  /// The first token at the beginning of this AST node, not including any
+  /// tokens for leading doc comments.
+  ///
+  /// If [node] is an [AnnotatedNode], then [beginToken] includes the
+  /// leading doc comment, which we want to handle separately. So, in that
+  /// case, explicitly skip past the doc comment to the subsequent metadata
+  /// (if there is any), or the beginning of the code.
+  Token get firstNonCommentToken {
+    return switch (this) {
+      AnnotatedNode(metadata: [var annotation, ...]) => annotation.beginToken,
+      AnnotatedNode(firstTokenAfterCommentAndMetadata: var token) => token,
+      _ => beginToken
+    };
+  }
+
   /// The comma token immediately following this if there is one, or `null`.
   Token? get commaAfter {
     var next = endToken.next!;

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -601,15 +601,6 @@ mixin PieceFactory implements CommentWriter {
         isValueDelimited: rightHandSide.isDelimited));
   }
 
-  /// Writes the argument list part of a constructor, function, or method call
-  /// after the name has been written.
-  void finishCall(ArgumentList argumentList) {
-    createList(
-        leftBracket: argumentList.leftParenthesis,
-        argumentList.arguments,
-        rightBracket: argumentList.rightParenthesis);
-  }
-
   /// Finishes writing a named function declaration or anonymous function
   /// expression after the return type (if any) and name (if any) has been
   /// written.

--- a/lib/src/front_end/sequence_builder.dart
+++ b/lib/src/front_end/sequence_builder.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:dart_style/src/ast_extensions.dart';
 
 import '../constants.dart';
 import '../piece/piece.dart';
@@ -46,17 +47,7 @@ class SequenceBuilder {
   /// Visits [node] and adds the resulting [Piece] to this sequence, handling
   /// any comments or blank lines that appear before it.
   void visit(AstNode node, {int? indent}) {
-    var token = switch (node) {
-      // If [node] is an [AnnotatedNode], then [beginToken] includes the
-      // leading doc comment, which we want to handle separately. So, in that
-      // case, explicitly skip past the doc comment to the subsequent metadata
-      // (if there is any), or the beginning of the code.
-      AnnotatedNode(metadata: [var annotation, ...]) => annotation.beginToken,
-      AnnotatedNode() => node.firstTokenAfterCommentAndMetadata,
-      _ => node.beginToken
-    };
-
-    addCommentsBefore(token);
+    addCommentsBefore(node.firstNonCommentToken);
     _visitor.visit(node);
     add(_visitor.pieces.split(), indent: indent);
   }

--- a/lib/src/front_end/sequence_builder.dart
+++ b/lib/src/front_end/sequence_builder.dart
@@ -87,7 +87,6 @@ class SequenceBuilder {
       if (_elements.isNotEmpty && comments.isHanging(i)) {
         // Attach the comment to the previous token.
         _visitor.space();
-
         _visitor.pieces.writeComment(comment, hanging: true);
       } else {
         // Write the comment as its own sequence piece.

--- a/lib/src/string_compare.dart
+++ b/lib/src/string_compare.dart
@@ -19,6 +19,9 @@
 /// add and remove trailing commas. It treats, `[`, `]`, `{`, and `}` as
 /// whitespace characters because the formatter may move a comment if it
 /// appears near the closing delimiter of an optional parameter section.
+///
+/// It treats `;` as whitespace because a trailing `;` inside an enum
+/// declaration that has no members will be removed.
 bool _isWhitespace(int c) {
   // Not using a set or something more elegant because this code is on the hot
   // path and this large expression is significantly faster than a set lookup.
@@ -27,6 +30,7 @@ bool _isWhitespace(int c) {
       c == 0x005d || // Treat `]` as "whitespace".
       c == 0x007b || // Treat `{` as "whitespace".
       c == 0x007d || // Treat `}` as "whitespace".
+      c == 0x003b || // Treat `;` as "whitespace".
       c >= 0x0009 && c <= 0x000d || // Control characters.
       c == 0x0020 || // SPACE.
       c == 0x0085 || // Control characters.

--- a/test/declaration/enum.unit
+++ b/test/declaration/enum.unit
@@ -1,0 +1,117 @@
+40 columns                              |
+>>> Single value.
+enum Unity {one}
+<<<
+enum Unity { one }
+>>> Multiple unsplit values.
+enum Primate{
+
+  bonobo,
+
+
+
+  chimp,
+
+
+  gorilla
+
+
+
+}
+<<<
+enum Primate { bonobo, chimp, gorilla }
+>>> Remove trailing comma if values don't split.
+enum Primate{bonobo,chimp,}
+<<<
+enum Primate { bonobo, chimp }
+>>> Split values and insert trailing comma.
+enum Primate{bonobo,chimp,gorilla,organutan}
+<<<
+enum Primate {
+  bonobo,
+  chimp,
+  gorilla,
+  organutan,
+}
+>>> Insert blank line before and after enum declaration.
+var x = 1;
+enum A { a }
+var y = 2;
+<<<
+var x = 1;
+
+enum A { a }
+
+var y = 2;
+>>> Remove semicolon if there are no members.
+enum E { a, b; }
+<<<
+enum E { a, b }
+>>> Remove trailing comma and semicolon if unsplit.
+enum E {a,b,c,;}
+<<<
+enum E { a, b, c }
+>>> Argument lists in values.
+enum Args {
+first(),second(a,b,c),
+third(named:1,2,another:3)
+}
+<<<
+enum Args {
+  first(),
+  second(a, b, c),
+  third(named: 1, 2, another: 3),
+}
+>>> Split argument lists in values.
+enum Args {
+firstEnumValue(longArgument,anotherArgument),
+secondEnumValue(longArgument,anotherArgument,aThirdArgument,theLastOne),
+thirdGenericOne<FirstTypeArgument,
+SecondTypeArgument<NestedTypeArgument,AnotherNestedTypeArgument>,
+LastTypeArgument>(namedArgument: firstValue,anotherNamed:argumentValue)
+}
+<<<
+enum Args {
+  firstEnumValue(
+    longArgument,
+    anotherArgument,
+  ),
+  secondEnumValue(
+    longArgument,
+    anotherArgument,
+    aThirdArgument,
+    theLastOne,
+  ),
+  thirdGenericOne<
+    FirstTypeArgument,
+    SecondTypeArgument<
+      NestedTypeArgument,
+      AnotherNestedTypeArgument
+    >,
+    LastTypeArgument
+  >(
+    namedArgument: firstValue,
+    anotherNamed: argumentValue,
+  ),
+}
+>>> Generic enum type.
+enum MagicNumbers< T    extends num   ,   S> {
+  one(1), two(2),pi<double,String>(3.14159)
+}
+<<<
+enum MagicNumbers<T extends num, S> {
+  one(1),
+  two(2),
+  pi<double, String>(3.14159),
+}
+>>> Split in type parameters forces body to split.
+enum SomeEnumType<LongTypeParameterName, Another> { a, b, c }
+<<<
+enum SomeEnumType<
+  LongTypeParameterName,
+  Another
+> {
+  a,
+  b,
+  c,
+}

--- a/test/declaration/enum_comment.unit
+++ b/test/declaration/enum_comment.unit
@@ -1,0 +1,207 @@
+40 columns                              |
+>>> Line comments.
+enum A {
+  // comment
+  B,
+
+  // comment
+  C
+
+  // comment
+}
+<<<
+enum A {
+  // comment
+  B,
+
+  // comment
+  C,
+
+  // comment
+}
+>>> Block comments.
+enum A {
+  /* comment */
+  B,
+
+  /* comment */
+  C
+
+  /* comment */
+}
+<<<
+enum A {
+  /* comment */
+  B,
+
+  /* comment */
+  C,
+
+  /* comment */
+}
+>>> Remove blank lines before beginning of body.
+enum A {
+
+
+
+  // comment
+  B
+}
+<<<
+enum A {
+  // comment
+  B,
+}
+>>> Remove blank lines after end of body.
+enum A {
+  B
+  // comment
+
+
+
+}
+<<<
+enum A {
+  B,
+  // comment
+}
+>>> Ensure blank line above doc comments.
+enum Foo {/// doc
+a,/// doc
+b,/// doc
+c
+}
+<<<
+enum Foo {
+  /// doc
+  a,
+
+  /// doc
+  b,
+
+  /// doc
+  c,
+}
+>>> Block comment before removed trailing comma.
+enum E { a /* before */, }
+<<<
+enum E { a /* before */ }
+>>> Block comment after removed comma.
+enum E { a, /* after */ }
+<<<
+enum E { a /* after */ }
+>>> Block comments before and after removed comma.
+enum E { a /* before */, /* after */ }
+<<<
+enum E { a /* before */ /* after */ }
+>>> Block comment before preserved trailing comma.
+enum E { longEnumValue, anotherValue /* before */, }
+<<<
+enum E {
+  longEnumValue,
+  anotherValue /* before */,
+}
+>>> Block comment after preserved trailing comma.
+enum E { longEnumValue, anotherValue, /* after */ }
+<<<
+enum E {
+  longEnumValue,
+  anotherValue /* after */,
+}
+>>> Block comment before and after preserved trailing comma.
+enum E { longEnumValue, anotherValue /* before */ , /* after */ }
+<<<
+enum E {
+  longEnumValue,
+  anotherValue /* before */ /* after */,
+}
+>>> Block comment at inserted comma.
+enum E { longEnumValue, anotherValue /* at */ }
+<<<
+enum E {
+  longEnumValue,
+  anotherValue /* at */,
+}
+>>> Line comment before trailing comma.
+enum E { a // before
+,}
+<<<
+enum E {
+  a, // before
+}
+>>> Line comment after trailing comma.
+enum E { a, // after
+}
+<<<
+enum E {
+  a, // after
+}
+>>> Block comment before removed trailing semicolon.
+enum E { a /* before */; }
+<<<
+enum E { a /* before */ }
+>>> Block comment after removed semicolon.
+enum E { a; /* after */ }
+<<<
+enum E { a /* after */ }
+>>> Block comments before and after removed semicolon.
+enum E { a /* before */; /* after */ }
+<<<
+enum E { a /* before */ /* after */ }
+>>> Line comment before trailing semicolon.
+enum E { a // before
+;}
+<<<
+enum E {
+  a, // before
+}
+>>> Line comment after trailing semicolon.
+enum E { a; // after
+}
+<<<
+enum E {
+  a, // after
+}
+>>> Block comment before removed trailing comma and semicolon.
+enum E { a /* before */,; }
+<<<
+enum E { a /* before */ }
+>>> Block comment after removed trailing comma and semicolon.
+enum E { a,; /* after */ }
+<<<
+enum E { a /* after */ }
+>>> Block comments before and after removed trailing comma and semicolon.
+enum E { a /* before */,; /* after */ }
+<<<
+enum E { a /* before */ /* after */ }
+>>> Line comment before trailing comma and semicolon.
+enum E { a // before
+,;}
+<<<
+enum E {
+  a, // before
+}
+>>> Line comment after trailing comma and semicolon.
+enum E { a; // after
+}
+<<<
+enum E {
+  a, // after
+}
+>>> Block comments around removed trailing comma and semicolon.
+enum E { a /* 1 */,/* 2 */;/* 3 */ }
+<<<
+enum E { a /* 1 */ /* 2 */ /* 3 */ }
+>>> Line comments around removed trailing comma and semicolon.
+### This is pathological, but removed tokens are a place where it's easy to
+### accidentally lose comments, so test it carefully.
+enum E { a // 1
+,// 2
+;// 3
+}
+<<<
+enum E {
+  a, // 1
+  // 2
+  // 3
+}

--- a/test/declaration/enum_member.unit
+++ b/test/declaration/enum_member.unit
@@ -1,0 +1,62 @@
+40 columns                              |
+>>> Insert blank line between values and members.
+enum E { a, b, c; int x; }
+<<<
+enum E {
+  a,
+  b,
+  c;
+
+  int x;
+}
+>>> Collapse multiple blank lines between values and members.
+enum E { a, b, c;
+
+
+
+int x; }
+<<<
+enum E {
+  a,
+  b,
+  c;
+
+  int x;
+}
+>>> Always split if there are members.
+enum E { a, b, c; int x; }
+<<<
+enum E {
+  a,
+  b,
+  c;
+
+  int x;
+}
+>>> Insert blank after non-empty block-bodied members.
+enum Foo {
+  x;
+var a = 1; b() {;} c() => null; get d {;} get e => null; set f(value) {;
+} set g(value) => null; var h = 1;}
+<<<
+enum Foo {
+  x;
+
+  var a = 1;
+  b() {
+    ;
+  }
+
+  c() => null;
+  get d {
+    ;
+  }
+
+  get e => null;
+  set f(value) {
+    ;
+  }
+
+  set g(value) => null;
+  var h = 1;
+}

--- a/test/declaration/enum_member_comment.unit
+++ b/test/declaration/enum_member_comment.unit
@@ -1,0 +1,256 @@
+40 columns                              |
+>>> Line comments.
+enum A {
+  // comment
+  B,
+
+  // comment
+  C;
+
+  // comment
+  f() {}
+}
+<<<
+enum A {
+  // comment
+  B,
+
+  // comment
+  C;
+
+  // comment
+  f() {}
+}
+>>> Block comments.
+enum A {
+  /* comment */
+  B,
+
+  /* comment */
+  C;
+
+  /* comment */
+  f() {}
+}
+<<<
+enum A {
+  /* comment */
+  B,
+
+  /* comment */
+  C;
+
+  /* comment */
+  f() {}
+}
+>>> Remove blank lines before beginning of body.
+enum A {
+
+
+
+  // comment
+  B;
+  f() {}
+}
+<<<
+enum A {
+  // comment
+  B;
+
+  f() {}
+}
+>>> Remove blank lines after end of body.
+enum A {
+  B;
+  f() {}
+  // comment
+
+
+
+}
+<<<
+enum A {
+  B;
+
+  f() {}
+  // comment
+}
+>>> Ensure blank line above doc comments.
+enum Foo {/// doc
+a,/// doc
+b;/// doc
+var x = 1;
+/// doc
+void y() {}}
+<<<
+enum Foo {
+  /// doc
+  a,
+
+  /// doc
+  b;
+
+  /// doc
+  var x = 1;
+
+  /// doc
+  void y() {}
+}
+>>> Block comment before removed trailing comma.
+enum E { a /* before */,;f() {} }
+<<<
+enum E {
+  a /* before */;
+
+  f() {}
+}
+>>> Block comment after removed comma.
+enum E { a, /* after */;f() {} }
+<<<
+enum E {
+  a /* after */;
+
+  f() {}
+}
+>>> Block comments before and after removed comma.
+enum E { a /* before */, /* after */;f() {} }
+<<<
+enum E {
+  a /* before */ /* after */;
+
+  f() {}
+}
+>>> Block comment before semicolon.
+enum E { longEnumValue, anotherValue /* before */;f() {} }
+<<<
+enum E {
+  longEnumValue,
+  anotherValue /* before */;
+
+  f() {}
+}
+>>> Block comment after semicolon.
+enum E { longEnumValue, anotherValue; /* after */ f() {}}
+<<<
+enum E {
+  longEnumValue,
+  anotherValue; /* after */
+
+  f() {}
+}
+>>> Block comment before and after semicolon.
+enum E { longEnumValue, anotherValue /* before */ ; /* after */ f() {}}
+<<<
+enum E {
+  longEnumValue,
+  anotherValue /* before */; /* after */
+
+  f() {}
+}
+>>> Line comment before trailing comma.
+enum E { a // before
+,;f() {}}
+<<<
+enum E {
+  a // before
+  ;
+
+  f() {}
+}
+>>> Line comment after trailing comma.
+enum E { a, // after
+;f() {}}
+<<<
+enum E {
+  a // after
+  ;
+
+  f() {}
+}
+>>> Line comment before semicolon.
+enum E { a // before
+;f() {}}
+<<<
+enum E {
+  a // before
+  ;
+
+  f() {}
+}
+>>> Line comment after semicolon.
+enum E { a; // after
+f() {}
+}
+<<<
+enum E {
+  a; // after
+
+  f() {}
+}
+>>> Block comment before trailing comma and semicolon.
+enum E { a /* before */,;f() {} }
+<<<
+enum E {
+  a /* before */;
+
+  f() {}
+}
+>>> Block comment after trailing comma and semicolon.
+enum E { a,; /* after */f() {} }
+<<<
+enum E {
+  a; /* after */
+
+  f() {}
+}
+>>> Block comments before and after trailing comma and semicolon.
+enum E { a /* before */,; /* after */f() {} }
+<<<
+enum E {
+  a /* before */; /* after */
+
+  f() {}
+}
+>>> Line comment before trailing comma and semicolon.
+enum E { a // before
+,;f() {}}
+<<<
+enum E {
+  a // before
+  ;
+
+  f() {}
+}
+>>> Line comment after trailing comma and semicolon.
+enum E { a; // after
+f() {}}
+<<<
+enum E {
+  a; // after
+
+  f() {}
+}
+>>> Block comments around trailing comma and semicolon.
+enum E { a /* 1 */,/* 2 */;/* 3 */f() {} }
+<<<
+enum E {
+  a /* 1 */ /* 2 */; /* 3 */
+
+  f() {}
+}
+>>> Line comments around trailing comma and semicolon.
+### This is pathological, but removed tokens are a place where it's easy to
+### accidentally lose comments, so test it carefully.
+enum E { a // 1
+,// 2
+;// 3
+f() {}
+}
+<<<
+enum E {
+  a // 1
+  // 2
+  ; // 3
+
+  f() {}
+}

--- a/test/string_compare_test.dart
+++ b/test/string_compare_test.dart
@@ -89,4 +89,10 @@ void main() {
     expect(equalIgnoringWhitespace('a}b}{c}{{}', 'abc'), isTrue);
     expect(equalIgnoringWhitespace('a}b}{c}{{}', 'cba'), isFalse);
   });
+
+  test('ignore differences from ";"', () {
+    expect(equalIgnoringWhitespace('enum E { a; }', 'enum E { a }'), isTrue);
+    expect(equalIgnoringWhitespace('a;b;;c;;', 'abc'), isTrue);
+    expect(equalIgnoringWhitespace('a;b;c;;', 'cba'), isFalse);
+  });
 }


### PR DESCRIPTION
Format enum declarations with and without members.

Enums are a little tricky because they are sort of like lists (i.e. ListPiece) and sort of like type declarations (i.e. BlockPiece). Enums without members should be formatted pretty much like any other delimited list where the declaration can collapse to one line (and discard any trailing comma) if it fits or expand to one element per line (and add a trailing comma) otherwise.

Enums with members are formatted pretty much like blocks where each constant  or member is on its own line.

There are a few wrinkles around trailing commas and the semicolon between the constants and members:

-   If the enum has no members, any trailing `;` is discarded. It doesn't do anything useful and I consider this morally equivalent to discarding other trailing commas.

-   If the enum has members, then a trailing comma after the last constant is redundant with the subsequent `;`. In that case, it discards the comma.

In both of these cases, we have to make sure we don't accidentally lose any comments around that discarded punctuation. So there are a lot of tests for all of those edge cases even though in practice no one writes code like that.

Discarding `;` on enums without members means that we treat `;` like whitespace, so I also loosened equalIgnoringWhitespace() to ignore semicolons too.

Since enums with and without members are formatted using different codepaths, there are a lot of mostly redundant-seeming tests for them.
