### PR TITLE
Format function references.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -874,7 +874,10 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitFunctionReference(FunctionReference node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      b.visit(node.function);
+      b.visit(node.typeArguments);
+    });
   }
 
   @override

--- a/test/type/function.stmt
+++ b/test/type/function.stmt
@@ -218,3 +218,65 @@ longMethod({
   required int
   reallyLongParameterNameWow,
 }) {}
+>>> Unsplit generic method instantiation.
+void main() => id  < int   > ;
+<<<
+void main() => id<int>;
+>>> Unsplit generic function reference, multiple type arguments.
+void main() => id  < int , String  , bool   > ;
+<<<
+void main() => id<int, String, bool>;
+>>> Unsplit generic constructor tear-off.
+var x = Class  < int  >;
+<<<
+var x = Class<int>;
+>>> Split generic function reference between arguments.
+LongClassName<First, Second, Third, Fourth>;
+<<<
+LongClassName<
+  First,
+  Second,
+  Third,
+  Fourth
+>;
+>>> Split generic function references, one type argument per line.
+LongClassName<First, Second, Third, Fourth, Fifth, Sixth, Seventh, Eighth>;
+<<<
+LongClassName<
+  First,
+  Second,
+  Third,
+  Fourth,
+  Fifth,
+  Sixth,
+  Seventh,
+  Eighth
+>;
+>>> Split generic function reference with nested type arguments.
+LongClassName<First, Inner<Second, Third, Fourth, Fifth, Sixth, Seventh>, Eighth>;
+<<<
+LongClassName<
+  First,
+  Inner<
+    Second,
+    Third,
+    Fourth,
+    Fifth,
+    Sixth,
+    Seventh
+  >,
+  Eighth
+>;
+>>> Split generic function reference nested inside expression.
+veryLongFunction(argument, ConstructorTearOff<First, Second, Third, Fourth>, argument);
+<<<
+veryLongFunction(
+  argument,
+  ConstructorTearOff<
+    First,
+    Second,
+    Third,
+    Fourth
+  >,
+  argument,
+);


### PR DESCRIPTION
Small PR to format function references -- really just builds upon type argument formatting.
I also migrated previous function reference tests over.