### PR TITLE
Prefer splitting before case in an if-case.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -956,10 +956,25 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
         b.token(ifStatement.ifKeyword);
         b.space();
         b.token(ifStatement.leftParenthesis);
-        b.add(buildPiece((b) {
-          b.visit(ifStatement.expression);
-          b.visit(ifStatement.caseClause, spaceBefore: true);
-        }));
+
+        // If the condition needs to split, we prefer splitting before the
+        // `case` keyword, like:
+        //
+        //     if (obj
+        //         case 123456789012345678901234567890) {
+        //       body;
+        //     }
+        var expressionPiece = nodePiece(ifStatement.expression);
+        if (ifStatement.caseClause case var caseClause?) {
+          var caseClausePiece = nodePiece(caseClause);
+          b.add(AssignPiece(
+            expressionPiece,
+            caseClausePiece,
+          ));
+        } else {
+          b.add(expressionPiece);
+        }
+
         b.token(ifStatement.rightParenthesis);
         b.space();
       });

--- a/test/statement/if_case.stmt
+++ b/test/statement/if_case.stmt
@@ -5,3 +5,17 @@ if (obj case true) {;}
 if (obj case true) {
   ;
 }
+>>> Split long expression before case.
+if (thisIsReallyQuiteAVeryLongVariableName case 1) {;}
+<<<
+if (thisIsReallyQuiteAVeryLongVariableName
+    case 1) {
+  ;
+}
+>>> Split long case clause before case.
+if (obj case 123456789012345678901234567890) {;}
+<<<
+if (obj
+    case 123456789012345678901234567890) {
+  ;
+}

--- a/test/statement/if_case_comment.stmt
+++ b/test/statement/if_case_comment.stmt
@@ -1,0 +1,27 @@
+40 columns                              |
+>>> Line comment before case keyword.
+if (obj // comment
+case true) {;}
+<<<
+if (obj // comment
+    case true) {
+  ;
+}
+>>> Line comment after case keyword.
+if (obj case // comment
+true) {;}
+<<<
+if (obj
+    case // comment
+    true) {
+  ;
+}
+>>> Line comment after case clause.
+if (obj case true // comment
+) {;}
+<<<
+if (obj
+    case true // comment
+    ) {
+  ;
+}


### PR DESCRIPTION
This is previous behaviour from the old formatter that would prefer splitting at the `case` keyword.
We want to retain this behaviour and I added a few tests for this.
We also need this because it seems to be used by most pattern tests.