### PR TITLE
Format super expressions.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1591,7 +1591,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitSuperExpression(SuperExpression node) {
-    throw UnimplementedError();
+    return tokenPiece(node.superKeyword);
   }
 
   @override

--- a/test/invocation/super.stmt
+++ b/test/invocation/super.stmt
@@ -1,0 +1,111 @@
+40 columns                              |
+>>> Unnamed call.
+super  (  arg1  ,  arg2  );
+<<<
+super(arg1, arg2);
+>>> Unnamed call with type arguments.
+super  <  int  ,  double  >  (  arg1  ,  arg2  );
+<<<
+super<int, double>(arg1, arg2);
+>>> Named call.
+super  .  name  (  arg1  ,  arg2  );
+<<<
+super.name(arg1, arg2);
+>>> Named call with type arguments.
+super  .  name  <  int  ,  double  >  (  arg1  ,  arg2  );
+<<<
+super.name<int, double>(arg1, arg2);
+>>> Getter.
+super  .  name;
+<<<
+super.name;
+>>> Setter.
+super  .  name  =  value;
+<<<
+super.name = value;
+>>> Equality operators.
+{
+  super  ==  other;
+  super  !=  other;
+}
+<<<
+{
+  super == other;
+  super != other;
+}
+>>> Comparison operators.
+{
+  super  <  other;
+  super  <=  other;
+  super  >  other;
+  super  >=  other;
+}
+<<<
+{
+  super < other;
+  super <= other;
+  super > other;
+  super >= other;
+}
+>>> Bitwise operators.
+{
+  super  &  other;
+  super  ^  other;
+  super  |  other;
+}
+<<<
+{
+  super & other;
+  super ^ other;
+  super | other;
+}
+>>> Shift operators.
+{
+  super  <<  other;
+  super  >>  other;
+  super  >>>  other;
+}
+<<<
+{
+  super << other;
+  super >> other;
+  super >>> other;
+}
+>>> Additive operators.
+{
+  super  +  other;
+  super  -  other;
+}
+<<<
+{
+  super + other;
+  super - other;
+}
+>>> Multiplicative operators.
+{
+  super  *  other;
+  super  /  other;
+  super  %  other;
+  super  ~/  other;
+}
+<<<
+{
+  super * other;
+  super / other;
+  super % other;
+  super ~/ other;
+}
+>>> Unary operators.
+{
+  -  super;
+  ~  super;
+}
+<<<
+{
+  -super;
+  ~super;
+}
+>>> Don't remove all spaces between multiple unary minuses.
+-  -  -  super;
+<<<
+- - -super;


### PR DESCRIPTION
Apparently the old formatter has *zero* tests of this. I went ahead and wrote tests of all of the ways `super` appears in the grammar. That's probably overkill given that the analyzer models `super` as a standalone expression, but that's not actually how it works in the language itself. (In Dart, `print(super)` isn't syntactically valid.)

I figured it made sense to write tests closer to the grammar.
