### PR TITLE
Refactor how piece constraints are applied.

### DIFF
--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -7,23 +7,19 @@ import 'code_writer.dart';
 /// A possibly incomplete set of selected states for a set of pieces being
 /// solved.
 class PieceStateSet {
-  // TODO(perf): Looking up and expanding the set of chunk states was a
-  // performance bottleneck in the old line splitter. If that turns out to be
-  // true here, then consider a faster representation for this list and the
-  // subsequent map field.
-  /// The in-order flattened list of all pieces being solved.
+  /// The states that pieces have been bound to.
   ///
-  /// This doesn't include pieces like text that have only a single value since
-  /// there's nothing to solve for them.
-  final List<Piece> _pieces;
-
+  /// Note that order that keys are inserted into this map is significant. When
+  /// ordering solutions, we use the order that pieces are bound in here to
+  /// break ties between solutions that otherwise have the same cost and
+  /// overflow.
   final Map<Piece, State> _pieceStates;
 
   /// Creates a new [PieceStateSet] with no pieces set to any state (which
   /// implicitly means they have state 0).
-  PieceStateSet(this._pieces) : _pieceStates = {};
+  PieceStateSet() : _pieceStates = {};
 
-  PieceStateSet._(this._pieces, this._pieceStates);
+  PieceStateSet._(this._pieceStates);
 
   /// The state this solution selects for [piece].
   ///
@@ -33,18 +29,43 @@ class PieceStateSet {
   /// Whether [piece] has been bound to a state in this set.
   bool isBound(Piece piece) => _pieceStates.containsKey(piece);
 
-  /// Creates a clone of this state with [piece] bound to [state].
-  PieceStateSet cloneWith(Piece piece, State state) {
-    return PieceStateSet._(_pieces, {..._pieceStates, piece: state});
+  /// Attempts to bind [piece] to [state], taking into account any constraints
+  /// pieces place on each other.
+  ///
+  /// Returns a new [PieceStateSet] with [piece] bound to [state] and any other
+  /// pieces constrained by that choice bound to their constrained values
+  /// (recursively). Returns `null` if a constraint conflicts with the already
+  /// bound or pinned state for some piece.
+  PieceStateSet? tryBind(Piece piece, State state) {
+    var conflict = false;
+    var boundStates = {..._pieceStates};
+
+    void traverse(Piece thisPiece, State thisState) {
+      // If this piece is already pinned or bound to some other state, then the
+      // solution doesn't make sense.
+      var alreadyBound = thisPiece.pinnedState ?? boundStates[thisPiece];
+      if (alreadyBound != null && alreadyBound != thisState) {
+        conflict = true;
+        return;
+      }
+
+      boundStates[thisPiece] = thisState;
+
+      // This piece may in turn place further constraints on others.
+      thisPiece.applyConstraints(thisState, traverse);
+    }
+
+    traverse(piece, state);
+
+    if (conflict) return null;
+    return PieceStateSet._(boundStates);
   }
 
   @override
   String toString() {
-    return _pieces.map((piece) {
-      var state = _pieceStates[piece];
-      var stateLabel = state == null ? '?' : '$state';
-      return '$piece:$stateLabel';
-    }).join(' ');
+    return _pieceStates.keys
+        .map((piece) => '$piece:${_pieceStates[piece]}')
+        .join(' ');
   }
 }
 
@@ -119,8 +140,8 @@ class Solution implements Comparable<Solution> {
   /// no selection.
   final int? selectionEnd;
 
-  factory Solution.initial(Piece root, int pageWidth, List<Piece> pieces) {
-    return Solution._(root, pageWidth, PieceStateSet(pieces));
+  factory Solution.initial(Piece root, int pageWidth) {
+    return Solution._(root, pageWidth, PieceStateSet());
   }
 
   factory Solution._(Piece root, int pageWidth, PieceStateSet state) {
@@ -137,10 +158,15 @@ class Solution implements Comparable<Solution> {
   /// piece and yields further solutions for each state that piece can have.
   List<Solution> expand(Piece root, int pageWidth) {
     if (_nextPieceToExpand case var piece?) {
-      return [
-        for (var state in piece.states)
-          Solution._(root, pageWidth, _state.cloneWith(piece, state))
-      ];
+      var result = <Solution>[];
+      for (var state in piece.states) {
+        var stateSet = _state.tryBind(piece, state);
+        if (stateSet != null) {
+          result.add(Solution._(root, pageWidth, stateSet));
+        }
+      }
+
+      return result;
     }
 
     // No piece we can expand.
@@ -161,14 +187,8 @@ class Solution implements Comparable<Solution> {
 
     if (overflow != other.overflow) return overflow.compareTo(other.overflow);
 
-    // Should be solving the same set of pieces.
-    assert(_state._pieces.length == other._state._pieces.length);
-
-    // If all else is equal, prefer lower states in earlier pieces.
-    // TODO(tall): This might not be needed once piece scoring is more
-    // sophisticated.
-    for (var i = 0; i < _state._pieces.length; i++) {
-      var piece = _state._pieces[i];
+    // If all else is equal, prefer lower states in earlier bound pieces.
+    for (var piece in _state._pieceStates.keys) {
       var thisState = _state.pieceState(piece);
       var otherState = other._state.pieceState(piece);
       if (thisState != otherState) return thisState.compareTo(otherState);

--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -75,7 +75,7 @@ class PieceStateSet {
 /// code and its cost.
 class Solution implements Comparable<Solution> {
   /// The states the pieces have been set to in this solution.
-  final PieceStateSet _state;
+  final PieceStateSet _stateSet;
 
   /// The formatted code.
   final String text;
@@ -150,7 +150,7 @@ class Solution implements Comparable<Solution> {
     return writer.finish();
   }
 
-  Solution(this._state, this.text, this.selectionStart, this.selectionEnd,
+  Solution(this._stateSet, this.text, this.selectionStart, this.selectionEnd,
       this._nextPieceToExpand,
       {required this.overflow, required this.cost, required this.isValid});
 
@@ -160,7 +160,7 @@ class Solution implements Comparable<Solution> {
     if (_nextPieceToExpand case var piece?) {
       return [
         for (var state in piece.states)
-          if (_state.tryBind(piece, state) case final stateSet?)
+          if (_stateSet.tryBind(piece, state) case final stateSet?)
             Solution._(root, pageWidth, stateSet)
       ];
     }
@@ -184,9 +184,9 @@ class Solution implements Comparable<Solution> {
     if (overflow != other.overflow) return overflow.compareTo(other.overflow);
 
     // If all else is equal, prefer lower states in earlier bound pieces.
-    for (var piece in _state._pieceStates.keys) {
-      var thisState = _state.pieceState(piece);
-      var otherState = other._state.pieceState(piece);
+    for (var piece in _stateSet._pieceStates.keys) {
+      var thisState = _stateSet.pieceState(piece);
+      var otherState = other._stateSet.pieceState(piece);
       if (thisState != otherState) return thisState.compareTo(otherState);
     }
 
@@ -199,7 +199,7 @@ class Solution implements Comparable<Solution> {
       '\$$cost',
       if (overflow > 0) '($overflow over)',
       if (!isValid) '(invalid)',
-      '$_state',
+      '$_stateSet',
     ].join(' ');
   }
 }

--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -158,15 +158,11 @@ class Solution implements Comparable<Solution> {
   /// piece and yields further solutions for each state that piece can have.
   List<Solution> expand(Piece root, int pageWidth) {
     if (_nextPieceToExpand case var piece?) {
-      var result = <Solution>[];
-      for (var state in piece.states) {
-        var stateSet = _state.tryBind(piece, state);
-        if (stateSet != null) {
-          result.add(Solution._(root, pageWidth, stateSet));
-        }
-      }
-
-      return result;
+      return [
+        for (var state in piece.states)
+          if (_state.tryBind(piece, state) case final stateSet?)
+            Solution._(root, pageWidth, stateSet)
+      ];
     }
 
     // No piece we can expand.

--- a/lib/src/back_end/solver.dart
+++ b/lib/src/back_end/solver.dart
@@ -34,27 +34,10 @@ class Solver {
 
   Solver(this._pageWidth);
 
-  /// Finds the best set of line splits for [piece] and returns the resulting
-  /// formatted code.
-  Solution format(Piece piece) {
-    // Collect all of the pieces with states that can be selected.
-    var unsolvedPieces = <Piece>[];
-
-    void traverse(Piece piece) {
-      // We don't need to worry about selecting pieces that have only one state.
-      if (piece.states.length > 1) unsolvedPieces.add(piece);
-      piece.forEachChild(traverse);
-    }
-
-    traverse(piece);
-
-    return _solve(piece, unsolvedPieces);
-  }
-
-  /// Finds the best solution for the piece tree starting at [root] with
-  /// selectable [pieces].
-  Solution _solve(Piece root, List<Piece> pieces) {
-    var solution = Solution.initial(root, _pageWidth, pieces);
+  /// Finds the best set of line splits for [root] piece and returns the
+  /// resulting formatted code.
+  Solution format(Piece root) {
+    var solution = Solution.initial(root, _pageWidth);
     _queue.add(solution);
 
     // The lowest cost solution found so far that does overflow.

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -4,6 +4,8 @@
 
 import '../back_end/code_writer.dart';
 
+typedef Constrain = void Function(Piece other, State constrainedState);
+
 /// Base class for the formatter's internal representation used for line
 /// splitting.
 ///
@@ -47,6 +49,14 @@ abstract class Piece {
   /// when surrounded by or containing other conditionals.
   State? get pinnedState => _pinnedState;
   State? _pinnedState;
+
+  /// Apply any constraints that this piece places on other pieces when this
+  /// piece is bound to [state].
+  ///
+  /// A piece class can override this. For any child piece that it wants to
+  /// constrain when this piece is in [state], call [constrain] and pass in the
+  /// child piece and the state that child should be constrained to.
+  void applyConstraints(State state, Constrain constrain) {}
 
   /// Given that this piece is in [state], use [writer] to produce its formatted
   /// output.


### PR DESCRIPTION
When I added support for constructors, I introduced a little API to let pieces enforce constraints between their state and the states of other child pieces. It worked but felt a little bolted on. In particular, enforcing the constraints during CodeWriter formatting meant we didn't prune invalid solutions as efficiently as we could.

I'm working on if elements now and I needed a better way to handle constraints between pieces for that, so I went ahead and refactored the way this works to be, I think, generally better:

- Enforce constraints between pieces during solution expansion instead of during formatting. This means that we eagerly discard any solution (and the whole tree of solutions that could have come from it) if it doesn't meet the constraints.

- Remove the `_pieces` fields in PieceStateSet. With the previous optimization to track the next unsolved piece in Solution, that list wasn't doing much of anything. It's only use (aside from debug output) was for determining the order that pieces are compared when comparing two solutions. But we can get that from iterating over the _pieceStates map since maps in Dart track their key insertion order.

- Update ConstructorPiece to use this new API.
