### PR TITLE
Format cascades.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -185,7 +185,12 @@ extension ExpressionExtensions on Expression {
 
       // Function calls can block split if their argument lists can.
       InstanceCreationExpression(:var argumentList) ||
-      MethodInvocation(:var argumentList) ||
+      MethodInvocation(:var argumentList) =>
+        argumentList.arguments.canSplit(argumentList.rightParenthesis),
+
+      // Note: Using a separate case instead of `||` for this type because
+      // Dart 3.0 reports an error that [argumentList] has a different type
+      // here than in the previous two clauses.
       FunctionExpressionInvocation(:var argumentList) =>
         argumentList.arguments.canSplit(argumentList.rightParenthesis),
 

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -218,7 +218,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitCascadeExpression(CascadeExpression node) {
-    throw UnimplementedError();
+    return ChainBuilder(this, node).build();
   }
 
   @override
@@ -1399,6 +1399,14 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitPropertyAccess(PropertyAccess node) {
+    // If there's no target, this is a section in a cascade.
+    if (node.target == null) {
+      return buildPiece((b) {
+        b.token(node.operator);
+        b.visit(node.propertyName);
+      });
+    }
+
     return ChainBuilder(this, node).build();
   }
 

--- a/lib/src/front_end/chain_builder.dart
+++ b/lib/src/front_end/chain_builder.dart
@@ -87,10 +87,8 @@ class ChainBuilder {
       //     target..cascade(
       //       argument,
       //     );
-      var blockCallIndex = switch (_calls) {
-        [..., ChainCall(canSplit: true)] => _calls.length - 1,
-        _ => -1,
-      };
+      var blockCallIndex =
+          _calls.length == 1 && _calls.single.canSplit ? 0 : -1;
 
       var chain = ChainPiece(_target, _calls,
           indent: Indent.cascade,

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -599,6 +599,7 @@ mixin PieceFactory {
     return buildPiece((b) {
       if (target != null) b.add(target);
       b.token(index.question);
+      b.token(index.period);
       b.token(index.leftBracket);
       b.visit(index.index);
       b.token(index.rightBracket);

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -108,13 +108,24 @@ class ChainPiece extends Piece {
   ///         .method();
   final bool _allowSplitInTarget;
 
+  /// How much to indent the chain when it splits.
+  ///
+  /// This is [Indent.expression] for regular chains and [Indent.cascade] for
+  /// cascades.
+  final int _indent;
+
   /// Creates a new ChainPiece.
   ///
   /// Instead of calling this directly, prefer using [ChainBuilder].
-  ChainPiece(
-      this._target, this._calls, this._leadingProperties, this._blockCallIndex,
-      {required bool allowSplitInTarget})
-      : _allowSplitInTarget = allowSplitInTarget,
+  ChainPiece(this._target, this._calls,
+      {int leadingProperties = 0,
+      int blockCallIndex = -1,
+      int indent = Indent.expression,
+      required bool allowSplitInTarget})
+      : _leadingProperties = leadingProperties,
+        _blockCallIndex = blockCallIndex,
+        _indent = indent,
+        _allowSplitInTarget = allowSplitInTarget,
         // If there are no calls, we shouldn't have created a chain.
         assert(_calls.isNotEmpty);
 
@@ -137,12 +148,12 @@ class ChainPiece extends Piece {
       case State.unsplit:
         writer.setAllowNewlines(_allowSplitInTarget);
       case _splitAfterProperties:
-        writer.setIndent(Indent.expression);
+        writer.setIndent(_indent);
         writer.setAllowNewlines(_allowSplitInTarget);
       case _blockFormatTrailingCall:
         writer.setAllowNewlines(_allowSplitInTarget);
       case State.split:
-        writer.setIndent(Indent.expression);
+        writer.setIndent(_indent);
     }
 
     writer.format(_target);

--- a/test/invocation/block_argument_kind.stmt
+++ b/test/invocation/block_argument_kind.stmt
@@ -165,6 +165,31 @@ function________________(new SomeClass());
 function________________(
   new SomeClass(),
 );
+>>> Function expression call.
+function((expression)(veryLongArgumentExpression));
+<<<
+function((expression)(
+  veryLongArgumentExpression,
+));
+>>> Zero-argument function expression call with block comment.
+function((expression)(/* long comment */));
+<<<
+function((expression)(
+  /* long comment */
+));
+>>> Zero-argument function expression call with line comment.
+function((expression)(// comment
+));
+<<<
+function((expression)(
+  // comment
+));
+>>> A zero-argument function expression call is not a block argument.
+function_______________________((expr)());
+<<<
+function_______________________(
+  (expr)(),
+);
 >>> Parenthesized expression where inner expression is a block argument.
 function((innerFunction(veryLongArgumentExpression)));
 <<<

--- a/test/invocation/cascade.stmt
+++ b/test/invocation/cascade.stmt
@@ -1,0 +1,227 @@
+40 columns                              |
+>>> Single cascade on same line.
+"foo"..toString();
+<<<
+"foo"..toString();
+>>> Split multiple cascades even if they fit.
+foo..fooBar()..toString();
+<<<
+foo
+  ..fooBar()
+  ..toString();
+>>> Split long single cascade but not after target.
+"foo"..toString(argument, argument, argument);
+<<<
+"foo"..toString(
+  argument,
+  argument,
+  argument,
+);
+>>> Split at target if single cascade doesn't fit.
+"some much longer string"..someLongMethod(argument, argument);
+<<<
+"some much longer string"
+  ..someLongMethod(argument, argument);
+>>> Split at target if single cascade doesn't fit.
+"some much longer string"..someLongMethod(argument, argument, argument);
+<<<
+"some much longer string"
+  ..someLongMethod(
+    argument,
+    argument,
+    argument,
+  );
+>>> Split multiple cascades even if the same name.
+list
+  ..add("baz")
+  ..add("bar");
+<<<
+list
+  ..add("baz")
+  ..add("bar");
+>>> Setters.
+foo..baz = 3..baz=5;
+<<<
+foo
+  ..baz = 3
+  ..baz = 5;
+>>> Don't indent contained block arguments if cascade doesn't split.
+"foo"..toString(() {body;});
+<<<
+"foo"..toString(() {
+  body;
+});
+>>> Indent contained block arguments if cascade splits.
+"foo"..another()..toString(() {body;});
+<<<
+"foo"
+  ..another()
+  ..toString(() {
+    body;
+  });
+>>> Split if receiver precedence isn't obvious.
+main() async {
+  // These are OK.
+  a = b..c();
+  a += b..c();
+  a.b..c();
+
+  // These are unclear.
+  a ? b : c..d();
+  a ?? b..c();
+  a && b..c();
+  a || b..c();
+  a == b..c();
+  a <= b..c();
+  a + b..c();
+  a / b..c();
+  a ^ b..c();
+  a << b..c();
+  -a..b();
+  !a..b();
+  --a..b();
+  await a..b();
+}
+<<<
+main() async {
+  // These are OK.
+  a = b..c();
+  a += b..c();
+  a.b..c();
+
+  // These are unclear.
+  a ? b : c
+    ..d();
+  a ?? b
+    ..c();
+  a && b
+    ..c();
+  a || b
+    ..c();
+  a == b
+    ..c();
+  a <= b
+    ..c();
+  a + b
+    ..c();
+  a / b
+    ..c();
+  a ^ b
+    ..c();
+  a << b
+    ..c();
+  -a
+    ..b();
+  !a
+    ..b();
+  --a
+    ..b();
+  await a
+    ..b();
+}
+>>> Omit split if single section on list literal.
+[veryLongElement,veryLongElement,veryLongElement,]..addAll(more);
+<<<
+[
+  veryLongElement,
+  veryLongElement,
+  veryLongElement,
+]..addAll(more);
+>>> Omit split if single section on map literal.
+var map = {1: veryLongElement,2: veryLongElement,3: veryLongElement,}..addAll(more);
+<<<
+var map = {
+  1: veryLongElement,
+  2: veryLongElement,
+  3: veryLongElement,
+}..addAll(more);
+>>> Omit split if single section on record literal.
+(veryLongElement,veryLongElement,veryLongElement,)..addAll(more);
+<<<
+(
+  veryLongElement,
+  veryLongElement,
+  veryLongElement,
+)..addAll(more);
+>>> Omit split if single section on function call.
+foo(veryLongElement,veryLongElement,veryLongElement)..addAll(more);
+<<<
+foo(
+  veryLongElement,
+  veryLongElement,
+  veryLongElement,
+)..addAll(more);
+>>> Omit split if single section on instance creation.
+new Foo(veryLongElement,veryLongElement,veryLongElement,)..addAll(more);
+<<<
+new Foo(
+  veryLongElement,
+  veryLongElement,
+  veryLongElement,
+)..addAll(more);
+>>> Omit split if single section on expression call.
+(foo)(veryLongElement,veryLongElement,veryLongElement,)..addAll(more);
+<<<
+(foo)(
+  veryLongElement,
+  veryLongElement,
+  veryLongElement,
+)..addAll(more);
+>>> Prefer splitting inside collection instead of at cascade.
+[element1, element2, element3]
+  ..cascade();
+<<<
+[
+  element1,
+  element2,
+  element3,
+]..cascade();
+>>> Don't force cascade to split on collection target if arg splits.
+[1, 2, 3, 4]..cascade(() {;});
+<<<
+[1, 2, 3, 4]..cascade(() {
+  ;
+});
+>>> Don't force cascade to split on collection target if target and arg split.
+[veryLongElement,veryLongElement,veryLongElement,]..cascade(() {;});
+<<<
+[
+  veryLongElement,
+  veryLongElement,
+  veryLongElement,
+]..cascade(() {
+  ;
+});
+>>> Null-aware getter.
+foo?..baz..baz;
+<<<
+foo
+  ?..baz
+  ..baz;
+>>> Null-aware setter.
+foo?..baz = 3..baz=5;
+<<<
+foo
+  ?..baz = 3
+  ..baz = 5;
+>>> Mixed null aware and regular cascades.
+foo?..a()..b()..c();
+<<<
+foo
+  ?..a()
+  ..b()
+  ..c();
+>>> Cascade index.
+object..[index]..method()..[index]=value;
+<<<
+object
+  ..[index]
+  ..method()
+  ..[index] = value;
+>>> Null-aware cascade index.
+object?..[index]..method()..[index]=value;
+<<<
+object
+  ?..[index]
+  ..method()
+  ..[index] = value;

--- a/test/invocation/cascade_comment.stmt
+++ b/test/invocation/cascade_comment.stmt
@@ -1,0 +1,50 @@
+40 columns                              |
+>>> Line comment on unsplit cascade line.
+receiver..cascade(); // comment
+<<<
+receiver..cascade(); // comment
+>>> Line comment on split cascade.
+receiver
+  ..cascade() // a
+  ..cascade() // b
+  ..more(); // c
+<<<
+receiver
+  ..cascade() // a
+  ..cascade() // b
+  ..more(); // c
+>>> Line comment before first multi-line cascade section stays on line.
+receiver // comment
+  ..cascade()
+  ..more();
+<<<
+receiver // comment
+  ..cascade()
+  ..more();
+>>> Remove blank lines around comments.
+receiver
+
+
+
+
+  // comment 1
+
+  ..cascade1()
+
+  // comment 2
+
+  ..cascade2()
+
+
+  // comment 3
+
+
+  ..cascade3();
+<<<
+receiver
+  // comment 1
+  ..cascade1()
+  // comment 2
+  ..cascade2()
+  // comment 3
+  ..cascade3();

--- a/test/invocation/cascade_mixed.stmt
+++ b/test/invocation/cascade_mixed.stmt
@@ -1,0 +1,39 @@
+40 columns                              |
+>>> Inline with method chain.
+object.method().method()..c();
+<<<
+object.method().method()..c();
+>>> Split cascade, unsplit chain.
+object.method().method()..cascade()..cascade();
+<<<
+object.method().method()
+  ..cascade()
+  ..cascade();
+>>> Split cascade and chain.
+object.method().method().method().method()..cascade()..cascade()..cascade();
+<<<
+object
+    .method()
+    .method()
+    .method()
+    .method()
+  ..cascade()
+  ..cascade()
+  ..cascade();
+>>> Cascade setters on chain.
+object.method().method().method().method()..x=1..y=2;
+<<<
+object
+    .method()
+    .method()
+    .method()
+    .method()
+  ..x = 1
+  ..y = 2;
+>>> Postfix on cascade calls.
+object..cascade()!..cascade()[index]..cascade()(arg);
+<<<
+object
+  ..cascade()!
+  ..cascade()[index]
+  ..cascade()(arg);


### PR DESCRIPTION
There were a couple of tricky corners, but this wasn't as bad as I'd feared. Most of ChainBuilder worked great for it.

In the process of doing this and migrating the tests, I noticed another kind of expression that should allow block formatting in an argument list: function expression invocations.

That's a `(...)` where the thing on the left is some kind of expression and not simply a name, like: `(foo + bar)(args)`.

Added support for that and added some tests of block formatting for those too.

I believe this is the last corner of the grammar where there might be some weird tricky formatting logic to implement. There's a lot still left to cover, but I think it's all syntactically similar to other already-implemented constructs. I'm breathing a  big sigh of relief because I think this means that the new Piece representation really is going to work out. 😌 
