### PR TITLE
Reorganize how Solution handles pinned states and constraints.

### DIFF
--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -208,7 +208,8 @@ class CodeWriter {
     _options.add(_PieceOptions(piece, _options.lastOrNull?.indent ?? 0,
         _options.lastOrNull?.allowNewlines ?? true));
 
-    var isUnsolved = !_solution.isBound(piece) && piece.states.length > 1;
+    var isUnsolved =
+        !_solution.isBound(piece) && piece.additionalStates.isNotEmpty;
     if (isUnsolved) _currentUnsolvedPieces.add(piece);
 
     // TODO(perf): Memoize this. Might want to create a nested PieceWriter

--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -134,7 +134,7 @@ class Solution implements Comparable<Solution> {
   /// The state this solution selects for [piece].
   ///
   /// If no state has been selected, defaults to the first state.
-  State pieceState(Piece piece) => _pieceStates[piece] ?? piece.states.first;
+  State pieceState(Piece piece) => _pieceStates[piece] ?? State.unsplit;
 
   /// Whether [piece] has been bound to a state in this set.
   bool isBound(Piece piece) => _pieceStates.containsKey(piece);

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -857,7 +857,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitIfElement(IfElement node) {
-    var piece = IfPiece();
+    var piece = IfPiece(isStatement: false);
 
     // Recurses through the else branches to flatten them into a linear if-else
     // chain handled by a single [IfPiece].
@@ -940,7 +940,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitIfStatement(IfStatement node) {
-    var piece = IfPiece();
+    var piece = IfPiece(isStatement: true);
 
     // Recurses through the else branches to flatten them into a linear if-else
     // chain handled by a single [IfPiece].
@@ -1834,7 +1834,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
     var body = nodePiece(node.body);
 
-    var piece = IfPiece();
+    var piece = IfPiece(isStatement: true);
     piece.add(condition, body, isBlock: node.body is Block);
     return piece;
   }

--- a/lib/src/piece/if.dart
+++ b/lib/src/piece/if.dart
@@ -10,7 +10,12 @@ import 'piece.dart';
 /// We also use this for while statements, which are formatted exactly like an
 /// if statement with no else clause.
 class IfPiece extends Piece {
+  /// Whether this is an if statement versus if collection element.
+  final bool _isStatement;
+
   final List<_IfSection> _sections = [];
+
+  IfPiece({required bool isStatement}) : _isStatement = isStatement;
 
   void add(Piece header, Piece statement, {required bool isBlock}) {
     _sections.add(_IfSection(header, statement, isBlock));
@@ -24,11 +29,12 @@ class IfPiece extends Piece {
     // If an if element, any spread collection's split state must follow the
     // surrounding if element's: we either split all the spreads or none of
     // them. And if any of the non-spread then or else branches split, then the
-    // spreads do too. This has no effect on if statements since blocks always
-    // split.
-    for (var section in _sections) {
-      if (section.isBlock) {
-        constrain(section.statement, state);
+    // spreads do too.
+    if (!_isStatement) {
+      for (var section in _sections) {
+        if (section.isBlock) {
+          constrain(section.statement, state);
+        }
       }
     }
   }

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -16,15 +16,13 @@ typedef Constrain = void Function(Piece other, State constrainedState);
 abstract class Piece {
   /// The ordered list of ways this piece may split.
   ///
-  /// If the piece is aready pinned, then this is just the one pinned state.
-  /// Otherwise, it's [State.unsplit], which all pieces support, followed by
-  /// any other [additionalStates].
+  /// This is [State.unsplit], which all pieces support, followed by any other
+  /// [additionalStates].
   List<State> get states {
-    if (_pinnedState case var state?) {
-      return [state];
-    } else {
-      return [State.unsplit, ...additionalStates];
-    }
+    // Pinned pieces should be bound eagerly in the Solution so we shouldn't
+    // ever need to iterate over their states.
+    assert(_pinnedState == null);
+    return [State.unsplit, ...additionalStates];
   }
 
   /// The ordered list of all possible ways this piece could split.


### PR DESCRIPTION
In the process of turning ListElement into a Piece, I ran into a couple of bugs in how pinned states and constraints between pieces are handled.

The tests didn't catch those bugs because there are basically two bugs that cancel out. The IfPiece was incorrectly pinning an empty else block in an if statement to split. But the solver was incorrectly ignoring pinned states in some cases. This fixes both bugs.

With this change, when generating a Solution, we eagerly bind as many Pieces to States as we can when the Solution is first created before running CodeWriter. To do that, we find all of the pinned Pieces and bind them to their pinned States, then propagate any constraints from that to other child Pieces.

This fixes a couple of bugs, but also, I think, leads to a cleaner module where at Solution creation time, we fill in as many piece states as we can based on what we know statically about the Piece tree (its pinned states and their constraints). Then during solution exploring and line splitting, we don't have to worry about pinned states at all.

This will, I think, align with future optimizations where we do some other piece pinning before running the solver.
