### PR TITLE
Ignore pieces with only one state during solving.

### DIFF
--- a/lib/src/back_end/solver.dart
+++ b/lib/src/back_end/solver.dart
@@ -42,7 +42,7 @@ class Solver {
 
     void traverse(Piece piece) {
       // We don't need to worry about selecting pieces that have only one state.
-      if (piece.states.isNotEmpty) unsolvedPieces.add(piece);
+      if (piece.states.length > 1) unsolvedPieces.add(piece);
       piece.forEachChild(traverse);
     }
 


### PR DESCRIPTION
Straight up dumb off-by-one error. 🙃 

This should make the solver a little faster (though it mostly uses the piece state map to look up states, so the shorter piece list won't have a huge effect).

The biggest practical effect is that the debug output of the solver is a lot easier to read because it isn't cluttered up by pointless pieces that it isn't solving for.