### PR TITLE
Update TODO comment on for-in to consider how "in" should split.

### DIFF
--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -330,7 +330,11 @@ mixin PieceFactory {
         //     }
         //
         // Currently, the formatter prefers 1 over 3. We may want to revisit
-        // that and prefer 3 instead.
+        // that and prefer 3 instead. Or perhaps we shouldn't pass
+        // `allowInnerSplit: true` and force the `in` to split if the
+        // initializer does. That would be consistent with how we handle
+        // splitting before `case` when the pattern has a newline in an if-case
+        // statement or element.
         return buildPiece((b) {
           b.token(leftParenthesis);
           b.add(createAssignment(


### PR DESCRIPTION
In the old and new style, if a newline occurs in the pattern of an if-case statement or element, it forces a split before the `case` too. That syntax is structurally similar to for-in loops, but for-in loops currently don't force that split. (And I had to add explicit support to *not* force a split there.)

Update the TODO comment to consider whether we want to make for-in loops format similar to if-case.
