### PR TITLE
Prefer any valid solution over an invalid one, regardless of overflow.

### DIFF
--- a/lib/src/back_end/solver.dart
+++ b/lib/src/back_end/solver.dart
@@ -92,15 +92,18 @@ class Solver {
         debug.log('');
       }
 
-      // Since we process the solutions from lowest cost up, as soon as we find
-      // a valid one that fits, it's the best.
       if (solution.isValid) {
+        // Since we process the solutions from lowest cost up, as soon as we
+        // find a valid one that fits, it's the best.
         if (solution.overflow == 0) {
           best = solution;
           break;
         }
 
-        if (solution.overflow < best.overflow) best = solution;
+        // If not, keep track of the least-bad one we've found so far.
+        if (!best.isValid || solution.overflow < best.overflow) {
+          best = solution;
+        }
       }
 
       // Otherwise, try to expand the solution to explore different splitting

--- a/test/pattern/declared_variable_comment.stmt
+++ b/test/pattern/declared_variable_comment.stmt
@@ -42,7 +42,8 @@ if (obj
   ;
 }
 <<<
-if (obj case final // c
+if (obj
+    case final // c
         thisIsReallyQuiteAVeryLongVariableName) {
   ;
 }


### PR DESCRIPTION
While the Solver is working through Solutions, it keeps track of the best Solution it's found so far. This will get returned if there is no Solution that fits within the page width: when overflow is inevitable, the formatter still tries to do the best it can.

The Solver is careful to not consider an invalid solution (one that contains a newline where none is allowed) to be the best solution. Except in one case: If the *initial* solution is invalid, the Solver will still store it in best. Then, as long as no other solution has less overflow than the initial invalid one, it ends up returning an invalid solution.

This fixes that: any valid solution, regardless of overflow, will kick out that initial invalid solution if there is one.
