### PR TITLE
Format multi-line strings and string interpolation.

### DIFF
--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -199,6 +199,15 @@ class CodeWriter {
         flushLeft: flushLeft);
   }
 
+  /// Queues [whitespace] to be written to the output.
+  ///
+  /// If any non-whitespace is written after this call, then this whitespace
+  /// will be written first. Also handles merging multiple kinds of whitespace
+  /// intelligently together.
+  ///
+  /// If [flushLeft] is `true`, then the new line begins at column 1 and ignores
+  /// any surrounding indentation. This is used for multi-line block comments
+  /// and multi-line strings.
   void whitespace(Whitespace whitespace, {bool flushLeft = false}) {
     if (whitespace case Whitespace.newline || Whitespace.blankLine) {
       _handleNewline();

--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -128,22 +128,6 @@ class CodeWriter {
         isValid: !_hasInvalidNewline, overflow: _overflow, cost: _cost);
   }
 
-  /// Notes that a newline has been written.
-  ///
-  /// If this occurs in a place where newlines are prohibited, then invalidates
-  /// the solution.
-  ///
-  /// This is called externally by [TextPiece] to let the writer know some of
-  /// the raw text contains a newline, which can happen in multi-line block
-  /// comments and multi-line string literals.
-  void handleNewline() {
-    if (!_options.allowNewlines) _hasInvalidNewline = true;
-
-    // Note that this piece contains a newline so that we can propagate that
-    // up to containing pieces too.
-    _options.hasNewline = true;
-  }
-
   /// Appends [text] to the output.
   ///
   /// If [text] contains any internal newlines, the caller is responsible for
@@ -204,16 +188,21 @@ class CodeWriter {
   ///
   /// If [indent] is given, set the indentation of the new line (and all
   /// subsequent lines) to that indentation relative to the containing piece.
-  void newline({bool blank = false, int? indent}) {
+  ///
+  /// If [flushLeft] is `true`, then the new line begins at column 1 and ignores
+  /// any surrounding indentation. This is used for multi-line block comments
+  /// and multi-line strings.
+  void newline({bool blank = false, int? indent, bool flushLeft = false}) {
     if (indent != null) setIndent(indent);
 
-    whitespace(blank ? Whitespace.blankLine : Whitespace.newline);
+    whitespace(blank ? Whitespace.blankLine : Whitespace.newline,
+        flushLeft: flushLeft);
   }
 
-  void whitespace(Whitespace whitespace) {
+  void whitespace(Whitespace whitespace, {bool flushLeft = false}) {
     if (whitespace case Whitespace.newline || Whitespace.blankLine) {
-      handleNewline();
-      _pendingIndent = _options.indent;
+      _handleNewline();
+      _pendingIndent = flushLeft ? 0 : _options.indent;
     }
 
     _pendingWhitespace = _pendingWhitespace.collapse(whitespace);
@@ -246,9 +235,7 @@ class CodeWriter {
     var childOptions = _pieceOptions.removeLast();
 
     // If the child [piece] contains a newline then this one transitively does.
-    // TODO(tall): At some point, we may want to provide an API so that pieces
-    // can block this from propagating outward.
-    if (childOptions.hasNewline) handleNewline();
+    if (childOptions.hasNewline) _handleNewline();
   }
 
   /// Format [piece] if not null.
@@ -270,6 +257,18 @@ class CodeWriter {
 
     _flushWhitespace();
     _selectionEnd = _buffer.length + end;
+  }
+
+  /// Notes that a newline has been written.
+  ///
+  /// If this occurs in a place where newlines are prohibited, then invalidates
+  /// the solution.
+  void _handleNewline() {
+    if (!_options.allowNewlines) _hasInvalidNewline = true;
+
+    // Note that this piece contains a newline so that we can propagate that
+    // up to containing pieces too.
+    _options.hasNewline = true;
   }
 
   /// Write any pending whitespace.

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1070,12 +1070,17 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitInterpolationExpression(InterpolationExpression node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      b.token(node.leftBracket);
+      b.visit(node.expression);
+      b.token(node.rightBracket);
+    });
   }
 
   @override
   Piece visitInterpolationString(InterpolationString node) {
-    throw UnimplementedError();
+    return pieces.stringLiteralPiece(node.contents,
+        isMultiline: (node.parent as StringInterpolation).isMultiline);
   }
 
   @override
@@ -1521,7 +1526,8 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitSimpleStringLiteral(SimpleStringLiteral node) {
-    return tokenPiece(node.literal);
+    return pieces.stringLiteralPiece(node.literal,
+        isMultiline: node.isMultiline);
   }
 
   @override
@@ -1534,7 +1540,11 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitStringInterpolation(StringInterpolation node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      for (var element in node.elements) {
+        b.visit(element);
+      }
+    });
   }
 
   @override

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -204,8 +204,11 @@ class PieceWriter {
   /// Writes multi-line [text] to the current [TextPiece].
   ///
   /// Handles breaking [text] into lines and adding them to the [TextPiece].
-  Piece _writeMultiLine(String lexeme, {required int offset}) {
-    var lines = lexeme.split(_lineTerminatorPattern);
+  ///
+  /// The [offset] parameter is the offset in the original source code of the
+  /// beginning of multi-line lexeme.
+  Piece _writeMultiLine(String text, {required int offset}) {
+    var lines = text.split(_lineTerminatorPattern);
     var currentOffset = offset;
     for (var i = 0; i < lines.length; i++) {
       if (i > 0) _currentText.newline(flushLeft: true);

--- a/test/expression/interpolation.stmt
+++ b/test/expression/interpolation.stmt
@@ -1,0 +1,82 @@
+40 columns                              |
+>>> Fix whitespace.
+" ${   interp+olate } and ${fn  (  1 ) } end";
+<<<
+" ${interp + olate} and ${fn(1)} end";
+>>> Allow splitting in interpolation if there is nowhere else.
+"some text that is long ${interpolate + a + thing} more";
+<<<
+"some text that is long ${interpolate +
+    a +
+    thing} more";
+>>> Prefer not splitting in interpolation.
+"first string ${has + interpolation}" + "another ${inter + polated}";
+<<<
+"first string ${has + interpolation}" +
+    "another ${inter + polated}";
+>>> Split interpolation in multi-line string.
+"""
+some text that is pretty long
+some more text that is pretty long ${    interpolate + a + thing   } more text
+""";
+<<<
+"""
+some text that is pretty long
+some more text that is pretty long ${interpolate +
+    a +
+    thing} more text
+""";
+>>> Split in nested interpolation.
+"some text that is ${pretty +  'long ${    interpolate +
+a + thing   } more'} text";
+<<<
+"some text that is ${pretty +
+    'long ${interpolate +
+        a +
+        thing} more'} text";
+>>> Mandatory newline in interpolation.
+"before ${(){statement();statement();statement();}} after";
+<<<
+"before ${() {
+  statement();
+  statement();
+  statement();
+}} after";
+>>> Deeply nested interpolation.
+'''a
+${b +
+"""c
+${d
++ '''e
+f'''
++
+g}
+h"""
++ i}
+j ${k
++
+l}''';
+<<<
+'''a
+${b +
+    """c
+${d +
+        '''e
+f''' +
+        g}
+h""" +
+    i}
+j ${k + l}''';
+>>> Line comment at beginning of interpolation.
+"before ${// comment
+a + b} after";
+<<<
+"before ${ // comment
+a + b} after";
+>>> Line comment inside interpolation.
+"before ${
+a + // comment
+b} after";
+<<<
+"before ${a + // comment
+    b} after";

--- a/test/expression/string.stmt
+++ b/test/expression/string.stmt
@@ -72,7 +72,7 @@ multiline
 multiline
 """;
 }
->>>
+>>> Only indent the first line of multiline strings.
 main() {
   inner() {
     function("""

--- a/test/expression/string.stmt
+++ b/test/expression/string.stmt
@@ -1,0 +1,88 @@
+40 columns                              |
+>>> Long single-line.
+"this string is longer than forty characters";
+<<<
+"this string is longer than forty characters";
+>>> Empty multi-line.
+{""""""; '''''';}
+<<<
+{
+  """""";
+  '''''';
+}
+>>> Blank lines in multi-line.
+'''
+
+
+two before
+
+one
+
+
+two
+
+
+''';
+<<<
+'''
+
+
+two before
+
+one
+
+
+two
+
+
+''';
+>>> Short one line multi-line.
+"""not too long""";
+<<<
+"""not too long""";
+>>> Multi-line with short lines.
+"""
+not too long
+or this one
+""";
+<<<
+"""
+not too long
+or this one
+""";
+>>> Multi-line with long lines.
+"""
+this string is longer than forty characters
+this one is also is longer than forty characters
+""";
+<<<
+"""
+this string is longer than forty characters
+this one is also is longer than forty characters
+""";
+>>> Only indent the first line of multiline strings.
+{
+"""
+multiline
+""";
+}
+<<<
+{
+  """
+multiline
+""";
+}
+>>>
+main() {
+  inner() {
+    function("""
+string""");
+  }
+}
+<<<
+main() {
+  inner() {
+    function("""
+string""");
+  }
+}

--- a/test/expression/string_comment.stmt
+++ b/test/expression/string_comment.stmt
@@ -1,0 +1,72 @@
+40 columns                              |
+### Since both comments and multi-line strings involve adding lines to the same
+### TextPiece, make sure they don't get confused.
+>>> Line comment before indented multi-line string.
+{{
+before +
+// comment 1
+// comment 2
+// comment 3
+"""multi
+line
+string
+""";
+}}
+<<<
+{
+  {
+    before +
+        // comment 1
+        // comment 2
+        // comment 3
+        """multi
+line
+string
+""";
+  }
+}
+>>> Line comment after indented multi-line string.
+{{
+"""multi
+line
+string
+""" // comment 1
+// comment 2
+// comment 3
++ after;
+}}
+<<<
+{
+  {
+    """multi
+line
+string
+""" // comment 1
+        // comment 2
+        // comment 3
+        +
+        after;
+  }
+}
+>>> Line comment after indented multi-line string.
+{{
+"""multi
+line
+string
+""" + // comment 1
+// comment 2
+// comment 3
+after;
+}}
+<<<
+{
+  {
+    """multi
+line
+string
+""" + // comment 1
+        // comment 2
+        // comment 3
+        after;
+  }
+}

--- a/test/invocation/block_argument_multiple.stmt
+++ b/test/invocation/block_argument_multiple.stmt
@@ -64,3 +64,12 @@ function(switch (a) {}, switch (b) { 1 => 2 }, switch (c) {});
 function(switch (a) {}, switch (b) {
   1 => 2,
 }, switch (c) {});
+>>> Collection and multi-line string prevents block formatting.
+function([element, element], '''multiple
+lines''');
+<<<
+function(
+  [element, element],
+  '''multiple
+lines''',
+);

--- a/test/invocation/block_argument_string.stmt
+++ b/test/invocation/block_argument_string.stmt
@@ -1,0 +1,97 @@
+40 columns                              |
+### Test multi-line strings as block arguments.
+>>> Allow block formatting a multi-line string.
+someMethod("""first line fits in here
+more stuff down here too that is long
+""");
+<<<
+someMethod("""first line fits in here
+more stuff down here too that is long
+""");
+>>>
+someMethod('''first line fits in here
+more stuff down here too that is long
+''');
+<<<
+someMethod('''first line fits in here
+more stuff down here too that is long
+''');
+>>> Allow block formatting a multi-line string with interpolation.
+someMethod("""first line fits in here
+more stuff $down here too that is long
+""");
+<<<
+someMethod("""first line fits in here
+more stuff $down here too that is long
+""");
+>>>
+someMethod('''first line fits in here
+more stuff ${down + here} that is long
+''');
+<<<
+someMethod('''first line fits in here
+more stuff ${down + here} that is long
+''');
+>>> Don't block format if first line doesn't fit.
+someMethod("""first line does not fit here
+""");
+<<<
+someMethod(
+  """first line does not fit here
+""",
+);
+>>> Block format multi-line string with non-block arguments before.
+someMethod("foo", "bar", """
+some
+text
+""");
+<<<
+someMethod("foo", "bar", """
+some
+text
+""");
+>>> Block format multi-line string with non-block arguments after.
+someMethod("""
+some
+text
+""", "foo", "bar");
+<<<
+someMethod("""
+some
+text
+""", "foo", "bar");
+>>> Block format multi-line string with non-block arguments before and after.
+someMethod("foo", """
+some
+text
+""",
+"bar");
+<<<
+someMethod("foo", """
+some
+text
+""", "bar");
+>>> Can't have multiple block formatted multi-line strings.
+someMethod("""
+some
+text
+""", """
+some
+more
+""", """
+even more
+""");
+<<<
+someMethod(
+  """
+some
+text
+""",
+  """
+some
+more
+""",
+  """
+even more
+""",
+);

--- a/test/selection/selection.stmt
+++ b/test/selection/selection.stmt
@@ -49,6 +49,10 @@ sec‹ond"""  ;›
 <<<
 """first
 sec‹ond""";›
+>>> In string interpolation.
+foo(  "$fi‹rst",  "${  sec›ond  }" );
+<<<
+foo("$fi‹rst", "${sec›ond}");
 >>> Only whitespace in zero space selected.
 foo(  ‹  ›  argument);
 <<<

--- a/test/tall_format_test.dart
+++ b/test/tall_format_test.dart
@@ -29,16 +29,14 @@ void main() async {
   test('FormatterException.message() does not throw', () {
     // This is a regression test for #358 where an error whose position is
     // past the end of the source caused FormatterException to throw.
-    try {
-      DartFormatter().format('library');
-    } on FormatterException catch (err) {
-      var message = err.message();
-      expect(message, contains('Could not format'));
-    }
+    expect(
+        () => DartFormatter().format('library'),
+        throwsA(isA<FormatterException>().having(
+            (e) => e.message(), 'message', contains('Could not format'))));
   });
 
   test('FormatterException describes parse errors', () {
-    try {
+    expect(() {
       DartFormatter().format('''
 
       var a = some error;
@@ -47,12 +45,12 @@ void main() async {
       ''', uri: 'my_file.dart');
 
       fail('Should throw.');
-    } on FormatterException catch (err) {
-      var message = err.message();
-      expect(message, contains('my_file.dart'));
-      expect(message, contains('line 2'));
-      expect(message, contains('line 4'));
-    }
+    },
+        throwsA(isA<FormatterException>().having(
+            (e) => e.message(),
+            'message',
+            allOf(contains('Could not format'), contains('line 2'),
+                contains('line 4')))));
   });
 
   test('adds newline to unit', () {
@@ -73,14 +71,12 @@ void main() async {
   });
 
   test('fails if anything is after the statement', () {
-    try {
-      DartFormatter().formatStatement('var x = 1;;');
-
-      fail('Should throw.');
-    } on FormatterException catch (ex) {
-      expect(ex.errors.length, equals(1));
-      expect(ex.errors.first.offset, equals(10));
-    }
+    expect(
+        () => DartFormatter().formatStatement('var x = 1;;'),
+        throwsA(isA<FormatterException>()
+            .having((e) => e.errors.length, 'errors.length', equals(1))
+            .having((e) => e.errors.first.offset, 'errors.length.first.offset',
+                equals(10))));
   });
 
   test('preserves initial indent', () {

--- a/test/tall_format_test.dart
+++ b/test/tall_format_test.dart
@@ -5,6 +5,7 @@
 @TestOn('vm')
 library dart_style.test.tall_format_test;
 
+import 'package:dart_style/dart_style.dart';
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -20,7 +21,118 @@ void main() async {
   await testDirectory('type', tall: true);
   await testDirectory('variable', tall: true);
 
-  // TODO(tall): The old formatter_test.dart has tests here for things like
-  // trailing newlines. Port those over to the new style once it supports all
-  // the syntax those tests rely on.
+  test('throws a FormatterException on failed parse', () {
+    var formatter = DartFormatter();
+    expect(() => formatter.format('wat?!'), throwsA(isA<FormatterException>()));
+  });
+
+  test('FormatterException.message() does not throw', () {
+    // This is a regression test for #358 where an error whose position is
+    // past the end of the source caused FormatterException to throw.
+    try {
+      DartFormatter().format('library');
+    } on FormatterException catch (err) {
+      var message = err.message();
+      expect(message, contains('Could not format'));
+    }
+  });
+
+  test('FormatterException describes parse errors', () {
+    try {
+      DartFormatter().format('''
+
+      var a = some error;
+
+      var b = another one;
+      ''', uri: 'my_file.dart');
+
+      fail('Should throw.');
+    } on FormatterException catch (err) {
+      var message = err.message();
+      expect(message, contains('my_file.dart'));
+      expect(message, contains('line 2'));
+      expect(message, contains('line 4'));
+    }
+  });
+
+  test('adds newline to unit', () {
+    expect(DartFormatter().format('var x = 1;'), equals('var x = 1;\n'));
+  });
+
+  test('adds newline to unit after trailing comment', () {
+    expect(DartFormatter().format('library foo; //zamm'),
+        equals('library foo; //zamm\n'));
+  });
+
+  test('removes extra newlines', () {
+    expect(DartFormatter().format('var x = 1;\n\n\n'), equals('var x = 1;\n'));
+  });
+
+  test('does not add newline to statement', () {
+    expect(DartFormatter().formatStatement('var x = 1;'), equals('var x = 1;'));
+  });
+
+  test('fails if anything is after the statement', () {
+    try {
+      DartFormatter().formatStatement('var x = 1;;');
+
+      fail('Should throw.');
+    } on FormatterException catch (ex) {
+      expect(ex.errors.length, equals(1));
+      expect(ex.errors.first.offset, equals(10));
+    }
+  });
+
+  test('preserves initial indent', () {
+    var formatter = DartFormatter(indent: 3);
+    expect(
+        formatter.formatStatement('if (foo) {bar;}'),
+        equals('   if (foo) {\n'
+            '     bar;\n'
+            '   }'));
+  });
+
+  group('line endings', () {
+    test('uses given line ending', () {
+      // Use zero width no-break space character as the line ending. We have
+      // to use a whitespace character for the line ending as the formatter
+      // will throw an error if it accidentally makes non-whitespace changes
+      // as will occur
+      var lineEnding = '\t';
+      expect(DartFormatter(lineEnding: lineEnding).format('var i = 1;'),
+          equals('var i = 1;\t'));
+    });
+
+    test('infers \\r\\n if the first newline uses that', () {
+      expect(DartFormatter().format('var\r\ni\n=\n1;\n'),
+          equals('var i = 1;\r\n'));
+    });
+
+    test('infers \\n if the first newline uses that', () {
+      expect(DartFormatter().format('var\ni\r\n=\r\n1;\r\n'),
+          equals('var i = 1;\n'));
+    });
+
+    test('defaults to \\n if there are no newlines', () {
+      expect(DartFormatter().format('var i =1;'), equals('var i = 1;\n'));
+    });
+
+    test('handles Windows line endings in multiline strings', () {
+      expect(
+          DartFormatter(lineEnding: '\r\n').formatStatement('  """first\r\n'
+              'second\r\n'
+              'third"""  ;'),
+          equals('"""first\r\n'
+              'second\r\n'
+              'third""";'));
+    });
+  });
+
+  test('throws an UnexpectedOutputException on non-whitespace changes', () {
+    // Use an invalid line ending character to ensure the formatter will
+    // attempt to make non-whitespace changes.
+    var formatter = DartFormatter(lineEnding: '%');
+    expect(() => formatter.format('var i = 1;'),
+        throwsA(isA<UnexpectedOutputException>()));
+  });
 }


### PR DESCRIPTION
In the old style, the formatter has some special code to discard line splits that occur inside string interpolation expressions. That's largely for historical reasons because the formatter initially didn't support formatting of string interpolation expressions *at all* and I didn't want too much churn when adding support for formatting them.

In the new style here, we don't do that: The contents of a string interpolation expression are split like any other expression. In practice, it doesn't matter much since users generally reorganize their code to avoid long strings and splits in string interpolation. This way leads to less special case code in the formatter.

This change is somewhat large because I also reorganized how newlines inside lexemes are handled in general. Previously, TextPiece stored a list of "lines" to handle things like line comments preceding or following a token. But it was also possible for a single "line" string in that list to internally contain newline characters because of multi-line strings or block comments.

But those internal newlines also need to force surrounding code to split, so there was this "_containsNewline" bit that had to be plumbed through and tracked. Even so, there were latent bugs where the column calculation in CodeWriter would be incorrect if a line contained internal newlines because it just used to the length of the entire "line" string.

With this change, the "_lines" list in TextPiece really is a list of lines. We eagerly split any incoming lexeme into multiple lines before writing it to the TextPiece. I think the resulting code is simpler, it fixes the column calculation in CodeWriter, and it means the formatter will correctly normalize line endings even when they occur inside block comments or multiline strings.

This was a good time to test the line ending code, so I copied those existing tests over from short_format_test.dart. I went ahead and copied all of the unit tests from that file, even the ones not related to line endings, since they're all working and passing now.

This PR does *not* handle adjacent strings. Those have a decent amount of special handling not related to what's going on here, so I'll do those separately.
