### PR TITLE
Format adjacent strings.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -313,3 +313,60 @@ extension CascadeExpressionExtensions on CascadeExpression {
     return true;
   }
 }
+
+extension AdjacentStringsExtensions on AdjacentStrings {
+  /// Whether subsequent strings should be indented relative to the first
+  /// string.
+  ///
+  /// We generally want to indent adjacent strings because it can be confusing
+  /// otherwise when they appear in a list of expressions, like:
+  ///
+  ///     [
+  ///       "one",
+  ///       "two"
+  ///       "three",
+  ///       "four"
+  ///     ]
+  ///
+  /// Especially when these strings are longer, it can be hard to tell that
+  /// "three" is a continuation of the previous element.
+  ///
+  /// However, the indentation is distracting in places that don't suffer from
+  /// this ambiguity:
+  ///
+  ///     var description =
+  ///         "A very long description..."
+  ///             "this extra indentation is unnecessary.");
+  ///
+  /// To balance these, we omit the indentation when an adjacent string
+  /// expression is in a context where it's unlikely to be confusing.
+  bool get indentStrings {
+    bool hasOtherStringArgument(List<Expression> arguments) => arguments
+        .any((argument) => argument != this && argument is StringLiteral);
+
+    return switch (parent) {
+      ArgumentList(:var arguments) => hasOtherStringArgument(arguments),
+
+      // Treat asserts like argument lists.
+      Assertion(:var condition, :var message) =>
+        hasOtherStringArgument([condition, if (message != null) message]),
+
+      // Don't add extra indentation in a variable initializer or assignment:
+      //
+      //     var variable =
+      //         "no extra"
+      //         "indent";
+      VariableDeclaration() => false,
+      AssignmentExpression(:var rightHandSide) when rightHandSide == this =>
+        false,
+
+      // Don't indent when following `:`.
+      MapLiteralEntry(:var value) when value == this => false,
+      NamedExpression() => false,
+
+      // Don't indent when the body of a `=>` function.
+      ExpressionFunctionBody() => false,
+      _ => true,
+    };
+  }
+}

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -10,6 +10,7 @@ import '../ast_extensions.dart';
 import '../constants.dart';
 import '../dart_formatter.dart';
 import '../piece/adjacent.dart';
+import '../piece/adjacent_strings.dart';
 import '../piece/assign.dart';
 import '../piece/block.dart';
 import '../piece/constructor.dart';
@@ -110,7 +111,8 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitAdjacentStrings(AdjacentStrings node) {
-    throw UnimplementedError();
+    return AdjacentStringsPiece(node.strings.map(nodePiece).toList(),
+        indent: node.indentStrings);
   }
 
   @override

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -463,7 +463,7 @@ class DelimitedListBuilder {
 
       // A function expression takes precedence over other block arguments.
       case ([var blockArgument], _, _):
-      // Otherwise, if there is single block argument, it can be block formatted.
+      // Otherwise, if there one block argument, it can be block formatted.
       case ([], [var blockArgument], _):
         _elements[blockArgument].allowNewlines = true;
     }

--- a/lib/src/piece/adjacent_strings.dart
+++ b/lib/src/piece/adjacent_strings.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import '../back_end/code_writer.dart';
+import '../constants.dart';
+import 'piece.dart';
+
+/// Piece for a series of adjacent strings, like:
+///
+///     var message =
+///         'This is a long message '
+///         'split into multiple strings';
+class AdjacentStringsPiece extends Piece {
+  final List<Piece> _strings;
+
+  /// Whether string after the first should be indented.
+  final bool _indent;
+
+  AdjacentStringsPiece(this._strings, {bool indent = true}) : _indent = indent;
+
+  @override
+  void format(CodeWriter writer, State state) {
+    if (_indent) writer.setIndent(Indent.expression);
+
+    for (var i = 0; i < _strings.length; i++) {
+      if (i > 0) writer.newline();
+      writer.format(_strings[i]);
+    }
+  }
+
+  @override
+  void forEachChild(void Function(Piece piece) callback) {
+    _strings.forEach(callback);
+  }
+}

--- a/lib/src/piece/adjacent_strings.dart
+++ b/lib/src/piece/adjacent_strings.dart
@@ -13,7 +13,7 @@ import 'piece.dart';
 class AdjacentStringsPiece extends Piece {
   final List<Piece> _strings;
 
-  /// Whether string after the first should be indented.
+  /// Whether strings after the first should be indented.
   final bool _indent;
 
   AdjacentStringsPiece(this._strings, {bool indent = true}) : _indent = indent;

--- a/test/expression/string_adjacent.stmt
+++ b/test/expression/string_adjacent.stmt
@@ -1,0 +1,259 @@
+40 columns                              |
+>>> Always split even if there is no existing newline and they fit.
+var name = 'a'     'b''c';
+<<<
+var name =
+    'a'
+    'b'
+    'c';
+>>> Split when they don't fit too, of course.
+var name = "the first very long string" "the second very longstring";
+<<<
+var name =
+    "the first very long string"
+    "the second very longstring";
+>>> All adjacent strings split or don't split together.
+var text = "first" "second" "third" "fourth" "fifth";
+<<<
+var text =
+    "first"
+    "second"
+    "third"
+    "fourth"
+    "fifth";
+>>> Don't preserve newlines between adjacent strings.
+var name = "the first string"
+"the second string"
+
+
+
+"the third string";
+<<<
+var name =
+    "the first string"
+    "the second string"
+    "the third string";
+>>> Adjacent strings inside interpolation.
+var x = '${  "a"   "b"   }';
+<<<
+var x =
+    '${"a"
+        "b"}';
+>>> Don't indent in argument list if other arguments are not strings.
+function(notString, "adjacent" "string");
+<<<
+function(
+  notString,
+  "adjacent"
+  "string",
+);
+>>> Do indent if another argument is a string.
+function("string",notString,"adjacent" "string");
+<<<
+function(
+  "string",
+  notString,
+  "adjacent"
+      "string",
+);
+>>> Do indent if another argument is a string interpolation.
+function("${str}${ing}",notString,"adjacent" "string");
+<<<
+function(
+  "${str}${ing}",
+  notString,
+  "adjacent"
+      "string",
+);
+>>> Do indent if another argument is an adjacent string.
+function("adjacent" "string",notString,"adjacent" "string");
+<<<
+function(
+  "adjacent"
+      "string",
+  notString,
+  "adjacent"
+      "string",
+);
+>>> Don't indent in assert if other arguments are not strings.
+assert(
+    condition,
+    "adjacent"
+    "string");
+<<<
+assert(
+  condition,
+  "adjacent"
+  "string",
+);
+>>> Do indent in assert if other argument is a string.
+assert("condition","adjacent" "string");
+<<<
+assert(
+  "condition",
+  "adjacent"
+      "string",
+);
+>>> Do indent adjacent strings in lists.
+var list = ["adjacent""string"];
+<<<
+var list = [
+  "adjacent"
+      "string",
+];
+>>> Do indent adjacent strings in lists.
+var list = [
+  "adjacent"
+  "string",
+  "another"
+  "adjacent"
+  "string"
+];
+<<<
+var list = [
+  "adjacent"
+      "string",
+  "another"
+      "adjacent"
+      "string",
+];
+>>> Do indent in map keys.
+var map = {"adjacent" "string": value};
+<<<
+var map = {
+  "adjacent"
+          "string":
+      value,
+};
+>>> Don't indent in map values.
+var map = {key: "adjacent" "string"};
+<<<
+var map = {
+  key:
+      "adjacent"
+      "string",
+};
+>>> Do indent in sets.
+var set = {"adjacent" "string"};
+<<<
+var set = {
+  "adjacent"
+      "string",
+};
+>>> Do indent positional record fields.
+var record = ("adjacent" "string",);
+<<<
+var record = (
+  "adjacent"
+      "string",
+);
+>>> Don't indent in named record fields.
+var record = (field: "adjacent" "string",);
+<<<
+var record = (
+  field:
+      "adjacent"
+      "string",
+);
+>>> Indent only positional fields in a mixed record.
+var record = ("adjacent" "string", field: "another" "one", "third" "field");
+<<<
+var record = (
+  "adjacent"
+      "string",
+  field:
+      "another"
+      "one",
+  "third"
+      "field",
+);
+>>> Don't indent in `=>` body.
+main() => "adjacent"
+"string"
+"another";
+<<<
+main() =>
+    "adjacent"
+    "string"
+    "another";
+>>> Don't indent in long `=>` body.
+main() => "very very very very long adjacent"
+"string"
+"another";
+<<<
+main() =>
+    "very very very very long adjacent"
+    "string"
+    "another";
+>>> Don't indent in `=>` function expression.
+function(
+(parameter) => "string" "adjacent",
+(parameter) => "long long long long string" "adjacent",
+another);
+<<<
+function(
+  (parameter) =>
+      "string"
+      "adjacent",
+  (parameter) =>
+      "long long long long string"
+      "adjacent",
+  another,
+);
+>>> Indent in then branch of `?:`.
+var string = condition ? "adjacent"
+"string" : "other";
+<<<
+var string =
+    condition
+        ? "adjacent"
+            "string"
+        : "other";
+>>> Indent in else branch of `?:`.
+var string = condition ? "other" : "adjacent"
+"string";
+<<<
+var string =
+    condition
+        ? "other"
+        : "adjacent"
+            "string";
+>>> Don't indent in initializer.
+var longVariableName = "very long adjacent"
+"string";
+<<<
+var longVariableName =
+    "very long adjacent"
+    "string";
+>>> Don't indent in assignment.
+long.receiver.expression = "very long adjacent"
+"string";
+<<<
+long.receiver.expression =
+    "very long adjacent"
+    "string";
+>>>
+function(variable = "very long adjacent"
+"string");
+<<<
+function(
+  variable =
+      "very long adjacent"
+      "string",
+);
+>>> Don't indent inside named arguments.
+function(named: "adjacent"
+"string",
+another: "adjacent"
+"string"
+"more");
+<<<
+function(
+  named:
+      "adjacent"
+      "string",
+  another:
+      "adjacent"
+      "string"
+      "more",
+);

--- a/test/expression/string_adjacent_comment.stmt
+++ b/test/expression/string_adjacent_comment.stmt
@@ -1,0 +1,60 @@
+40 columns                              |
+>>> Line comment before adjacent string.
+string = // comment
+'adjacent' 'string';
+<<<
+string = // comment
+    'adjacent'
+    'string';
+>>> Line comment inside adjacent string.
+string = 'adjacent' // comment
+'string';
+<<<
+string =
+    'adjacent' // comment
+    'string';
+>>>
+string = 'adjacent'
+// comment
+'string';
+<<<
+string =
+    'adjacent'
+    // comment
+    'string';
+>>> Line comment after adjacent string.
+### Looks weird but users don't put comment here.
+string = 'adjacent' 'string' // comment
+;
+<<<
+string =
+    'adjacent'
+    'string' // comment
+    ;
+>>> Inline block comment before adjacent string.
+string = /* comment */ 'adjacent' 'string';
+<<<
+string = /* comment */
+    'adjacent'
+    'string';
+>>> Inline block comment inside adjacent string.
+string = 'adjacent' /* comment */ 'string';
+<<<
+string =
+    'adjacent' /* comment */
+    'string';
+>>>
+string = 'adjacent'
+/* comment */
+'string';
+<<<
+string =
+    'adjacent'
+    /* comment */
+    'string';
+>>> Inline block comment after adjacent string.
+string = 'adjacent' 'string' /* comment */;
+<<<
+string =
+    'adjacent'
+    'string' /* comment */;

--- a/test/invocation/block_argument_multiple.stmt
+++ b/test/invocation/block_argument_multiple.stmt
@@ -73,3 +73,70 @@ function(
   '''multiple
 lines''',
 );
+>>> Adjacent strings preceding a function expression doesn't prevent block formatting.
+test('First adjacent string' 'second adjacent string'
+'third adjacent string', () async {
+  ;
+});
+<<<
+test('First adjacent string'
+    'second adjacent string'
+    'third adjacent string', () async {
+  ;
+});
+>>> Don't block format a function with a preceding adjacent string if it doesn't fit.
+test('First adjacent string' 'second long adjacent string', () async {
+  ;
+});
+<<<
+test(
+  'First adjacent string'
+  'second long adjacent string',
+  () async {
+    ;
+  },
+);
+>>> Don't block format adjacent strings preceding a non-function block argument.
+test('First adjacent string'
+    'second adjacent string'
+    'third adjacent string', [
+  element1,
+  element2,
+  element3,
+  element4,
+]);
+<<<
+test(
+  'First adjacent string'
+  'second adjacent string'
+  'third adjacent string',
+  [
+    element1,
+    element2,
+    element3,
+    element4,
+  ],
+);
+>>> Other string arguments don't prevent block formatting.
+test('First string line 1' 'first string line 2', () {
+  ;
+}, 'Another simple string');
+<<<
+test('First string line 1'
+    'first string line 2', () {
+  ;
+}, 'Another simple string');
+>>> Other adjacent string arguments prevent block formatting.
+test('First string line 1' 'first string line 2', () {
+  ;
+}, 'Another adjacent' 'string argument');
+<<<
+test(
+  'First string line 1'
+      'first string line 2',
+  () {
+    ;
+  },
+  'Another adjacent'
+      'string argument',
+);


### PR DESCRIPTION
Most of this was fairly straightforward, but the two tricky bits are:

### 1. Deciding whether or not to indent

There are some rules around whether subsequent strings in the adjacent strings get indented or not. The answer is yes in some cases to avoid confusion:

```
var list = function(
  'string 1',
  'adjacent'
      'string 2',
  'string 3',
];
```

But not in others since it looks nicer to line them up when possible:

```
var description =
    'some text '
    'more text';
```

### 2. Handling `test()` and `group()`

It's really important that test functions don't end up fully split because doing so would lead to the inner function expression getting indented +2:

```
test('this looks good', () {
  body;
});

test(
  'this looks bad',
  () {
    body;
  },
);
```

Test descriptions often span multiple lines using adjacent strings:

```
test('this is a very long test description '
    'spanning multiple lines, () {
  body;
});
```

Normally, the newline inside the adjacent strings would cause the entire argument list to split. The old style handles that (I think) by allowing multiple block-formatted arguments and then treating both the adjacent strings and the function expressions as block arguments.

The new style currently only allows a single block argument (because in almost all of the Flutter code I found using block formatting, one argument was sufficient). So I chose a more narrowly targeted rule here where we allow adjacent strings to not prevent block formatting only if the adjacent strings are the first argument and the block argument is a function expression as the next argument.

I left a TODO to see if we want to iterate on that rule, but I think it works pretty well.

### Other stuff

Unlike the old style, I chose to always split between adjacent strings. The old style will preserve newlines there but if a user chooses to deliberately put multiple adjacent strings on the same line and they fit, it will honor it. That didn't seem useful to me, so now they just always split. I don't think adjacent strings ever look good on the same line.

I ended up moving the state to track which elements in a ListPiece out of ListPiece and into the ListElements themselves. I think it's clearer this way and will be easier to evolve if we end up supporting multiple block formatted elements in a single list.
