### PR TITLE
Format assert statements.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -131,15 +131,14 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
   @override
   void visitAssertStatement(AssertStatement node) {
     token(node.assertKeyword);
-
-    var arguments = [node.condition];
-    if (node.message case var message?) arguments.add(message);
     createList(
-      arguments,
+      [
+        node.condition,
+        if (node.message case var message?) message,
+      ],
       leftBracket: node.leftParenthesis,
       rightBracket: node.rightParenthesis,
     );
-
     token(node.semicolon);
   }
 

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -130,7 +130,17 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitAssertStatement(AssertStatement node) {
-    throw UnimplementedError();
+    token(node.assertKeyword);
+
+    var arguments = [node.condition];
+    if (node.message case var message?) arguments.add(message);
+    createList(
+      arguments,
+      leftBracket: node.leftParenthesis,
+      rightBracket: node.rightParenthesis,
+    );
+
+    token(node.semicolon);
   }
 
   @override

--- a/test/statement/assert.stmt
+++ b/test/statement/assert.stmt
@@ -1,55 +1,55 @@
 40 columns                              |
->>> single-line assert
+>>> Single-line assert.
 assert("some short string");
 <<<
 assert("some short string");
->>> wrapped assert
+>>> Split single-line assert.
 assert("some very long string that wraps");
 <<<
 assert(
   "some very long string that wraps",
 );
->>> single-line assert with message
+>>> Single-line assert with message.
 assert(true, "blah");
 <<<
 assert(true, "blah");
->>> split assert with message before both
+>>> Split assert with long message.
 assert(true, "looong string that wraps");
 <<<
 assert(
   true,
   "looong string that wraps",
 );
->>> split assert with message after first
+>>> Split assert with message and long condition.
 assert(veryLongCondition, "long string that wraps");
 <<<
 assert(
   veryLongCondition,
   "long string that wraps",
 );
->>> split assert with message at both
+>>> Split assert with a long message and a long condition.
 assert(veryVeryVeryVeryVeryLongCondition, "long string that wraps");
 <<<
 assert(
   veryVeryVeryVeryVeryLongCondition,
   "long string that wraps",
 );
->>> split assert with trailing comma
+>>> Remove trailing comma if not split, with no message.
 assert(condition,);
 <<<
 assert(condition);
->>> split assert with trailing comma and message
+>>> Remove trailing comma if not split, with a message.
 assert(condition, "some message",);
 <<<
 assert(condition, "some message");
->>> remove from assert arg list if unsplit
+>>> Unsplit the argument list and remove trailing comma.
 assert(
   1,
   2,
 );
 <<<
 assert(1, 2);
->>> add to assert arg list if split
+>>> Add trailing comma if argument list split.
 assert(longArgument1, veryLongArgument2);
 <<<
 assert(

--- a/test/statement/assert.stmt
+++ b/test/statement/assert.stmt
@@ -1,0 +1,58 @@
+40 columns                              |
+>>> single-line assert
+assert("some short string");
+<<<
+assert("some short string");
+>>> wrapped assert
+assert("some very long string that wraps");
+<<<
+assert(
+  "some very long string that wraps",
+);
+>>> single-line assert with message
+assert(true, "blah");
+<<<
+assert(true, "blah");
+>>> split assert with message before both
+assert(true, "looong string that wraps");
+<<<
+assert(
+  true,
+  "looong string that wraps",
+);
+>>> split assert with message after first
+assert(veryLongCondition, "long string that wraps");
+<<<
+assert(
+  veryLongCondition,
+  "long string that wraps",
+);
+>>> split assert with message at both
+assert(veryVeryVeryVeryVeryLongCondition, "long string that wraps");
+<<<
+assert(
+  veryVeryVeryVeryVeryLongCondition,
+  "long string that wraps",
+);
+>>> split assert with trailing comma
+assert(condition,);
+<<<
+assert(condition);
+>>> split assert with trailing comma and message
+assert(condition, "some message",);
+<<<
+assert(condition, "some message");
+>>> remove from assert arg list if unsplit
+assert(
+  1,
+  2,
+);
+<<<
+assert(1, 2);
+>>> add to assert arg list if split
+assert(longArgument1, veryLongArgument2);
+<<<
+assert(
+  longArgument1,
+  veryLongArgument2,
+);


### PR DESCRIPTION
This looks really similar to how asserts were formatted in the old formatter.
It's also similar logic to assert initializers, but we need constructors done first and then I'll handle that after.

I assume we have test logic for comments in ListPieces and general statements so I didn't add any extra for that, but if you think otherwise, let me know!