### PR TITLE
Format list pattern and rest pattern.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -317,11 +317,9 @@ extension PatternExtensions on DartPattern {
   /// expressions that allows "block-like" formatting in some contexts.
   ///
   /// See [ExpressionExtensions.canBlockSplit].
-  bool get canBlockSplit {
-    return switch (this) {
-      ListPattern(:var elements, :var rightBracket) =>
-        elements.canSplit(rightBracket),
-      _ => false,
-    };
-  }
+  bool get canBlockSplit => switch (this) {
+        ListPattern(:var elements, :var rightBracket) =>
+          elements.canSplit(rightBracket),
+        _ => false,
+      };
 }

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -313,6 +313,10 @@ extension CascadeExpressionExtensions on CascadeExpression {
 }
 
 extension PatternExtensions on DartPattern {
+  /// Whether this expression is a non-empty delimited container for inner
+  /// expressions that allows "block-like" formatting in some contexts.
+  ///
+  /// See [ExpressionExtensions.canBlockSplit].
   bool get canBlockSplit {
     return switch (this) {
       ListPattern(:var elements, :var rightBracket) =>

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -311,3 +311,13 @@ extension CascadeExpressionExtensions on CascadeExpression {
     return true;
   }
 }
+
+extension PatternExtensions on DartPattern {
+  bool get canBlockSplit {
+    return switch (this) {
+      ListPattern(:var elements, :var rightBracket) =>
+        elements.canSplit(rightBracket),
+      _ => false,
+    };
+  }
+}

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -964,12 +964,17 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
         var expressionPiece = nodePiece(ifStatement.expression);
         if (ifStatement.caseClause case var caseClause?) {
           var caseClausePiece = nodePiece(caseClause);
-          // If the right-hand side can have block formatting, then a newline in
-          // it doesn't force the operator to split, as in:
+          // If the case clause can have block formatting, then a newline in
+          // it doesn't force the if-case to split before the `case` keyword,
+          // like:
           //
-          //    var list = [
-          //      element,
-          //    ];
+          //     if (obj case [
+          //       first,
+          //       second,
+          //       third,
+          //     ]) {
+          //       ;
+          //     }
           var allowInnerSplit = caseClause.guardedPattern.pattern.canBlockSplit;
           b.add(AssignPiece(
             expressionPiece,

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -157,6 +157,7 @@ class DelimitedListBuilder {
     var format = switch (element) {
       FunctionExpression() when element.canBlockSplit => BlockFormat.function,
       Expression() when element.canBlockSplit => BlockFormat.block,
+      DartPattern() when element.canBlockSplit => BlockFormat.block,
       _ => BlockFormat.none,
     };
 

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -119,9 +119,14 @@ mixin PieceFactory {
   }
 
   /// Creates a [ListPiece] for a collection literal.
-  Piece createCollection(Token? constKeyword, Token leftBracket,
-      List<AstNode> elements, Token rightBracket,
-      {TypeArgumentList? typeArguments, ListStyle style = const ListStyle()}) {
+  Piece createCollection(
+    Token leftBracket,
+    List<AstNode> elements,
+    Token rightBracket, {
+    Token? constKeyword,
+    TypeArgumentList? typeArguments,
+    ListStyle style = const ListStyle(),
+  }) {
     return buildPiece((b) {
       b.modifier(constKeyword);
       b.visit(typeArguments);

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -118,7 +118,7 @@ mixin PieceFactory {
     });
   }
 
-  /// Creates a [ListPiece] for a collection literal.
+  /// Creates a [ListPiece] for a collection literal or pattern.
   Piece createCollection(
     Token leftBracket,
     List<AstNode> elements,

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -114,7 +114,9 @@ class AssignPiece extends Piece {
 
     writer.format(target);
     writer.splitIf(state == _atOperator);
-    if (_indentInValue) {
+
+    // We need extra indentation when there's no inner splitting of the value.
+    if (!_allowInnerSplit && _indentInValue) {
       writer.setIndent(Indent.expression * 2);
     }
     writer.format(value);

--- a/test/pattern/list.stmt
+++ b/test/pattern/list.stmt
@@ -1,0 +1,91 @@
+40 columns                              |
+>>> Basic list patterns. 
+switch (obj) {
+case  [  ]  :
+case  <  int  >  [  ]  :
+case  [  2  ]  :
+case  [  2  ,  ]  :
+case  [  2  ,  3  ]  :
+  ok;
+}
+<<<
+switch (obj) {
+  case []:
+  case <int>[]:
+  case [2]:
+  case [2]:
+  case [2, 3]:
+    ok;
+}
+>>> Unsplit list.
+if (obj case [1, ...var x, 3]) {;}
+<<<
+if (obj case [1, ...var x, 3]) {
+  ;
+}
+>>> If it splits anywhere in the list, it splits at every element.
+if (obj case [first,second,third,fourth]) {;}
+<<<
+if (obj case [
+  first,
+  second,
+  third,
+  fourth,
+]) {
+  ;
+}
+>>> Unsplit short list even with a comma.
+if (obj case [1,]) {;}
+<<<
+if (obj case [1]) {
+  ;
+}
+>>> Nested list patterns don't force outer to split
+if (obj case [[1, 2], [[3]]]) {;}
+<<<
+if (obj case [[1, 2], [[3]]]) {
+  ;
+}
+>>> Split all elements and keep line comment on newline.
+if (obj case [
+  // yeah
+  a,b,c,
+  d,e,f,
+]) {;}
+<<<
+if (obj case [
+  // yeah
+  a,
+  b,
+  c,
+  d,
+  e,
+  f,
+]) {
+  ;
+}
+>>> Split in type argument, but not in the body.
+if (obj case <Map<VeryLongTypeArgument, VeryLongTypeArgument>>[e]) {;}
+<<<
+if (obj case <
+  Map<
+    VeryLongTypeArgument,
+    VeryLongTypeArgument
+  >
+>[e]) {
+  ;
+}
+>>> Split in type argument and body.
+if (obj case <Map<VeryLongTypeArgument, VeryLongTypeArgument>>[element,VeryLongElementElementElement]) {;}
+<<<
+if (obj case <
+  Map<
+    VeryLongTypeArgument,
+    VeryLongTypeArgument
+  >
+>[
+  element,
+  VeryLongElementElementElement,
+]) {
+  ;
+}


### PR DESCRIPTION
Changes
- Add an extension to `DartPattern` so we can block split `ListPattern`s.
- Implemented `visitListPattern` and `visitRestPattern`.
- Avoid extra indentation in `AssignPiece` when we are (inner) block splitting.
- Migrated existing list pattern tests.