### PR TITLE
Format map patterns.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -390,6 +390,8 @@ extension PatternExtensions on DartPattern {
   bool get canBlockSplit => switch (this) {
         ListPattern(:var elements, :var rightBracket) =>
           elements.canSplit(rightBracket),
+        MapPattern(:var elements, :var rightBracket) =>
+          elements.canSplit(rightBracket),
         _ => false,
       };
 }

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1189,12 +1189,18 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitMapPattern(MapPattern node) {
-    throw UnimplementedError();
+    return createCollection(
+      typeArguments: node.typeArguments,
+      node.leftBracket,
+      node.elements,
+      node.rightBracket,
+    );
   }
 
   @override
   Piece visitMapPatternEntry(MapPatternEntry node) {
-    throw UnimplementedError();
+    return createAssignment(node.key, node.separator, node.value,
+        spaceBeforeOperator: false);
   }
 
   @override

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -884,8 +884,7 @@ mixin PieceFactory {
   ///
   /// If [allowInnerSplit] is `true`, then a newline inside the target or
   /// right-hand side doesn't force splitting at the operator itself.
-  Piece createAssignment(
-      AstNode target, Token operator, Expression rightHandSide,
+  Piece createAssignment(AstNode target, Token operator, AstNode rightHandSide,
       {bool splitBeforeOperator = false,
       bool includeComma = false,
       bool spaceBeforeOperator = true,
@@ -896,7 +895,11 @@ mixin PieceFactory {
     //    var list = [
     //      element,
     //    ];
-    allowInnerSplit |= rightHandSide.canBlockSplit;
+    allowInnerSplit |= switch (rightHandSide) {
+      Expression() => rightHandSide.canBlockSplit,
+      DartPattern() => rightHandSide.canBlockSplit,
+      _ => false
+    };
 
     if (splitBeforeOperator) {
       var targetPiece = nodePiece(target);

--- a/test/pattern/map.stmt
+++ b/test/pattern/map.stmt
@@ -1,0 +1,58 @@
+40 columns                              |
+>>> Unsplit map.
+if (obj case {k: 1, m: 3, ...}) {;}
+<<<
+if (obj case {k: 1, m: 3, ...}) {
+  ;
+}
+>>> If it splits anywhere, it splits at every element.
+if (obj case {first: 1,second: 2,third: 3}) {;}
+<<<
+if (obj case {
+  first: 1,
+  second: 2,
+  third: 3,
+}) {
+  ;
+}
+>>> Nested map patterns don't force outer to split.
+if (obj case {a: {k: 1}, m: [{k: 3}]}) {;}
+<<<
+if (obj case {a: {k: 1}, m: [{k: 3}]}) {
+  ;
+}
+>>> Tall splitting style with line comment.
+if (obj case {
+  // yeah
+  a:1,b:2,c:3,
+  d:4,e:5,f:6,
+}) {;}
+<<<
+if (obj case {
+  // yeah
+  a: 1,
+  b: 2,
+  c: 3,
+  d: 4,
+  e: 5,
+  f: 6,
+}) {
+  ;
+}
+>>> Remove trailing comma if unsplit.
+if (obj case {k:1,}) {;}
+<<<
+if (obj case {k: 1}) {
+  ;
+}
+>>> Remove trailing comma if unsplit, multiple.
+if (e case {a: 1, b: 2,}) {}
+<<<
+if (e case {a: 1, b: 2}) {}
+>>> Add comma to map pattern if split.
+if (e case {a: longPattern1, b: veryLongPattern2}) {}
+<<<
+if (e case {
+  a: longPattern1,
+  b: veryLongPattern2,
+}) {}

--- a/test/pattern/map_comment.stmt
+++ b/test/pattern/map_comment.stmt
@@ -1,0 +1,46 @@
+40 columns                              |
+>>> Indent line comment inside map.
+if (obj case {
+ // c
+}) {;}
+<<<
+if (obj case {
+  // c
+}) {
+  ;
+}
+>>> Line comment on opening line of map.
+if (obj case {// c
+}) {;}
+<<<
+if (obj case {
+  // c
+}) {
+  ;
+}
+>>> Indented block comment in map.
+if (obj case {
+  /* comment */
+}){;}
+<<<
+if (obj case {
+  /* comment */
+}) {
+  ;
+}
+>>> Inline block comment in map.
+if (obj case {  /* comment */  k: v  }){;}
+<<<
+if (obj case {/* comment */ k: v}) {
+  ;
+}
+>>> Line comment between map items.
+if (obj case {k: 'a', // comment
+  m: 'b'}){;}
+<<<
+if (obj case {
+  k: 'a', // comment
+  m: 'b',
+}) {
+  ;
+}


### PR DESCRIPTION
- Map patterns and entries are now formatted.
- Migrated map pattern tests.
- Altered `createAssignment` so it can take `AstNode`s and calculate `allowInnerSplit` depending on which node.