### PR TITLE
Format try statements.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -211,7 +211,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitCatchClauseParameter(CatchClauseParameter node) {
-    assert(false, 'This node is handled by visitTryStatement().');
+    token(node.name);
   }
 
   @override

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -206,12 +206,12 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitCatchClause(CatchClause node) {
-    throw UnimplementedError();
+    assert(false, 'This node is handled by visitTryStatement().');
   }
 
   @override
   void visitCatchClauseParameter(CatchClauseParameter node) {
-    throw UnimplementedError();
+    assert(false, 'This node is handled by visitTryStatement().');
   }
 
   @override
@@ -1390,7 +1390,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void>
 
   @override
   void visitTryStatement(TryStatement node) {
-    throw UnimplementedError();
+    createTry(node);
   }
 
   @override

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -248,24 +248,15 @@ mixin PieceFactory implements CommentWriter {
 
     for (var i = 0; i < tryStatement.catchClauses.length; i++) {
       var catchClause = tryStatement.catchClauses[i];
-      if (catchClause.onKeyword case var onKeyword?) {
-        token(onKeyword);
-        space();
-        visit(catchClause.exceptionType);
-      }
-      if (catchClause.catchKeyword case var catchKeyword?) {
-        space();
-        token(catchKeyword);
-        space();
-        token(catchClause.leftParenthesis);
-        token(catchClause.exceptionParameter?.name);
-        if (catchClause.comma case var comma?) {
-          token(comma);
-          space();
-          token(catchClause.stackTraceParameter?.name);
-        }
-        token(catchClause.rightParenthesis);
-      }
+      token(catchClause.onKeyword, after: space);
+      visit(catchClause.exceptionType, after: space);
+
+      token(catchClause.catchKeyword, after: space);
+      token(catchClause.leftParenthesis);
+      token(catchClause.exceptionParameter?.name);
+      token(catchClause.comma, after: space);
+      token(catchClause.stackTraceParameter?.name);
+      token(catchClause.rightParenthesis);
       var catchClauseHeader = pieces.split();
 
       // Edge case: When there's another catch/on/finally after this one, we

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -252,13 +252,13 @@ mixin PieceFactory implements CommentWriter {
       Piece? onPiece;
       if (catchClause.onKeyword case var onKeyword?) {
         token(onKeyword, after: space);
-        visit(catchClause.exceptionType, after: space);
+        visit(catchClause.exceptionType);
         onPiece = pieces.split();
       }
 
       Piece? catchPiece;
       if (catchClause.catchKeyword case var catchKeyword?) {
-        token(catchKeyword, after: space);
+        token(catchKeyword);
         var catchKeywordPiece = pieces.split();
 
         var builder = DelimitedListBuilder(this);

--- a/lib/src/piece/adjacent.dart
+++ b/lib/src/piece/adjacent.dart
@@ -8,12 +8,17 @@ import 'piece.dart';
 class AdjacentPiece extends Piece {
   final List<Piece> _pieces;
 
-  AdjacentPiece(this._pieces);
+  /// The pieces that should have a space after them.
+  final Set<Piece> _spaceAfter;
+
+  AdjacentPiece(this._pieces, {List<Piece> spaceAfter = const []})
+      : _spaceAfter = spaceAfter.toSet();
 
   @override
   void format(CodeWriter writer, State state) {
     for (var piece in _pieces) {
       writer.format(piece);
+      if (_spaceAfter.contains(piece)) writer.space();
     }
   }
 

--- a/lib/src/piece/try.dart
+++ b/lib/src/piece/try.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import '../back_end/code_writer.dart';
+import 'piece.dart';
+
+/// A piece for a try statement.
+class TryPiece extends Piece {
+  final List<_TrySectionPiece> _sections = [];
+
+  void add(Piece header, Piece statement) {
+    _sections.add(_TrySectionPiece(header, statement));
+  }
+
+  @override
+  void format(CodeWriter writer, State state) {
+    for (var i = 0; i < _sections.length; i++) {
+      var section = _sections[i];
+      writer.format(section.header);
+      writer.space();
+      writer.format(section.body);
+
+      // Adds the space between the end of a block and the next header.
+      if (i < _sections.length - 1) {
+        writer.space();
+      }
+    }
+  }
+
+  @override
+  void forEachChild(void Function(Piece piece) callback) {
+    for (var section in _sections) {
+      callback(section.header);
+      callback(section.body);
+    }
+  }
+
+  @override
+  String toString() => 'Try';
+}
+
+/// A section for a try.
+///
+/// This could be a try, an on/catch, or a finally section. They are all
+/// formatted similarly.
+class _TrySectionPiece {
+  final Piece header;
+  final Piece body;
+
+  _TrySectionPiece(this.header, this.body);
+}

--- a/lib/src/piece/try.dart
+++ b/lib/src/piece/try.dart
@@ -8,8 +8,8 @@ import 'piece.dart';
 class TryPiece extends Piece {
   final List<_TrySectionPiece> _sections = [];
 
-  void add(Piece header, Piece statement) {
-    _sections.add(_TrySectionPiece(header, statement));
+  void add(Piece header, Piece block) {
+    _sections.add(_TrySectionPiece(header, block));
   }
 
   @override

--- a/lib/src/piece/try.dart
+++ b/lib/src/piece/try.dart
@@ -34,9 +34,6 @@ class TryPiece extends Piece {
       callback(section.body);
     }
   }
-
-  @override
-  String toString() => 'Try';
 }
 
 /// A section for a try.

--- a/test/statement/try.stmt
+++ b/test/statement/try.stmt
@@ -1,0 +1,113 @@
+40 columns                              |
+>>> Try and catch exception.
+try {
+doSomething();
+} catch (e) {
+print(e);
+}
+<<<
+try {
+  doSomething();
+} catch (e) {
+  print(e);
+}
+>>> Try and catch exception with on clause.
+try{
+doSomething();
+}on Exception catch (e){
+print(e);
+}
+<<<
+try {
+  doSomething();
+} on Exception catch (e) {
+  print(e);
+}
+>>> Try and catch exception with on clause and stack trace.
+try{
+doSomething();
+}on Exception catch (e,   s){
+print(e);
+}
+<<<
+try {
+  doSomething();
+} on Exception catch (e, s) {
+  print(e);
+}
+>>> Split empty catch if there is a finally.
+try {;} catch (err) {} finally {;}
+<<<
+try {
+  ;
+} catch (err) {
+} finally {
+  ;
+}
+>>> Split empty on if there is a finally.
+try {;} on Exception {} finally {;}
+<<<
+try {
+  ;
+} on Exception {
+} finally {
+  ;
+}
+>>> Split all empty catches if there is a finally.
+try {;} catch (err1) {} catch (err2) {} catch (err3) {} finally {;}
+<<<
+try {
+  ;
+} catch (err1) {
+} catch (err2) {
+} catch (err3) {
+} finally {
+  ;
+}
+>>> Split leading empty catches if there are multiple.
+try {;} catch (err1) {} catch (err2) {} catch (err3) {}
+<<<
+try {
+  ;
+} catch (err1) {
+} catch (err2) {
+} catch (err3) {}
+>>> Split empty catch with on clause if there is a finally.
+try {
+  doSomething();
+} on Exception catch (e) {} finally {
+  cleanupSomething();
+}
+<<<
+try {
+  doSomething();
+} on Exception catch (e) {
+} finally {
+  cleanupSomething();
+}
+>>> Split multiple on clauses.
+try {
+  doSomething();
+} on FooException {} on BarException {
+  doSomething();
+}
+<<<
+try {
+  doSomething();
+} on FooException {
+} on BarException {
+  doSomething();
+}
+>>> Don't split try.
+try {
+  doSomething();
+} on FooException {} on BarException {
+  doSomething();
+}
+<<<
+try {
+  doSomething();
+} on FooException {
+} on BarException {
+  doSomething();
+}

--- a/test/statement/try_comment.stmt
+++ b/test/statement/try_comment.stmt
@@ -1,0 +1,123 @@
+40 columns                              |
+>>> Line comment after `try`.
+try // comment
+{ body; } catch (e) { print(e); }
+<<<
+try // comment
+{
+  body;
+} catch (e) {
+  print(e);
+}
+>>> Line comment after `catch`.
+try { body; } catch // comment
+(e) { print(e); }
+<<<
+try {
+  body;
+} catch // comment
+(e) {
+  print(e);
+}
+>>> Line comment before `catch` condition.
+try { body; } catch (// comment
+e) { print(e); }
+<<<
+try {
+  body;
+} catch ( // comment
+e) {
+  print(e);
+}
+>>> Line comment after `catch` condition.
+try { body; } catch (e// comment
+) { print(e); }
+<<<
+try {
+  body;
+} catch (e // comment
+) {
+  print(e);
+}
+>>> Line comment after entire simple `catch` clause.
+try { body; } catch (e) // comment
+{ print(e); }
+<<<
+try {
+  body;
+} catch (e) // comment
+{
+  print(e);
+}
+>>> Line comment before `on`.
+try { body; } // comment
+on Exception catch (e) { print(e); }
+<<<
+try {
+  body;
+} // comment
+on Exception catch (e) {
+  print(e);
+}
+>>> Line comment after `on`.
+try { body; } on // comment
+Exception catch (e) { print(e); }
+<<<
+try {
+  body;
+} on // comment
+Exception catch (e) {
+  print(e);
+}
+>>> Line comment after exception in `on` clause.
+try { body; } on Exception // comment
+catch (e) { print(e); }
+<<<
+try {
+  body;
+} on Exception // comment
+catch (e) {
+  print(e);
+}
+>>> Line comment after `catch` body.
+try { body; } catch (e) { print(e); } // comment
+<<<
+try {
+  body;
+} catch (e) {
+  print(e);
+} // comment
+>>> Line comment before `finally`.
+try { body; } catch (e) { print(e); } // comment
+finally { ; }
+<<<
+try {
+  body;
+} catch (e) {
+  print(e);
+} // comment
+finally {
+  ;
+}
+>>> Line comment after `finally`.
+try { body; } catch (e) { print(e); } finally // comment
+{ ; }
+<<<
+try {
+  body;
+} catch (e) {
+  print(e);
+} finally // comment
+{
+  ;
+}
+>>> Line comment after `finally` body.
+try { body; } catch (e) { print(e); } finally { ; } // comment
+<<<
+try {
+  body;
+} catch (e) {
+  print(e);
+} finally {
+  ;
+} // comment

--- a/test/statement/try_comment.stmt
+++ b/test/statement/try_comment.stmt
@@ -25,8 +25,10 @@ e) { print(e); }
 <<<
 try {
   body;
-} catch ( // comment
-e) {
+} catch (
+  // comment
+  e,
+) {
   print(e);
 }
 >>> Line comment after `catch` condition.
@@ -35,7 +37,8 @@ try { body; } catch (e// comment
 <<<
 try {
   body;
-} catch (e // comment
+} catch (
+  e, // comment
 ) {
   print(e);
 }


### PR DESCRIPTION
- Added a new `TryPiece` for try statements. They are very similar to if statements, but I kept them separate.
- Each `TryPiece` has one or more `_TrySectionPiece` which is a catch or finally header and block. They're all formatted similarly.
- Tests for trys and their comments.

Will also remove the temp dir tests after submission.

(I'll send this over to Nate for readability after approval :D )