### PR TITLE
Format the experimental "macro" keyword before classes.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -256,6 +256,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
           node.interfaceKeyword,
           node.finalKeyword,
           node.sealedKeyword,
+          node.macroKeyword,
           node.mixinKeyword,
         ],
         node.classKeyword,

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -592,6 +592,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     modifier(node.finalKeyword);
     modifier(node.sealedKeyword);
     modifier(node.mixinKeyword);
+    modifier(node.macroKeyword);
     token(node.classKeyword);
     space();
     token(node.name);

--- a/test/declaration/class.unit
+++ b/test/declaration/class.unit
@@ -74,3 +74,10 @@ class SomeClass native "Zapp" {
 }
 <<<
 class SomeClass native "Zapp" {}
+>>> Macro class.
+macro  class  C {}
+abstract  macro  class D {}
+<<<
+macro class C {}
+
+abstract macro class D {}

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -151,8 +151,8 @@ void _testFile(
             indent: formatTest.leadingIndent,
             fixes: [...?baseFixes, ...formatTest.fixes],
             experimentFlags: useTallStyle
-                ? const ['inline-class', tallStyleExperimentFlag]
-                : const ['inline-class']);
+                ? const ['inline-class', 'macros', tallStyleExperimentFlag]
+                : const ['inline-class', 'macros']);
 
         var actual = formatter.formatSource(formatTest.input);
 

--- a/test/whitespace/classes.unit
+++ b/test/whitespace/classes.unit
@@ -244,3 +244,10 @@ abstract mixin class C12 = Object
     with Mixin;
 abstract base mixin class C13 = Object
     with Mixin;
+>>> macro class
+macro  class C1 {}
+abstract  macro  class C6 {}
+<<<
+macro class C1 {}
+
+abstract macro class C6 {}


### PR DESCRIPTION
In order to use this, you have to pass "--enable-experiment=macros" to the formatter (which the formatter tests now pass).

This adds support to both the old and new styles.