### PR TITLE
Parse with language version 3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.5-wip
+
+* Use language version `3.3` to parse so that
+  code with extension types can be formatted.
+
 ## 2.3.4
 
 * Add `tall-style` experiment flag to enable the in-progress unstable new

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -219,7 +219,7 @@ class DartFormatter {
   // happens to parse without error, then we use that result instead.
   ParseStringResult _parse(String source, String? uri,
       {required bool patterns}) {
-    var version = patterns ? Version(3, 0, 0) : Version(2, 19, 0);
+    var version = patterns ? Version(3, 3, 0) : Version(2, 19, 0);
 
     // Don't pass the formatter's own experiment flag to the parser.
     var experiments = experimentFlags.toList();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.4
+version: 2.3.5-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
Since extension types are now enabled by default (https://github.com/dart-lang/sdk/commit/a19ae4ee688e5297ef95970eb1077cba3fddb5eb) and `dart_style` supports formatting extension types, the language version passed to the analyzer should be updated.

Reference: https://github.com/dart-lang/sdk/issues/54139#issuecomment-1824826027