### PR TITLE
Prune solutions derived from invalid ones.

### DIFF
--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -20,7 +20,7 @@ import 'solution.dart';
 class CodeWriter {
   final int _pageWidth;
 
-  /// The solution being formatted.
+  /// The solution this [CodeWriter] is generating code for.
   final Solution _solution;
 
   /// Buffer for the code being written.
@@ -88,10 +88,8 @@ class CodeWriter {
 
   CodeWriter(this._pageWidth, this._solution);
 
-  /// Called after this writer has finished formatting the entire piece tree.
-  ///
   /// Returns the final formatted text and the next piece that can be expanded
-  /// from this solution, if any.
+  /// from the solution this [CodeWriter] is writing, if any.
   (String, Piece?) finish() {
     _finishLine();
 
@@ -128,11 +126,15 @@ class CodeWriter {
   /// piece to [indent], relative to the indentation of the surrounding piece.
   ///
   /// Replaces any previous indentation set by this piece.
-  ///
   // TODO(tall): Add another API that adds/subtracts existing indentation.
   void setIndent(int indent) {
-    var parentIndent =
-        _options.length > 1 ? _options[_options.length - 2].indent : 0;
+    var parentIndent = 0;
+
+    // If there is a surrounding Piece, then set the indent relative to that
+    // piece's current indentation.
+    if (_options.length > 1) {
+      parentIndent = _options[_options.length - 2].indent;
+    }
 
     _options.last.indent = parentIndent + indent;
   }

--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -197,6 +197,10 @@ class Solution implements Comparable<Solution> {
     var newCost = cost;
 
     void bind(Piece thisPiece, State thisState) {
+      // If we've already failed from a previous sibling's constraint violation,
+      // early out.
+      if (conflict) return;
+
       // If this piece is already pinned or bound to some other state, then the
       // solution doesn't make sense.
       var alreadyBound = thisPiece.pinnedState ?? newStates[thisPiece];

--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -4,10 +4,16 @@
 import '../piece/piece.dart';
 import 'code_writer.dart';
 
-/// A single possible line splitting solution.
+/// A single possible set of formatting choices.
 ///
-/// Stores the states that each piece is set to and the resulting formatted
-/// code and its cost.
+/// Each solution binds some number of [Piece]s in the piece tree to [State]s.
+/// (Any pieces whose states are not bound are treated as having a default
+/// unsplit state.)
+///
+/// Given that set of states, we can create a [CodeWriter] and give that to all
+/// of the pieces in the tree so they can format themselves. That in turn
+/// yields a total number of overflow characters, cost, and formatted output,
+/// which are all stored here.
 class Solution implements Comparable<Solution> {
   /// The states that pieces have been bound to.
   ///

--- a/lib/src/back_end/solver.dart
+++ b/lib/src/back_end/solver.dart
@@ -37,17 +37,20 @@ class Solver {
   /// Finds the best set of line splits for [root] piece and returns the
   /// resulting formatted code.
   Solution format(Piece root) {
-    var solution = Solution.initial(root, _pageWidth);
+    var solution = Solution(root, _pageWidth);
     _queue.add(solution);
 
     // The lowest cost solution found so far that does overflow.
     var best = solution;
 
+    var tries = 0;
+
     while (_queue.isNotEmpty) {
       var solution = _queue.removeFirst();
+      tries++;
 
       if (debug.traceSolver) {
-        debug.log(debug.bold(solution));
+        debug.log(debug.bold('#$tries $solution'));
         debug.log(solution.text);
         debug.log('');
       }

--- a/lib/src/back_end/solver.dart
+++ b/lib/src/back_end/solver.dart
@@ -10,7 +10,7 @@ import 'solution.dart';
 /// Selects states for each piece in a tree of pieces to find the best set of
 /// line splits that minimizes overflow characters and line splitting costs.
 ///
-/// This problem is combinatorial for the number of pieces and each of their
+/// This problem is combinatorial over the number of pieces and each of their
 /// possible states, so it isn't feasible to brute force. There are a few
 /// techniques we use to avoid that:
 ///
@@ -24,7 +24,7 @@ import 'solution.dart';
 ///
 /// -   When selecting states for pieces to expand solutions, we only look at
 ///     pieces in the first line containing overflow characters or invalid
-///     newlines. See [Solution._livePieces] for more details.
+///     newlines. See [Solution._nextPieceToExpand] for more details.
 // TODO(perf): At some point, we may also want to do memoization of previously
 // formatted Piece subtrees.
 class Solver {


### PR DESCRIPTION
Prune solutions derived from invalid ones.

A solution is invalid if a child piece writes a newline at a point in time where a parent disallows newlines.

When that happens, the parent's may be explicitly bound to a state by the solution, or it may still be in an unbound state (and thus using the default). If unbound, then even though this solution is invalid, it may lead to later valid ones by binding that parent piece to a different state.

But once a solution binds a piece to a state, all solutions derived from that state keep the same binding. So if we hit an invalid solution and the piece whose newline constraint was already violated, we can discard that solution and all possible solutions derived from it.

This skips an entire potentially huge subtree from the solution space being explored.

In an example giant deeply nested function call from the benchmark, before this optimization, the solver tries 329,057 solutions before finding a winning one. With this optimization, it only takes 5,405.

I broke this PR into two commits to make it easier to review. The first commit is a refactoring that moves some code around to make the second commit easier to implement. Then after uploading that, I figured out a cleaner way to model invalid states and an idea for further optimization, so uploaded another commit with those changes.