### PR TITLE
Format record pattern.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -392,6 +392,8 @@ extension PatternExtensions on DartPattern {
           elements.canSplit(rightBracket),
         MapPattern(:var elements, :var rightBracket) =>
           elements.canSplit(rightBracket),
+        RecordPattern(:var fields, :var rightParenthesis) =>
+          fields.canSplit(rightParenthesis),
         _ => false,
       };
 }

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1360,7 +1360,19 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitPatternField(PatternField node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      b.visit(node.name);
+      b.visit(node.pattern);
+    });
+  }
+
+  @override
+  Piece visitPatternFieldName(PatternFieldName node) {
+    return buildPiece((b) {
+      b.token(node.name);
+      b.token(node.colon);
+      if (node.name != null) b.space();
+    });
   }
 
   @override
@@ -1429,27 +1441,21 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitRecordLiteral(RecordLiteral node) {
-    ListStyle style;
-    if (node.fields.length == 1 && node.fields[0] is! NamedExpression) {
-      // Single-element records always have a trailing comma, unless the single
-      // element is a named field.
-      style = const ListStyle(commas: Commas.alwaysTrailing);
-    } else {
-      style = const ListStyle(commas: Commas.trailing);
-    }
-
-    return createCollection(
+    return createRecordCollection(
       constKeyword: node.constKeyword,
       node.leftParenthesis,
       node.fields,
       node.rightParenthesis,
-      style: style,
     );
   }
 
   @override
   Piece visitRecordPattern(RecordPattern node) {
-    throw UnimplementedError();
+    return createRecordCollection(
+      node.leftParenthesis,
+      node.fields,
+      node.rightParenthesis,
+    );
   }
 
   @override

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1441,7 +1441,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitRecordLiteral(RecordLiteral node) {
-    return createRecordCollection(
+    return createRecord(
       constKeyword: node.constKeyword,
       node.leftParenthesis,
       node.fields,
@@ -1451,7 +1451,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitRecordPattern(RecordPattern node) {
-    return createRecordCollection(
+    return createRecord(
       node.leftParenthesis,
       node.fields,
       node.rightParenthesis,

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -715,34 +715,37 @@ mixin PieceFactory {
     Token? constKeyword,
   }) {
     var style = switch (fields) {
-      // Record patterns with named fields don't add trailing commas unless
-      // split, like:
+      // Record patterns with a single positional field will always
+      // have a trailing comma, like:
       //
-      //     if (obj case (name: value)) {
+      //     if (obj case (pattern,)) {
       //       ;
       //     }
-      [PatternField(name: _?)] => const ListStyle(commas: Commas.trailing),
-
-      // Record types with named fields don't add trailing commas unless split,
-      // like:
-      //
-      //     ({int n}) x;
-      [NamedExpression()] => const ListStyle(commas: Commas.trailing),
+      [PatternField(name: null)] =>
+        const ListStyle(commas: Commas.alwaysTrailing),
 
       // Record types with a single position field will always have a trailing
       // comma, like:
       //
       //     (int,) x;
       //
-      // Similarly, record patterns with a single positional field will always
-      // have a trailing comma, like:
+      [var field] when field is! NamedExpression && field is! PatternField =>
+        const ListStyle(commas: Commas.alwaysTrailing),
+
+      // All other record types and patterns have regular trailing commas when
+      // split.
       //
-      //     if (obj case (pattern,)) {
+      // Record types with a single named fields don't add trailing commas
+      // unless it's split, like:
+      //
+      //     ({int n}) x;
+      //
+      // Record patterns with a single named fields don't add trailing commas
+      // unless it's split, like:
+      //
+      //     if (obj case (name: value)) {
       //       ;
       //     }
-      [_] => const ListStyle(commas: Commas.alwaysTrailing),
-
-      // Typical trailing comma when split for more than 1 field in the record.
       _ => const ListStyle(commas: Commas.trailing)
     };
     return createCollection(

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -708,44 +708,41 @@ mixin PieceFactory {
   }
 
   /// Creates a [ListPiece] for a record literal or pattern.
-  Piece createRecordCollection(
+  Piece createRecord(
     Token leftParenthesis,
     List<AstNode> fields,
     Token rightParenthesis, {
     Token? constKeyword,
   }) {
     var style = switch (fields) {
-      // Record patterns with a single positional field will always
-      // have a trailing comma, like:
-      //
-      //     if (obj case (pattern,)) {
-      //       ;
-      //     }
-      [PatternField(name: null)] =>
-        const ListStyle(commas: Commas.alwaysTrailing),
-
-      // Record types with a single position field will always have a trailing
-      // comma, like:
-      //
-      //     (int,) x;
-      //
-      [var field] when field is! NamedExpression && field is! PatternField =>
-        const ListStyle(commas: Commas.alwaysTrailing),
-
-      // All other record types and patterns have regular trailing commas when
-      // split.
-      //
-      // Record types with a single named fields don't add trailing commas
-      // unless it's split, like:
+      // Record types or patterns with a single named field don't add a trailing
+      // comma unless it's split, like:
       //
       //     ({int n}) x;
       //
-      // Record patterns with a single named fields don't add trailing commas
-      // unless it's split, like:
+      // Or:
       //
       //     if (obj case (name: value)) {
       //       ;
       //     }
+      [PatternField(name: _?)] => const ListStyle(commas: Commas.trailing),
+      [NamedExpression()] => const ListStyle(commas: Commas.trailing),
+
+      // Record types or patterns with a single positional field always have a
+      // trailing comma to disambiguate from parenthesized expressions or
+      // patterns, like:
+      //
+      //     (int,) x;
+      //
+      // Or:
+      //
+      //     if (obj case (pattern,)) {
+      //       ;
+      //     }
+      [_] => const ListStyle(commas: Commas.alwaysTrailing),
+
+      // Record types or patterns with multiple fields have regular trailing
+      // commas when split.
       _ => const ListStyle(commas: Commas.trailing)
     };
     return createCollection(

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -713,7 +713,6 @@ mixin PieceFactory {
     List<AstNode> fields,
     Token rightParenthesis, {
     Token? constKeyword,
-    TypeArgumentList? typeArguments,
   }) {
     var style = switch (fields) {
       // Record patterns with named fields don't add trailing commas unless

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -707,6 +707,54 @@ mixin PieceFactory {
     );
   }
 
+  /// Creates a [ListPiece] for a record literal or pattern.
+  Piece createRecordCollection(
+    Token leftParenthesis,
+    List<AstNode> fields,
+    Token rightParenthesis, {
+    Token? constKeyword,
+    TypeArgumentList? typeArguments,
+  }) {
+    var style = switch (fields) {
+      // Record patterns with named fields don't add trailing commas unless
+      // split, like:
+      //
+      //     if (obj case (name: value)) {
+      //       ;
+      //     }
+      [PatternField(name: _?)] => const ListStyle(commas: Commas.trailing),
+
+      // Record types with named fields don't add trailing commas unless split,
+      // like:
+      //
+      //     ({int n}) x;
+      [NamedExpression()] => const ListStyle(commas: Commas.trailing),
+
+      // Record types with a single position field will always have a trailing
+      // comma, like:
+      //
+      //     (int,) x;
+      //
+      // Similarly, record patterns with a single positional field will always
+      // have a trailing comma, like:
+      //
+      //     if (obj case (pattern,)) {
+      //       ;
+      //     }
+      [_] => const ListStyle(commas: Commas.alwaysTrailing),
+
+      // Typical trailing comma when split for more than 1 field in the record.
+      _ => const ListStyle(commas: Commas.trailing)
+    };
+    return createCollection(
+      constKeyword: constKeyword,
+      leftParenthesis,
+      fields,
+      rightParenthesis,
+      style: style,
+    );
+  }
+
   /// Creates a class, enum, extension, mixin, or mixin application class
   /// declaration.
   ///

--- a/test/pattern/record.stmt
+++ b/test/pattern/record.stmt
@@ -3,6 +3,8 @@
 switch (obj) {
   case  (  )  :
   case  (  value  ,  )  :
+  case  (  : var x  ,  )  :
+  case  ( name : var x  ,  )  :
   case  (  first  ,  second  ,  third  )  :
   case  (  first  :  1  ,  2  ,  third  :  3  )  :
   case  (  :  var  x  ,  :  var  y  )  :
@@ -12,6 +14,8 @@ switch (obj) {
 switch (obj) {
   case ():
   case (value,):
+  case (:var x):
+  case (name: var x):
   case (first, second, third):
   case (first: 1, 2, third: 3):
   case (:var x, :var y):

--- a/test/pattern/record.stmt
+++ b/test/pattern/record.stmt
@@ -1,0 +1,162 @@
+40 columns                              |
+>>> Basic record switch. 
+switch (obj) {
+  case  (  )  :
+  case  (  value  ,  )  :
+  case  (  first  ,  second  ,  third  )  :
+  case  (  first  :  1  ,  2  ,  third  :  3  )  :
+  case  (  :  var  x  ,  :  var  y  )  :
+    ok;
+}
+<<<
+switch (obj) {
+  case ():
+  case (value,):
+  case (first, second, third):
+  case (first: 1, 2, third: 3):
+  case (:var x, :var y):
+    ok;
+}
+>>> Unsplit single-element record, with trailing comma.
+if (obj case (pattern,)) {;}
+<<<
+if (obj case (pattern,)) {
+  ;
+}
+>>> Remove trailing comma from single named field.
+if (obj case (name: value,)) {;}
+<<<
+if (obj case (name: value)) {
+  ;
+}
+>>> Split single-element record after ",".
+if (obj case (veryLongRecordField____________,)) {;}
+<<<
+if (obj case (
+  veryLongRecordField____________,
+)) {
+  ;
+}
+>>> Split single-element named record.
+if (obj case (longFieldName: longRecordFieldValue)) {;}
+<<<
+if (obj case (
+  longFieldName: longRecordFieldValue,
+)) {
+  ;
+}
+>>> Split single-element named record at name.
+if (obj case (longFieldName: veryLongRecordFieldValue)) {;}
+<<<
+if (obj case (
+  longFieldName: veryLongRecordFieldValue,
+)) {
+  ;
+}
+>>> Split single-element record with inferred name.
+if (obj case (:var veryLongInferredFieldName_____)) {;}
+<<<
+if (obj case (
+  :var veryLongInferredFieldName_____,
+)) {
+  ;
+}
+>>> Split multiple-element record with inferred names.
+if (obj case (:var firstLongInferredFieldName, :var secondLongInferredName)) {;}
+<<<
+if (obj case (
+  :var firstLongInferredFieldName,
+  :var secondLongInferredName,
+)) {
+  ;
+}
+>>> Don't split between name and list subpattern.
+if (obj case (longFieldName: [first, second, third])) {;}
+<<<
+if (obj case (
+  longFieldName: [first, second, third],
+)) {
+  ;
+}
+>>> Don't split between name and map subpattern.
+if (obj case (longFieldName: {first: 1, second: 2})) {;}
+<<<
+if (obj case (
+  longFieldName: {first: 1, second: 2},
+)) {
+  ;
+}
+>>> Don't split between name and record subpattern.
+if (obj case (longFieldName: (first: 1, second: 2))) {;}
+<<<
+if (obj case (
+  longFieldName: (first: 1, second: 2),
+)) {
+  ;
+}
+>>> If any field splits, all fields split.
+if (obj case (first, second, third, fourth, fifth)) {;}
+<<<
+if (obj case (
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+)) {
+  ;
+}
+>>> Don't force outer record to split.
+if (obj case ((a,), (b, c))) {;}
+<<<
+if (obj case ((a,), (b, c))) {
+  ;
+}
+>>> Split nested record.
+if (obj case (first, (second, third, fourth), fifth, (sixth, seventh, eighth, nine, tenth,
+    eleventh))) {;}
+<<<
+if (obj case (
+  first,
+  (second, third, fourth),
+  fifth,
+  (
+    sixth,
+    seventh,
+    eighth,
+    nine,
+    tenth,
+    eleventh,
+  ),
+)) {
+  ;
+}
+>>> Tall splitting style with line comment.
+if (obj case (
+  // yeah
+  a,b,c,
+  d,e,f,
+)) {;}
+<<<
+if (obj case (
+  // yeah
+  a,
+  b,
+  c,
+  d,
+  e,
+  f,
+)) {
+  ;
+}
+>>> Remove comma from multiple-field record pattern if unsplit
+if (e case (a, b,)) {}
+<<<
+if (e case (a, b)) {}
+>>> Add comma to record pattern if split.
+if (e case (longPattern1, veryLongPattern2)) {}
+<<<
+if (e case (
+  longPattern1,
+  veryLongPattern2,
+)) {}

--- a/test/pattern/record_comment.stmt
+++ b/test/pattern/record_comment.stmt
@@ -1,0 +1,26 @@
+40 columns                              |
+>>> Empty record pattern block comment.
+if (obj case (  /* comment */  )) {;}
+<<<
+if (obj case (/* comment */)) {
+  ;
+}
+>>> Empty record pattern line comment.
+if (obj case (  // comment
+)) {;}
+<<<
+if (obj case (
+  // comment
+)) {
+  ;
+}
+>>> Record line comment between fields.
+if (obj case ( first , // comment
+second)){;}
+<<<
+if (obj case (
+  first, // comment
+  second,
+)) {
+  ;
+}


### PR DESCRIPTION
- Added the helper `createRecordCollection` to handle similar trailing comma situations for record types and patterns.

Records should only have an always trailing comma with a single positional field, in every other scenario, it will have a regular trailing comma style (if split).

- Migrated record pattern tests from the temp repo.
- Allow `RecordPattern` to block split.