### PR TITLE
Format collection spread elements.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -861,7 +861,15 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
-    throw UnimplementedError();
+    // TODO(tall): This is just basic support to get the syntax doing something
+    // so that tests of other features that happen to use this syntax can run.
+    // The main tests for function expression calls still need to be migrated
+    // over and this may need some tweaks.
+    return buildPiece((b) {
+      b.visit(node.function);
+      b.visit(node.typeArguments);
+      b.visit(node.argumentList);
+    });
   }
 
   @override
@@ -1404,7 +1412,10 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitSpreadElement(SpreadElement node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      b.token(node.spreadOperator);
+      b.visit(node.expression);
+    });
   }
 
   @override

--- a/test/README.md
+++ b/test/README.md
@@ -67,7 +67,7 @@ declaration/  - Typedef, class, enum, extension, mixin, and member declarations.
                 Includes constructors, getters, setters, methods, and fields,
                 but not functions and variables, which are in their own
                 directories below.
-expression/   - Expressions.
+expression/   - Expressions and collection elements.
 invocation/   - Function and member invocations.
 selection/    - Test preserving selection information.
 statement/    - Statements.

--- a/test/expression/collection_spread.stmt
+++ b/test/expression/collection_spread.stmt
@@ -1,0 +1,55 @@
+40 columns                              |
+>>> Unsplit.
+var list = [  ...  a,...b,  ...
+c];
+<<<
+var list = [...a, ...b, ...c];
+>>> Don't split after `...`.
+var list = [...comicallyLongIdentifierThatOverflows];
+<<<
+var list = [
+  ...comicallyLongIdentifierThatOverflows,
+];
+>>> Null-aware.
+var list = [  ...?  a,...?b,  ...?
+c];
+<<<
+var list = [...?a, ...?b, ...?c];
+>>> Don't split after `...?`.
+var list = [...?comicallyLongIdentifierThatOverflows];
+<<<
+var list = [
+  ...?comicallyLongIdentifierThatOverflows,
+];
+>>> Split inside spread expression.
+var list = [1, ...some + very + long + spread + expression, 3];
+<<<
+var list = [
+  1,
+  ...some +
+      very +
+      long +
+      spread +
+      expression,
+  3,
+];
+>>> Spread function expression.
+var list = [1, ...() { body; }, 4];
+<<<
+var list = [
+  1,
+  ...() {
+    body;
+  },
+  4,
+];
+>>> Spread immediately invoked function expression.
+var list = [1, ...() sync* { yield thing; }(), 4];
+<<<
+var list = [
+  1,
+  ...() sync* {
+    yield thing;
+  }(),
+  4,
+];


### PR DESCRIPTION
Unlike the old tests, I didn't redundantly test everything you can do with spreads in all three kinds of collection literals. Since we know those literals all use the same implementation, that seemed needlessly redundant to me.
