### PR TITLE
Change code blocks to use indentation instead of backticks.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -131,27 +131,21 @@ extension ExpressionExtensions on Expression {
   /// example, in an assignment, a split in the assigned value is usually
   /// indented:
   ///
-  /// ```
-  /// var variableName =
-  ///     longValue;
-  /// ```
+  ///     var variableName =
+  ///         longValue;
   ///
   /// But if the initializer is block-like, we don't split at the `=`:
   ///
-  /// ```
-  /// var variableName = [
-  ///   element,
-  /// ];
-  /// ```
+  ///     var variableName = [
+  ///       element,
+  ///     ];
   ///
   /// Likewise, in an argument list, block-like expressions can avoid splitting
   /// the surrounding argument list:
   ///
-  /// ```
-  /// function([
-  ///   element,
-  /// ]);
-  /// ```
+  ///     function([
+  ///       element,
+  ///     ]);
   ///
   /// Completely empty delimited constructs like `[]` and `foo()` don't allow
   /// splitting inside them, so are not considered block-like.
@@ -165,21 +159,17 @@ extension ExpressionExtensions on Expression {
     // TODO(tall): We should also allow multi-line strings to be formatted
     // like block arguments, at least in some cases like:
     //
-    // ```
-    // function('''
-    //   Lots of
-    //   text
-    // ''');
-    // ```
+    //     function('''
+    //       Lots of
+    //       text
+    //     ''');
 
     // TODO(tall): Consider whether immediately-invoked function expressions
     // should be block argument candidates, like:
     //
-    // ```
-    // function(() {
-    //   body;
-    // }());
-    // ```
+    //     function(() {
+    //       body;
+    //     }());
     return switch (expression) {
       // A function expression can use either a non-empty parameter list or a
       // non-empty block body for block formatting.

--- a/lib/src/comment_type.dart
+++ b/lib/src/comment_type.dart
@@ -20,9 +20,7 @@ enum CommentType {
   /// preceding the `/*`, after the `*/`, or both. An inline block comment
   /// may be multiple lines, as in:
   ///
-  /// ```
-  /// code /* comment
-  ///   more */
-  /// ```
+  ///     code /* comment
+  ///       more */
   inlineBlock,
 }

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -631,9 +631,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
     if (node.parameters case var parameters?) {
       // A function-typed field formal like:
       //
-      // ```
-      // C(this.fn(parameter));
-      // ```
+      //     C(this.fn(parameter));
       return createFunctionType(
           node.type,
           fieldKeyword: node.thisKeyword,
@@ -721,15 +719,13 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
         // where each clause is a separate argument. This means that when they
         // split, they split like:
         //
-        // ```
-        // for (
-        //   initializerClause;
-        //   conditionClause;
-        //   incrementClause
-        // ) {
-        //   body;
-        // }
-        // ```
+        //     for (
+        //       initializerClause;
+        //       conditionClause;
+        //       incrementClause
+        //     ) {
+        //       body;
+        //     }
         var partsList =
             DelimitedListBuilder(this, const ListStyle(commas: Commas.none));
         partsList.leftBracket(node.leftParenthesis);
@@ -779,13 +775,11 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
         // If a for-in loop, treat the for parts like an assignment, so they
         // split like:
         //
-        // ```
-        // for (var variable in [
-        //   initializer,
-        // ]) {
-        //   body;
-        // }
-        // ```
+        //     for (var variable in [
+        //       initializer,
+        //     ]) {
+        //       body;
+        //     }
         forPartsPiece = buildPiece((b) {
           b.token(node.leftParenthesis);
           b.add(createAssignment(
@@ -1036,12 +1030,10 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
       // Edge case: When the then branch is a block and there is an else clause
       // after it, we want to force the block to split even if empty, like:
       //
-      // ```
-      // if (condition) {
-      // } else {
-      //   body;
-      // }
-      // ```
+      //     if (condition) {
+      //     } else {
+      //       body;
+      //     }
       var thenStatement = switch (ifStatement.thenStatement) {
         Block thenBlock when ifStatement.elseStatement != null =>
           createBlock(thenBlock, forceSplit: true),
@@ -1586,9 +1578,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
     if (node.parameters case var parameters?) {
       // A function-typed super parameter like:
       //
-      // ```
-      // C(super.fn(parameter));
-      // ```
+      //     C(super.fn(parameter));
       return createFunctionType(
           node.type,
           fieldKeyword: node.superKeyword,

--- a/lib/src/front_end/comment_writer.dart
+++ b/lib/src/front_end/comment_writer.dart
@@ -193,15 +193,13 @@ class SourceComment {
 ///
 /// For example, this code:
 ///
-/// ```dart
-/// a /* c1 */
-/// /* c2 */
+///     a /* c1 */
+///     /* c2 */
 ///
-/// /* c3 */
+///     /* c3 */
 ///
 ///
-/// b
-/// ```
+///     b
 ///
 /// Produces a sequence like:
 ///

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -67,9 +67,7 @@ class DelimitedListBuilder {
   /// after [bracket]. This is used for parameter lists where all parameters
   /// are optional or named, as in:
   ///
-  /// ```
-  /// function([parameter]);
-  /// ```
+  ///     function([parameter]);
   ///
   /// Here, [bracket] will be `(` and [delimiter] will be `[`.
   void leftBracket(Token bracket, {Piece? preceding, Token? delimiter}) {
@@ -90,9 +88,7 @@ class DelimitedListBuilder {
   /// after [bracket]. This is used for parameter lists with optional or named
   /// parameters, like:
   ///
-  /// ```
-  /// function(mandatory, {named});
-  /// ```
+  ///     function(mandatory, {named});
   ///
   /// Here, [bracket] will be `)` and [delimiter] will be `}`.
   ///
@@ -107,13 +103,11 @@ class DelimitedListBuilder {
     // bracket. If there is a delimiter, this will move comments between it and
     // the bracket to before the delimiter, as in:
     //
-    // ```
-    // // Before:
-    // f([parameter] /* comment */) {}
+    //     // Before:
+    //     f([parameter] /* comment */) {}
     //
-    // // After:
-    // f([parameter /* comment */]) {}
-    // ```
+    //     // After:
+    //     f([parameter /* comment */]) {}
     if (delimiter != null) {
       commentsBefore = _visitor.comments
           .takeCommentsBefore(delimiter)
@@ -188,15 +182,11 @@ class DelimitedListBuilder {
     // Preserve any comments before the delimiter. Treat them as occurring
     // before the previous element's comma. This means that:
     //
-    // ```
-    // function(p1, /* comment */ [p1]);
-    // ```
+    //     function(p1, /* comment */ [p1]);
     //
     // Will be formatted as:
     //
-    // ```
-    // function(p1 /* comment */, [p1]);
-    // ```
+    //     function(p1 /* comment */, [p1]);
     //
     // (In practice, it's such an unusual place for a comment that it doesn't
     // matter that much where it goes and this seems to be simple and
@@ -280,13 +270,11 @@ class DelimitedListBuilder {
   ///
   /// For example:
   ///
-  /// ```
-  /// function(
-  ///   argument /* inline */, // hanging
-  ///   // separate
-  ///   /* leading */ nextArgument
-  /// );
-  /// ```
+  ///     function(
+  ///       argument /* inline */, // hanging
+  ///       // separate
+  ///       /* leading */ nextArgument
+  ///     );
   ///
   /// Calculating these takes into account whether there are newlines before or
   /// after the comments, and which side of the commas the comments appear on.
@@ -322,12 +310,10 @@ class DelimitedListBuilder {
     // Inline block comments before the `,` stay with the preceding element, as
     // in:
     //
-    // ```
-    // function(
-    //   argument /* hanging */ /* comment */,
-    //   argument,
-    // );
-    // ```
+    //     function(
+    //       argument /* hanging */ /* comment */,
+    //       argument,
+    //     );
     var inlineCommentCount = 0;
     if (_elements.isNotEmpty) {
       while (inlineCommentCount < _commentsBeforeComma.length) {
@@ -361,12 +347,10 @@ class DelimitedListBuilder {
     // Inline block comments on the same line as the next element lead at the
     // beginning of that line, as in:
     ///
-    // ```
-    // function(
-    //   argument,
-    //   /* leading */ /* comment */ argument,
-    // );
-    // ```
+    //     function(
+    //       argument,
+    //       /* leading */ /* comment */ argument,
+    //     );
     var leadingCommentCount = 0;
     if (hasElementAfter && commentsBeforeElement.isNotEmpty) {
       while (leadingCommentCount < commentsBeforeElement.length) {
@@ -386,14 +370,12 @@ class DelimitedListBuilder {
     // Comments that are neither hanging nor leading are formatted like
     // separate elements, as in:
     //
-    // ```
-    // function(
-    //   argument,
-    //   /* comment */
-    //   argument,
-    //   // another
-    // );
-    // ```
+    //     function(
+    //       argument,
+    //       /* comment */
+    //       argument,
+    //       // another
+    //     );
     var separateComments =
         separateCommentsBeforeComma.concatenate(separateCommentsAfterComma);
 
@@ -433,13 +415,11 @@ class DelimitedListBuilder {
     // be it.
     // TODO(tall): The old formatter allows multiple block arguments, like:
     //
-    // ```
-    // function(() {
-    //   body;
-    // }, () {
-    //   more;
-    // });
-    // ```
+    //     function(() {
+    //       body;
+    //     }, () {
+    //       more;
+    //     });
     //
     // This doesn't seem very common in the Flutter repo, but does occur
     // sometimes. We'll probably want to experiment to see if it's worth

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -71,10 +71,8 @@ mixin PieceFactory {
   /// is used, for example, with empty blocks in `if` statements followed by
   /// `else` clauses:
   ///
-  /// ```
-  /// if (condition) {
-  /// } else {}
-  /// ```
+  ///     if (condition) {
+  ///     } else {}
   Piece createBody(
       Token leftBracket, List<AstNode> contents, Token rightBracket,
       {bool forceSplit = false}) {
@@ -104,10 +102,8 @@ mixin PieceFactory {
   /// is used, for example, with empty blocks in `if` statements followed by
   /// `else` clauses:
   ///
-  /// ```
-  /// if (condition) {
-  /// } else {}
-  /// ```
+  ///     if (condition) {
+  ///     } else {}
   Piece createBlock(Block block, {bool forceSplit = false}) {
     return createBody(block.leftBracket, block.statements, block.rightBracket,
         forceSplit: forceSplit);
@@ -133,12 +129,10 @@ mixin PieceFactory {
       // TODO(tall): Support a line comment inside a collection literal as a
       // signal to preserve internal newlines. So if you have:
       //
-      // ```
-      // var list = [
-      //   1, 2, 3, // comment
-      //   4, 5, 6,
-      // ];
-      // ```
+      //     var list = [
+      //       1, 2, 3, // comment
+      //       4, 5, 6,
+      //     ];
       //
       // The formatter will preserve the newline after element 3 and the lack of
       // them after the other elements.
@@ -380,14 +374,12 @@ mixin PieceFactory {
       // Edge case: When there's another catch/on/finally after this one, we
       // want to force the block to split even if it's empty.
       //
-      // ```
-      // try {
-      //   ..
-      // } on Foo {
-      // } finally Bar {
-      //   body;
-      // }
-      // ```
+      //     try {
+      //       ..
+      //     } on Foo {
+      //     } finally Bar {
+      //       body;
+      //     }
       var forceSplit = i < tryStatement.catchClauses.length - 1 ||
           tryStatement.finallyBlock != null;
       var catchClauseBody =

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -127,13 +127,11 @@ class PieceWriter {
         // non-hanging ones. Otherwise, we would end up dropping comment pieces
         // on the floor. So given:
         //
-        // ```
-        // before + // one
-        //    // two
-        //    // three
-        //    // four
-        //    after;
-        // ```
+        //     before + // one
+        //        // two
+        //        // three
+        //        // four
+        //        after;
         //
         // The pieces are:
         //
@@ -321,15 +319,11 @@ class PieceWriter {
   /// Removes any trailing whitespace from the selection. For example, if the
   /// original selection markers are:
   ///
-  /// ```
-  /// function(lotsOfSpac‹eAfter,     ›     andBefore);
-  /// ```
+  ///     function(lotsOfSpac‹eAfter,     ›     andBefore);
   ///
   /// Then this function moves the end marker to:
   ///
-  /// ```
-  /// function(lotsOfSpac‹eAfter,›          andBefore);
-  /// ```
+  ///     function(lotsOfSpac‹eAfter,›          andBefore);
   ///
   /// We do this because the formatter itself rewrites whitespace so it's not
   /// useful or even meaningful to try to preserve a selection's location within

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -17,25 +17,19 @@ import 'piece.dart';
 ///
 /// [State.unsplit] No split at all:
 ///
-/// ```
-/// var x = 123;
-/// ```
+///     var x = 123;
 ///
 /// If the value is a delimited "block-like" expression, then we allow splitting
 /// inside the value but not at the `=` with no additional indentation:
 ///
-/// ```
-/// var list = [
-///   element,
-/// ];
-/// ```
+///     var list = [
+///       element,
+///     ];
 ///
 /// [_atOperator] Split after the `=`:
 ///
-/// ```
-/// var name =
-///     longValueExpression;
-/// ```
+///     var name =
+///         longValueExpression;
 class AssignPiece extends Piece {
   /// Split after the operator.
   ///
@@ -60,21 +54,17 @@ class AssignPiece extends Piece {
   // TODO(tall): The old formatter allows the first operand of a split
   // conditional expression to be on the same line as the `=`, as in:
   //
-  // ```
-  // var value = condition
-  //     ? thenValue
-  //     : elseValue;
-  // ```
+  //     var value = condition
+  //         ? thenValue
+  //         : elseValue;
   //
   // It's not clear if this behavior is deliberate or not. It does look OK,
   // though. We could do the same thing here. If we do, I think it's worth
   // considering allowing the same thing for infix expressions too:
   //
-  // ```
-  // var value = operand +
-  //     operand +
-  //     operand;
-  // ```
+  //     var value = operand +
+  //         operand +
+  //         operand;
   //
   // For now, we do not implement this special case behavior. Once more of the
   // language is implemented in the new back end and we can run the formatter
@@ -84,21 +74,17 @@ class AssignPiece extends Piece {
   // If we don't do that, consider at least not adding another level of
   // indentation for subsequent operands in an infix operator chain. So prefer:
   //
-  // ```
-  // var value =
-  //     operand +
-  //     operand +
-  //     operand;
-  // ```
+  //     var value =
+  //         operand +
+  //         operand +
+  //         operand;
   //
   // Over:
   //
-  // ```
-  // var value =
-  //     operand +
+  //     var value =
   //         operand +
-  //         operand;
-  // ```
+  //             operand +
+  //             operand;
 
   @override
   List<State> get additionalStates => [_atOperator];

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -12,9 +12,7 @@ import 'piece.dart';
 
 /// A dotted series of property access or method calls, like:
 ///
-/// ```
-/// target.getter.method().another.method();
-/// ```
+///     target.getter.method().another.method();
 ///
 /// This piece handles splitting before the `.`.
 class ChainPiece extends Piece {

--- a/lib/src/piece/clause.dart
+++ b/lib/src/piece/clause.dart
@@ -13,59 +13,51 @@ import 'piece.dart';
 ///
 /// Clauses can be chained on one line if they all fit, like:
 ///
-/// ```
-/// import 'animals.dart' show Ant, Bat hide Cat, Dog;
-/// ```
+///     import 'animals.dart' show Ant, Bat hide Cat, Dog;
 ///
 /// Or can split before all of the clauses, like:
 ///
-/// ```
-/// import 'animals.dart'
-///     show Ant, Bat
-///     hide Cat, Dog;
-/// ```
+///     import 'animals.dart'
+///         show Ant, Bat
+///         hide Cat, Dog;
 ///
 /// They can also split before every item in any of the clauses. If they do so,
 /// then the clauses must split too. So these are allowed:
 ///
-/// ```
-/// import 'animals.dart'
-///     show
-///         Ant,
-///         Bat
-///     hide Cat, Dog;
+///     import 'animals.dart'
+///         show
+///             Ant,
+///             Bat
+///         hide Cat, Dog;
 ///
-/// import 'animals.dart'
-///     show Ant, Bat
-///     hide
-///         Cat,
-///         Dog;
+///     import 'animals.dart'
+///         show Ant, Bat
+///         hide
+///             Cat,
+///             Dog;
 ///
-/// import 'animals.dart'
-///     show
-///         Ant,
-///         Bat
-///     hide
-///         Cat,
-///         Dog;
-/// ```
+///     import 'animals.dart'
+///         show
+///             Ant,
+///             Bat
+///         hide
+///             Cat,
+///             Dog;
 ///
 /// But these are not:
 ///
-/// ```
-/// // Wrap list but not keyword:
-/// import 'animals.dart' show
-///         Ant,
-///         Bat
-///     hide Cat, Dog;
+///     // Wrap list but not keyword:
+///     import 'animals.dart' show
+///             Ant,
+///             Bat
+///         hide Cat, Dog;
 ///
-/// // Wrap one keyword but not both:
-/// import 'animals.dart'
-///     show Ant, Bat hide Cat, Dog;
+///     // Wrap one keyword but not both:
+///     import 'animals.dart'
+///         show Ant, Bat hide Cat, Dog;
 ///
-/// import 'animals.dart' show Ant, Bat
-///     hide Cat, Dog;
-/// ```
+///     import 'animals.dart' show Ant, Bat
+///         hide Cat, Dog;
 ///
 /// This ensures that when any wrapping occurs, the keywords are always at the
 /// beginning of the line.
@@ -82,12 +74,10 @@ class ClausesPiece extends Piece {
   /// a little specially because it's a deeper coupling to the class and so we
   /// want it to stay on the top line even if the other clauses split, like:
   ///
-  /// ```
-  /// class BaseClass extends Derived
-  ///     implements OtherThing {
-  ///   ...
-  /// }
-  /// ```
+  ///     class BaseClass extends Derived
+  ///         implements OtherThing {
+  ///       ...
+  ///     }
   final bool _allowLeadingClause;
 
   ClausesPiece(this._clauses, {bool allowLeadingClause = false})

--- a/lib/src/piece/constructor.dart
+++ b/lib/src/piece/constructor.dart
@@ -13,48 +13,40 @@ import 'piece.dart';
 ///
 /// [State.unsplit] No splits at all, in the parameters or initializers.
 ///
-/// ```
-///   SomeClass(param) : a = 1, b = 2;
-/// ```
+///       SomeClass(param) : a = 1, b = 2;
 ///
 /// [_splitBeforeInitializers] Split before the `:` and between the
 /// initializers but not in the parameters.
 ///
-/// ```
-///   SomeClass(param)
-///     : a = 1,
-///       b = 2;
-/// ```
+///       SomeClass(param)
+///         : a = 1,
+///           b = 2;
 ///
 /// [_splitBetweenInitializers] Split between the initializers but not before
 /// the `:`. This state should only be chosen when the parameters split. If
 /// there are no parameters, this state is excluded.
 ///
-/// ```
-///   SomeClass(
-///     param
-///   ) : a = 1,
-///       b = 2;
-/// ```
+///       SomeClass(
+///         param
+///       ) : a = 1,
+///           b = 2;
 ///
 /// In addition, this piece deals with indenting initializers appropriately
 /// based on whether the parameter list has a `]` or `}` before the `)`. If
 /// there are optional parameters, then initializers after the first are
 /// indented one space more to line up with the first initializer:
 ///
-/// ```
-/// SomeClass(
-///   mandatory,
-/// ) : firstInitializer = 1,
-///     second = 2;
-/// // ^ Four spaces of indentation.
+///     SomeClass(
+///       mandatory,
+///     ) : firstInitializer = 1,
+///         second = 2;
+///     // ^ Four spaces of indentation.
 ///
-/// SomeClass([
-///   optional,
-/// ]) : firstInitializer = 1,
-///      second = 2;
-/// //  ^ Five spaces of indentation.
-/// ```
+///     SomeClass([
+///       optional,
+///     ]) : firstInitializer = 1,
+///          second = 2;
+///     //  ^ Five spaces of indentation.
 class ConstructorPiece extends Piece {
   static const _splitBeforeInitializers = State(1, cost: 1);
 

--- a/lib/src/piece/for.dart
+++ b/lib/src/piece/for.dart
@@ -20,10 +20,8 @@ class ForPiece extends Piece {
   /// the body isn't a block, then we allow a discretionary split after the
   /// loop parts, as in:
   ///
-  /// ```
-  /// for (;;)
-  ///   print("ok");
-  /// ```
+  ///     for (;;)
+  ///       print("ok");
   final bool _hasBlockBody;
 
   ForPiece(this._forKeyword, this._forParts, this._body,

--- a/lib/src/piece/infix.dart
+++ b/lib/src/piece/infix.dart
@@ -7,9 +7,7 @@ import 'piece.dart';
 
 /// A piece for a series of binary expressions at the same precedence, like:
 ///
-/// ```
-/// a + b + c
-/// ```
+///     a + b + c
 class InfixPiece extends Piece {
   /// The series of operands.
   ///

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -19,28 +19,22 @@ import 'piece.dart';
 ///
 /// [State.split] Fully unsplit:
 ///
-/// ```
-/// function(argument, argument, argument);
-/// ```
+///     function(argument, argument, argument);
 ///
 /// If one of the elements is a "block element", then we allow newlines inside
 /// it to support output like:
 ///
-/// ```
-/// function(argument, () {
-///   blockElement;
-/// }, argument);
-/// ```
+///     function(argument, () {
+///       blockElement;
+///     }, argument);
 ///
 /// [_splitState] Split around all of the items:
 ///
-/// ```
-/// function(
-///   argument,
-///   argument,
-///   argument,
-/// );
-/// ```
+///     function(
+///       argument,
+///       argument,
+///       argument,
+///     );
 ///
 /// ListPieces are usually constructed using [createList()] or
 /// [DelimitedListBuilder].
@@ -160,12 +154,10 @@ class ListPiece extends Piece {
 /// comment piece represents an element with a hanging comment after the
 /// (potentially ommitted) comma:
 ///
-/// ```dart
-/// function(
-///   first,
-///   // Standalone.
-///   second, // Hanging.
-/// ```
+///     function(
+///       first,
+///       // Standalone.
+///       second, // Hanging.
 ///
 /// Here, `first` is a [ListElement] with only an element, `// Standalone.` is
 /// a [ListElement] with only a comment, and `second, // Hanging.` is a
@@ -186,12 +178,10 @@ final class ListElement {
   /// This is only used for parameter lists when an optional or named parameter
   /// section begins in the middle of the parameter list, like:
   ///
-  /// ```
-  /// function(
-  ///   int parameter1, [
-  ///   int parameter2,
-  /// ]);
-  /// ```
+  ///     function(
+  ///       int parameter1, [
+  ///       int parameter2,
+  ///     ]);
   String _delimiter = '';
 
   /// The hanging inline block and line comments that appear after the content.
@@ -202,11 +192,9 @@ final class ListElement {
   /// A list item may have hanging comments before and after the delimiter, as
   /// in:
   ///
-  /// ```
-  /// function(
-  ///   argument /* 1 */ /* 2 */, /* 3 */ /* 4 */ // 5
-  /// );
-  /// ```
+  ///     function(
+  ///       argument /* 1 */ /* 2 */, /* 3 */ /* 4 */ // 5
+  ///     );
   ///
   /// This field counts the number of comments that should be before the
   /// delimiter (here `,` and 2).
@@ -329,10 +317,8 @@ class ListStyle {
   /// split. This is false for most lists, but true for switch expression
   /// bodies:
   ///
-  /// ```
-  /// v = switch (e) { 1 => 'one', 2 => 'two' };
-  /// //              ^                      ^
-  /// ```
+  ///     v = switch (e) { 1 => 'one', 2 => 'two' };
+  ///     //              ^                      ^
   final bool spaceWhenUnsplit;
 
   /// Whether a split in the [_before] piece should force the list to split too.
@@ -343,41 +329,35 @@ class ListStyle {
   /// contains the type arguments. If those split, this is `false` to allow the
   /// list itself to remain unsplit as in:
   ///
-  /// ```
-  /// <
-  ///   VeryLongTypeName,
-  ///   AnotherLongTypeName,
-  /// >{a: 1};
-  /// ```
+  ///     <
+  ///       VeryLongTypeName,
+  ///       AnotherLongTypeName,
+  ///     >{a: 1};
   ///
   /// For switch expressions, the `switch (value) {` part is in [_before] and
   /// the body is the list. In that case, if the value splits, we want to force
   /// the body to split too:
   ///
-  /// ```
-  /// // Disallowed:
-  /// e = switch (
-  ///   "a long string that must wrap"
-  /// ) { 0 => "ok" };
+  ///     // Disallowed:
+  ///     e = switch (
+  ///       "a long string that must wrap"
+  ///     ) { 0 => "ok" };
   ///
-  /// // Instead:
-  /// e = switch (
-  ///   "a long string that must wrap"
-  /// ) {
-  ///   0 => "ok",
-  /// };
-  /// ```
+  ///     // Instead:
+  ///     e = switch (
+  ///       "a long string that must wrap"
+  ///     ) {
+  ///       0 => "ok",
+  ///     };
   final bool splitListIfBeforeSplits;
 
   /// Whether an element in the list is allowed to have block-like formatting,
   /// as in:
   ///
-  /// ```
-  /// function(argument, [
-  ///   block,
-  ///   like,
-  /// ], argument);
-  /// ```
+  ///     function(argument, [
+  ///       block,
+  ///       like,
+  ///     ], argument);
   final bool allowBlockElement;
 
   const ListStyle(

--- a/lib/src/piece/postfix.dart
+++ b/lib/src/piece/postfix.dart
@@ -11,12 +11,10 @@ import 'piece.dart';
 /// For example, an [ImportPiece] uses a [PostfixPiece] for the list of
 /// configurations:
 ///
-/// ```
-/// import 'foo.dart'
-///   if (a) 'foo_a.dart'
-///   if (b) 'foo_a.dart'
-///   if (c) 'foo_a.dart';
-/// ```
+///     import 'foo.dart'
+///       if (a) 'foo_a.dart'
+///       if (b) 'foo_a.dart'
+///       if (c) 'foo_a.dart';
 ///
 /// We either split before every `if` or none of them, and the [PostfixPiece]
 /// contains a piece for each configuration to model that.

--- a/lib/src/piece/variable.dart
+++ b/lib/src/piece/variable.dart
@@ -14,26 +14,20 @@ import 'piece.dart';
 /// Untyped variables never split after the keyword but do indent subsequent
 /// variables:
 ///
-/// ```
-/// var longVariableName = initializer,
-///     anotherVariable = anotherInitializer;
-/// ```
+///     var longVariableName = initializer,
+///         anotherVariable = anotherInitializer;
 ///
 /// Typed variables can split that way too:
 ///
-/// ```
-/// String longVariableName = initializer,
-///     anotherVariable = anotherInitializer;
-/// ```
+///     String longVariableName = initializer,
+///         anotherVariable = anotherInitializer;
 ///
 /// But they can also split after the type annotation. When that happens, the
 /// variables aren't indented:
 ///
-/// ```
-/// VeryLongTypeName
-/// longVariableName = initializer,
-/// anotherVariable = anotherInitializer;
-/// ```
+///     VeryLongTypeName
+///     longVariableName = initializer,
+///     anotherVariable = anotherInitializer;
 class VariablePiece extends Piece {
   /// Split between each variable in a multiple variable declaration.
   static const State _betweenVariables = State(1);


### PR DESCRIPTION
Not exactly the most impactful change. :) But in a previous PR, Nate suggested that old-style Markdown indentation for code blocks would be better than backticks since it's shorter and we aren't actually running the comments through a Markdown formatter anyway.

This converts all of them over in on Go so the codebase is consistent.
