### PR TITLE
Format declared variable pattern.

### DIFF
--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -173,7 +173,7 @@ class CodeWriter {
   ///
   /// Replaces any previous indentation set by this piece.
   ///
-  /// TODO(tall): Add another API that adds/subtracts existing indentation.
+  // TODO(tall): Add another API that adds/subtracts existing indentation.
   void setIndent(int indent) {
     _options.indent = _pieceOptions[_pieceOptions.length - 2].indent + indent;
   }

--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -172,6 +172,8 @@ class CodeWriter {
   /// piece to [indent], relative to the indentation of the surrounding piece.
   ///
   /// Replaces any previous indentation set by this piece.
+  ///
+  /// TODO(tall): Add another API that adds/subtracts existing indentation.
   void setIndent(int indent) {
     _options.indent = _pieceOptions[_pieceOptions.length - 2].indent + indent;
   }

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -452,17 +452,6 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitDeclaredVariablePattern(DeclaredVariablePattern node) {
-    // We don't need any splitting behavior if we don't have a type.
-    if (node.keyword != null && node.type == null) {
-      return buildPiece((b) {
-        b.modifier(node.keyword);
-        b.visit(node.type, spaceAfter: true);
-        b.token(node.name);
-      });
-    }
-
-    // Build a [VariablePiece] that can split between the type and the variable
-    // name.
     var header = buildPiece((b) {
       b.modifier(node.keyword);
       b.visit(node.type);
@@ -470,7 +459,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
     return VariablePiece(
       header,
       [tokenPiece(node.name)],
-      hasType: true,
+      hasType: node.type != null,
     );
   }
 

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -471,7 +471,6 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
       header,
       [tokenPiece(node.name)],
       hasType: true,
-      isDeclaredVarPattern: true,
     );
   }
 
@@ -979,6 +978,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
           b.add(AssignPiece(
             expressionPiece,
             caseClausePiece,
+            indentInValue: true,
           ));
         } else {
           b.add(expressionPiece);

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -452,7 +452,27 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitDeclaredVariablePattern(DeclaredVariablePattern node) {
-    throw UnimplementedError();
+    // We don't need any splitting behavior if we don't have a type.
+    if (node.keyword != null && node.type == null) {
+      return buildPiece((b) {
+        b.modifier(node.keyword);
+        b.visit(node.type, spaceAfter: true);
+        b.token(node.name);
+      });
+    }
+
+    // Build a [VariablePiece] that can split between the type and the variable
+    // name.
+    var header = buildPiece((b) {
+      b.modifier(node.keyword);
+      b.visit(node.type);
+    });
+    return VariablePiece(
+      header,
+      [tokenPiece(node.name)],
+      hasType: true,
+      isDeclaredVarPattern: true,
+    );
   }
 
   @override

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -48,8 +48,20 @@ class AssignPiece extends Piece {
   /// split at the assignment operator.
   final bool _allowInnerSplit;
 
-  AssignPiece(this.target, this.value, {bool allowInnerSplit = false})
-      : _allowInnerSplit = allowInnerSplit;
+  /// Whether there's an extra indent needed in the [value] piece when it
+  /// splits, like:
+  //
+  //    if (obj
+  //        case SomeLongTypeName
+  //            longVariableName) {
+  //      ;
+  //    }
+  final bool _indentInValue;
+
+  AssignPiece(this.target, this.value,
+      {bool allowInnerSplit = false, bool indentInValue = false})
+      : _allowInnerSplit = allowInnerSplit,
+        _indentInValue = indentInValue;
 
   // TODO(tall): The old formatter allows the first operand of a split
   // conditional expression to be on the same line as the `=`, as in:
@@ -102,6 +114,9 @@ class AssignPiece extends Piece {
 
     writer.format(target);
     writer.splitIf(state == _atOperator);
+    if (_indentInValue) {
+      writer.setIndent(Indent.expression * 2);
+    }
     writer.format(value);
   }
 

--- a/lib/src/piece/variable.dart
+++ b/lib/src/piece/variable.dart
@@ -45,12 +45,17 @@ class VariablePiece extends Piece {
   /// Whether the variable declaration has a type annotation.
   final bool _hasType;
 
+  /// Whether the variable piece is a declared variable pattern.
+  final bool _isDeclaredVarPattern;
+
   /// Creates a [VariablePiece].
   ///
   /// The [hasType] parameter should be `true` if the variable declaration has
   /// a type annotation.
-  VariablePiece(this._header, this._variables, {required bool hasType})
-      : _hasType = hasType;
+  VariablePiece(this._header, this._variables,
+      {required bool hasType, bool isDeclaredVarPattern = false})
+      : _hasType = hasType,
+        _isDeclaredVarPattern = isDeclaredVarPattern;
 
   @override
   List<State> get additionalStates => [
@@ -71,8 +76,18 @@ class VariablePiece extends Piece {
       writer.setAllowNewlines(false);
     }
 
+    // Declared variable patterns add an extra indentation if there's a split
+    // after the type, like:
+    //
+    //    if (obj
+    //        case SomeLongTypeName
+    //            longVariableName) {
+    //      ;
+    //    }
+    var splitIndent = _isDeclaredVarPattern ? Indent.expression : 0;
+
     // Split after the type annotation.
-    writer.splitIf(state == _afterType);
+    writer.splitIf(state == _afterType, indent: splitIndent);
 
     for (var i = 0; i < _variables.length; i++) {
       // Split between variables.

--- a/lib/src/piece/variable.dart
+++ b/lib/src/piece/variable.dart
@@ -45,17 +45,12 @@ class VariablePiece extends Piece {
   /// Whether the variable declaration has a type annotation.
   final bool _hasType;
 
-  /// Whether the variable piece is a declared variable pattern.
-  final bool _isDeclaredVarPattern;
-
   /// Creates a [VariablePiece].
   ///
   /// The [hasType] parameter should be `true` if the variable declaration has
   /// a type annotation.
-  VariablePiece(this._header, this._variables,
-      {required bool hasType, bool isDeclaredVarPattern = false})
-      : _hasType = hasType,
-        _isDeclaredVarPattern = isDeclaredVarPattern;
+  VariablePiece(this._header, this._variables, {required bool hasType})
+      : _hasType = hasType;
 
   @override
   List<State> get additionalStates => [
@@ -76,18 +71,8 @@ class VariablePiece extends Piece {
       writer.setAllowNewlines(false);
     }
 
-    // Declared variable patterns add an extra indentation if there's a split
-    // after the type, like:
-    //
-    //    if (obj
-    //        case SomeLongTypeName
-    //            longVariableName) {
-    //      ;
-    //    }
-    var splitIndent = _isDeclaredVarPattern ? Indent.expression : 0;
-
     // Split after the type annotation.
-    writer.splitIf(state == _afterType, indent: splitIndent);
+    writer.splitIf(state == _afterType);
 
     for (var i = 0; i < _variables.length; i++) {
       // Split between variables.

--- a/test/README.md
+++ b/test/README.md
@@ -69,6 +69,7 @@ declaration/  - Typedef, class, enum, extension, mixin, and member declarations.
                 directories below.
 expression/   - Expressions and collection elements.
 invocation/   - Function and member invocations.
+pattern/      - Patterns.
 selection/    - Test preserving selection information.
 statement/    - Statements.
 top_level/    - Top-level directives.

--- a/test/pattern/declared_variable.stmt
+++ b/test/pattern/declared_variable.stmt
@@ -1,19 +1,19 @@
 40 columns                              |
->>> no split after "var"
+>>> No split after "var".
 if (obj case var thisIsReallyQuiteAVeryLongVariableName) {;}
 <<<
 if (obj
     case var thisIsReallyQuiteAVeryLongVariableName) {
   ;
 }
->>> no split after "final"
+>>> No split after "final".
 if (obj case final thisIsReallyQuiteAVeryLongVariableName) {;}
 <<<
 if (obj
     case final thisIsReallyQuiteAVeryLongVariableName) {
   ;
 }
->>> no split between "final" and type
+>>> No split between "final" and type.
 if (obj case final ThisIsReallyQuiteAVeryLongTypeName variable) {;}
 <<<
 if (obj
@@ -21,7 +21,7 @@ if (obj
         variable) {
   ;
 }
->>> split between type and name
+>>> Split between type and name.
 if (obj case SomeLongTypeName longVariableName) {
   ;
 }

--- a/test/pattern/declared_variable.stmt
+++ b/test/pattern/declared_variable.stmt
@@ -1,0 +1,33 @@
+40 columns                              |
+>>> no split after "var"
+if (obj case var thisIsReallyQuiteAVeryLongVariableName) {;}
+<<<
+if (obj
+    case var thisIsReallyQuiteAVeryLongVariableName) {
+  ;
+}
+>>> no split after "final"
+if (obj case final thisIsReallyQuiteAVeryLongVariableName) {;}
+<<<
+if (obj
+    case final thisIsReallyQuiteAVeryLongVariableName) {
+  ;
+}
+>>> no split between "final" and type
+if (obj case final ThisIsReallyQuiteAVeryLongTypeName variable) {;}
+<<<
+if (obj
+    case final ThisIsReallyQuiteAVeryLongTypeName
+        variable) {
+  ;
+}
+>>> split between type and name
+if (obj case SomeLongTypeName longVariableName) {
+  ;
+}
+<<<
+if (obj
+    case SomeLongTypeName
+        longVariableName) {
+  ;
+}

--- a/test/pattern/declared_variable_comment.stmt
+++ b/test/pattern/declared_variable_comment.stmt
@@ -1,0 +1,37 @@
+40 columns                              |
+>>> Line comment before "var".
+if (obj case // c
+var x) {;}
+<<<
+if (obj
+    case // c
+        var x) {
+  ;
+}
+>>> Line comment after "var".
+if (obj case var // c
+x) {;}
+<<<
+if (obj
+    case var // c
+        x) {
+  ;
+}
+>>> Line comment after variable (looks weird, but user should move comment).
+if (obj case var x // c
+) {;}
+<<<
+if (obj
+    case var x // c
+        ) {
+  ;
+}
+>>> Line comment after type.
+if (obj case List<int> // c
+x) {;}
+<<<
+if (obj
+    case List<int> // c
+        x) {
+  ;
+}

--- a/test/pattern/declared_variable_comment.stmt
+++ b/test/pattern/declared_variable_comment.stmt
@@ -35,3 +35,14 @@ if (obj
         x) {
   ;
 }
+>>> Line comment after type, before long name.
+if (obj
+    case final // c
+    thisIsReallyQuiteAVeryLongVariableName) {
+  ;
+}
+<<<
+if (obj case final // c
+        thisIsReallyQuiteAVeryLongVariableName) {
+  ;
+}

--- a/test/statement/if_case_comment.stmt
+++ b/test/statement/if_case_comment.stmt
@@ -13,7 +13,7 @@ true) {;}
 <<<
 if (obj
     case // comment
-    true) {
+        true) {
   ;
 }
 >>> Line comment after case clause.
@@ -22,6 +22,6 @@ if (obj case true // comment
 <<<
 if (obj
     case true // comment
-    ) {
+        ) {
   ;
 }

--- a/test/tall_format_test.dart
+++ b/test/tall_format_test.dart
@@ -14,6 +14,7 @@ void main() async {
   await testDirectory('expression', tall: true);
   await testDirectory('function', tall: true);
   await testDirectory('invocation', tall: true);
+  await testDirectory('pattern', tall: true);
   await testDirectory('selection', tall: true);
   await testDirectory('statement', tall: true);
   await testDirectory('top_level', tall: true);


### PR DESCRIPTION
- Added a `pattern` test directory.
- Implemented `visitDeclaredVariablePattern`'s splitting using an `AssignPiece`.
- Added `_indentInValue` to `AssignPiece` which adds extra indentation to the `value` when split and should be used for all patterns that have the similar splitting and indenting as declared variable patterns.

Indentation for some of the comment cases are a little weird, like this one:
```dart
if (obj
    case true // comment
        ) {
  ;
}
```
But this is probably fine for how much this occurs.