### PR TITLE
Ensure that line comments always get newlines after them.

### DIFF
--- a/lib/src/front_end/comment_writer.dart
+++ b/lib/src/front_end/comment_writer.dart
@@ -78,7 +78,6 @@ mixin CommentWriter {
 
       if (comments.isHanging(i)) {
         // Attach the comment to the previous token.
-        pieces.writeSpace();
         pieces.writeComment(comment, hanging: true);
       } else {
         pieces.writeNewline();
@@ -202,8 +201,7 @@ class SourceComment {
       {required this.flushLeft, required this.offset});
 
   /// Whether this comment contains a mandatory newline, either because it's a
-  /// comment that should be on its own line or a lexeme with a newline inside
-  /// it (i.e. multi-line block comment, multi-line string).
+  /// comment that should be on its own line or is a multi-line block comment.
   bool get containsNewline =>
       type != CommentType.inlineBlock || text.contains('\n');
 

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -4,7 +4,6 @@
 import 'package:analyzer/dart/ast/token.dart';
 
 import '../back_end/solver.dart';
-import '../comment_type.dart';
 import '../dart_formatter.dart';
 import '../debug.dart' as debug;
 import '../piece/piece.dart';

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -80,14 +80,19 @@ class TextPiece extends Piece {
   /// multiline strings, etc.
   bool _containsNewline = false;
 
+  /// Whether this piece should have a newline written at the end of it.
+  ///
+  /// This is true during piece construction while lines are still being
+  /// written. It may also be true once a piece is fully complete if it ends in
+  /// a line comment.
+  bool _trailingNewline = false;
+
   /// The offset from the beginning of [text] where the selection starts, or
   /// `null` if the selection does not start within this chunk.
-  int? get selectionStart => _selectionStart;
   int? _selectionStart;
 
   /// The offset from the beginning of [text] where the selection ends, or
   /// `null` if the selection does not start within this chunk.
-  int? get selectionEnd => _selectionEnd;
   int? _selectionEnd;
 
   /// Whether the last line of this piece's text ends with [text].
@@ -98,16 +103,25 @@ class TextPiece extends Piece {
   /// If [text] internally contains a newline, then [containsNewline] should
   /// be `true`.
   void append(String text, {bool containsNewline = false}) {
-    if (_lines.isEmpty) _lines.add('');
+    if (_lines.isEmpty || _trailingNewline) _lines.add('');
 
     // TODO(perf): Consider a faster way of accumulating text.
     _lines.last = _lines.last + text;
 
     if (containsNewline) _containsNewline = true;
+
+    _trailingNewline = false;
+  }
+
+  void appendSpace() {
+    // Don't write an unnecessary space at the beginning of a line.
+    if (_trailingNewline) return;
+
+    append(' ');
   }
 
   void newline() {
-    _lines.add('');
+    _trailingNewline = true;
   }
 
   @override
@@ -128,6 +142,8 @@ class TextPiece extends Piece {
       if (i > 0) writer.newline();
       writer.write(_lines[i]);
     }
+
+    if (_trailingNewline) writer.newline();
   }
 
   @override
@@ -141,7 +157,6 @@ class TextPiece extends Piece {
       start += line.length;
     }
 
-    // print('TextPiece start $start (absolute = $abs)');
     _selectionStart = start;
   }
 
@@ -153,7 +168,6 @@ class TextPiece extends Piece {
       end += line.length;
     }
 
-    // print('TextPiece end $end (absolute = $abs)');
     _selectionEnd = end;
   }
 


### PR DESCRIPTION
The formatter currently mostly relies on the surrounding piece's setAllowedWhitespace() rules to make sure that a line comment forces the surrounding piece to split in a way that ensures there is a newline after the comment.

This works correctly in lots of places where line comments are actually expected, but isn't reliable when a line comment occurs in a weird location. When that happens, it's important that we still always put a newline after the comment. Otherwise the code is meaningfully changed.

This does that. Whenever a TextPiece ends in a line comment, it will know that it has a trailing newline. It then always writes that to the CodeWriter. That leads to redundant newlines in cases where the surrounding piece is already going to put a newline, so I also moved some of the "pending" newline collapsing code from PieceWriter farther down the pipeline to CodeWriter.

This doesn't change the behavior of any of the current tests. It will fix many untested corners of the language. I'm working on some new tests for comments in if statements that will be fixed by this change, but I'm also changing the actual formatting of if statements, so I want to do that in a separate change.
