### PR TITLE
Better debug output for piece trees.

### DIFF
--- a/lib/src/debug.dart
+++ b/lib/src/debug.dart
@@ -283,7 +283,8 @@ class _PieceDebugTree {
     });
   }
 
-  /// The approximate number of characters needed to print this tree.
+  /// The approximate number of characters of output needed to print this tree
+  /// on a single line.
   ///
   /// Used to determine when to show a tree's children inline or split. Note
   /// that this is O(n^2), but we don't really care since it's only used for

--- a/lib/src/piece/adjacent.dart
+++ b/lib/src/piece/adjacent.dart
@@ -21,7 +21,4 @@ class AdjacentPiece extends Piece {
   void forEachChild(void Function(Piece piece) callback) {
     _pieces.forEach(callback);
   }
-
-  @override
-  String toString() => 'Adjacent';
 }

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -129,7 +129,4 @@ class AssignPiece extends Piece {
     callback(target);
     callback(value);
   }
-
-  @override
-  String toString() => 'Assign';
 }

--- a/lib/src/piece/block.dart
+++ b/lib/src/piece/block.dart
@@ -55,7 +55,4 @@ class BlockPiece extends Piece {
     callback(contents);
     callback(rightBracket);
   }
-
-  @override
-  String toString() => 'Block';
 }

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -46,7 +46,4 @@ class ChainPiece extends Piece {
   void forEachChild(void Function(Piece piece) callback) {
     _operations.forEach(callback);
   }
-
-  @override
-  String toString() => 'Chain';
 }

--- a/lib/src/piece/clause.dart
+++ b/lib/src/piece/clause.dart
@@ -121,9 +121,6 @@ class ClausesPiece extends Piece {
   void forEachChild(void Function(Piece piece) callback) {
     _clauses.forEach(callback);
   }
-
-  @override
-  String toString() => 'Clauses';
 }
 
 /// A keyword followed by a comma-separated list of items described by that
@@ -156,7 +153,4 @@ class ClausePiece extends Piece {
     callback(_keyword);
     _parts.forEach(callback);
   }
-
-  @override
-  String toString() => 'Clause';
 }

--- a/lib/src/piece/do_while.dart
+++ b/lib/src/piece/do_while.dart
@@ -25,7 +25,4 @@ class DoWhilePiece extends Piece {
     callback(_body);
     callback(_condition);
   }
-
-  @override
-  String toString() => 'DoWhile';
 }

--- a/lib/src/piece/for.dart
+++ b/lib/src/piece/for.dart
@@ -59,7 +59,4 @@ class ForPiece extends Piece {
     callback(_forParts);
     callback(_body);
   }
-
-  @override
-  String toString() => 'For';
 }

--- a/lib/src/piece/function.dart
+++ b/lib/src/piece/function.dart
@@ -56,5 +56,5 @@ class FunctionPiece extends Piece {
   }
 
   @override
-  String toString() => 'Fn';
+  String get debugName => 'Fn';
 }

--- a/lib/src/piece/if.dart
+++ b/lib/src/piece/if.dart
@@ -75,9 +75,6 @@ class IfPiece extends Piece {
       callback(section.statement);
     }
   }
-
-  @override
-  String toString() => 'If';
 }
 
 /// A single section in a chain of if-elses.

--- a/lib/src/piece/infix.dart
+++ b/lib/src/piece/infix.dart
@@ -42,7 +42,4 @@ class InfixPiece extends Piece {
   void forEachChild(void Function(Piece piece) callback) {
     operands.forEach(callback);
   }
-
-  @override
-  String toString() => 'Infix';
 }

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -123,9 +123,6 @@ class ListPiece extends Piece {
 
     if (_after case var after?) callback(after);
   }
-
-  @override
-  String toString() => 'List';
 }
 
 /// An element in a [ListPiece].

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -59,6 +59,14 @@ abstract class Piece {
   void pin(State state) {
     _pinnedState = state;
   }
+
+  /// The name of this piece as it appears in debug output.
+  ///
+  /// By default, this is the class's name with `Piece` removed.
+  String get debugName => runtimeType.toString().replaceAll('Piece', '');
+
+  @override
+  String toString() => debugName;
 }
 
 /// A simple atomic piece of code.

--- a/lib/src/piece/postfix.dart
+++ b/lib/src/piece/postfix.dart
@@ -46,7 +46,4 @@ class PostfixPiece extends Piece {
   void forEachChild(void Function(Piece piece) callback) {
     pieces.forEach(callback);
   }
-
-  @override
-  String toString() => 'Post';
 }

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -39,7 +39,7 @@ class SequencePiece extends Piece {
   }
 
   @override
-  String toString() => 'Sequence';
+  String get debugName => 'Seq';
 }
 
 /// An element inside a [SequencePiece].

--- a/lib/src/piece/type.dart
+++ b/lib/src/piece/type.dart
@@ -39,7 +39,4 @@ class TypePiece extends Piece {
     if (_clauses case var clauses?) callback(clauses);
     callback(_body);
   }
-
-  @override
-  String toString() => 'Type';
 }

--- a/lib/src/piece/variable.dart
+++ b/lib/src/piece/variable.dart
@@ -95,5 +95,5 @@ class VariablePiece extends Piece {
   }
 
   @override
-  String toString() => 'Var';
+  String get debugName => 'Var';
 }


### PR DESCRIPTION
The old formatter has pretty nice debug output, but the new one is still pretty rudimentary. This improves that situation somewhat from:

```
Sequence(Type(`class Foo` Block(`{` Sequence(Var(`static late final int` `i;`) Var(`static late int` `i;`) Var(`static late var` `i;`) Var(`covariant late var` `i;`) Var(`covariant late int` `i;`) Var(`late final int` `i;`) Var(`late int` `i;`) Var(`late var` `i;`)) `}`)))
```

To:

```
Seq(
  Type(
    `class Foo`
    Block(
      `{`
      Seq(
        Var(`static late final int` `i;`)
        Var(`static late int` `i;`)
        Var(`static late var` `i;`)
        Var(`covariant late var` `i;`)
        Var(`covariant late int` `i;`)
        Var(`late final int` `i;`)
        Var(`late int` `i;`)
        Var(`late var` `i;`)
      )
      `}`
    )
  )
)
```

It also eliminates a bunch of pointless `toString()` implementations that are only used for debugging and can be inferred from runtimeType.
