### PR TITLE
Bump version to publish 2.3.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.3.4-wip
+## 2.3.4
 
 * Add `tall-style` experiment flag to enable the in-progress unstable new
   formatting style (#1253).

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -11,7 +11,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '2.3.3';
+const dartStyleVersion = '2.3.4';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 class FormatterOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.4-wip
+version: 2.3.4
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
This commit has already been rolled into the SDK and internally, so getting ready to publish a new version of the dart_style package.

cc @kallentu @natebosch 