### PR TITLE
Format logic and parenthesized patterns

### DIFF
--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -291,8 +291,6 @@ class CodeWriter {
     var previousHadNewline = _hadNewline;
     _hadNewline = false;
 
-    _indentStack.add(_indentStack.last);
-
     var isUnsolved =
         !_solution.isBound(piece) && piece.additionalStates.isNotEmpty;
     if (isUnsolved) _currentUnsolvedPieces.add(piece);
@@ -307,7 +305,6 @@ class CodeWriter {
     _hadNewline = previousHadNewline;
 
     _currentPiece = previousPiece;
-    _indentStack.removeLast();
 
     // If the child contained a newline then the parent transitively does.
     if (childHadNewline && _currentPiece != null) _handleNewline();

--- a/lib/src/back_end/solver.dart
+++ b/lib/src/back_end/solver.dart
@@ -92,15 +92,18 @@ class Solver {
         debug.log('');
       }
 
-      // Since we process the solutions from lowest cost up, as soon as we find
-      // a valid one that fits, it's the best.
       if (solution.isValid) {
+        // Since we process the solutions from lowest cost up, as soon as we
+        // find a valid one that fits, it's the best.
         if (solution.overflow == 0) {
           best = solution;
           break;
         }
 
-        if (solution.overflow < best.overflow) best = solution;
+        // If not, keep track of the least-bad one we've found so far.
+        if (!best.isValid || solution.overflow < best.overflow) {
+          best = solution;
+        }
       }
 
       // Otherwise, try to expand the solution to explore different splitting

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -79,4 +79,24 @@ class Indent {
 
   /// The ":" on a wrapped constructor initialization list.
   static const constructorInitializer = 4;
+
+  /// A wrapped constructor initializer after the first one when the parameter
+  /// list does not have optional or named parameters, like:
+  ///
+  ///     Constructor(
+  ///       parameter,
+  ///     ) : first,
+  ///         second;
+  ///       ^^ This indentation.
+  static const initializer = 2;
+
+  /// A wrapped constructor initializer after the first one when the parameter
+  /// list has optional or named parameters, like:
+  ///
+  ///     Constructor([
+  ///       parameter,
+  ///     ]) : first,
+  ///          second;
+  ///       ^^^ This indentation.
+  static const initializerWithOptionalParameter = 3;
 }

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1168,12 +1168,26 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitLogicalAndPattern(LogicalAndPattern node) {
-    throw UnimplementedError();
+    return createInfixChain<LogicalAndPattern>(
+        node,
+        precedence: node.operator.type.precedence,
+        (expression) => (
+              expression.leftOperand,
+              expression.operator,
+              expression.rightOperand
+            ));
   }
 
   @override
   Piece visitLogicalOrPattern(LogicalOrPattern node) {
-    throw UnimplementedError();
+    return createInfixChain<LogicalOrPattern>(
+        node,
+        precedence: node.operator.type.precedence,
+        (expression) => (
+              expression.leftOperand,
+              expression.operator,
+              expression.rightOperand
+            ));
   }
 
   @override
@@ -1316,7 +1330,11 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitParenthesizedPattern(ParenthesizedPattern node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      b.token(node.leftParenthesis);
+      b.visit(node.pattern);
+      b.token(node.rightParenthesis);
+    });
   }
 
   @override

--- a/lib/src/piece/adjacent_strings.dart
+++ b/lib/src/piece/adjacent_strings.dart
@@ -20,12 +20,14 @@ class AdjacentStringsPiece extends Piece {
 
   @override
   void format(CodeWriter writer, State state) {
-    if (_indent) writer.setIndent(Indent.expression);
+    if (_indent) writer.pushIndent(Indent.expression);
 
     for (var i = 0; i < _strings.length; i++) {
       if (i > 0) writer.newline();
       writer.format(_strings[i]);
     }
+
+    if (_indent) writer.popIndent();
   }
 
   @override

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -110,16 +110,23 @@ class AssignPiece extends Piece {
     }
 
     // Don't indent a split delimited expression.
-    if (state != State.unsplit) writer.setIndent(Indent.expression);
+    if (state != State.unsplit) writer.pushIndent(Indent.expression);
 
     writer.format(target);
     writer.splitIf(state == _atOperator);
 
     // We need extra indentation when there's no inner splitting of the value.
     if (!_allowInnerSplit && _indentInValue) {
-      writer.setIndent(Indent.expression * 2);
+      writer.pushIndent(Indent.expression);
     }
+
     writer.format(value);
+
+    if (!_allowInnerSplit && _indentInValue) {
+      writer.popIndent();
+    }
+
+    if (state != State.unsplit) writer.popIndent();
   }
 
   @override

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -105,9 +105,7 @@ class AssignPiece extends Piece {
   void format(CodeWriter writer, State state) {
     // A split in either child piece forces splitting at assignment operator
     // unless specifically allowed.
-    if (!_allowInnerSplit && state == State.unsplit) {
-      writer.setAllowNewlines(false);
-    }
+    writer.pushAllowNewlines(_allowInnerSplit || state != State.unsplit);
 
     // Don't indent a split delimited expression.
     if (state != State.unsplit) writer.pushIndent(Indent.expression);
@@ -127,6 +125,8 @@ class AssignPiece extends Piece {
     }
 
     if (state != State.unsplit) writer.popIndent();
+
+    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -115,7 +115,7 @@ class AssignPiece extends Piece {
 
     // We need extra indentation when there's no inner splitting of the value.
     if (!_allowInnerSplit && _indentInValue) {
-      writer.pushIndent(Indent.expression);
+      writer.pushIndent(Indent.expression, canCollapse: true);
     }
 
     writer.format(value);

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -146,12 +146,12 @@ class ChainPiece extends Piece {
     //         );
     switch (state) {
       case State.unsplit:
-        writer.setAllowNewlines(_allowSplitInTarget);
+        writer.pushAllowNewlines(_allowSplitInTarget);
       case _splitAfterProperties:
         writer.pushIndent(_indent);
-        writer.setAllowNewlines(_allowSplitInTarget);
+        writer.pushAllowNewlines(_allowSplitInTarget);
       case _blockFormatTrailingCall:
-        writer.setAllowNewlines(_allowSplitInTarget);
+        writer.pushAllowNewlines(_allowSplitInTarget);
       case State.split:
         writer.pushIndent(_indent);
     }
@@ -161,14 +161,14 @@ class ChainPiece extends Piece {
     for (var i = 0; i < _calls.length; i++) {
       switch (state) {
         case State.unsplit:
-          writer.setAllowNewlines(false);
+          writer.pushAllowNewlines(false);
         case _splitAfterProperties:
-          writer.setAllowNewlines(i >= _leadingProperties);
+          writer.pushAllowNewlines(i >= _leadingProperties);
           writer.splitIf(i >= _leadingProperties, space: false);
         case _blockFormatTrailingCall:
-          writer.setAllowNewlines(i == _blockCallIndex);
+          writer.pushAllowNewlines(i == _blockCallIndex);
         case State.split:
-          writer.setAllowNewlines(true);
+          writer.pushAllowNewlines(true);
           writer.newline();
       }
 
@@ -182,10 +182,20 @@ class ChainPiece extends Piece {
         _ => false,
       };
       writer.format(_calls[i]._call, separate: separate);
+
+      writer.popAllowNewlines();
     }
 
-    if (state == _splitAfterProperties || state == State.split) {
-      writer.popIndent();
+    switch (state) {
+      case State.unsplit:
+        writer.popAllowNewlines();
+      case _splitAfterProperties:
+        writer.popIndent();
+        writer.popAllowNewlines();
+      case _blockFormatTrailingCall:
+        writer.popAllowNewlines();
+      case State.split:
+        writer.popIndent();
     }
   }
 

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -148,12 +148,12 @@ class ChainPiece extends Piece {
       case State.unsplit:
         writer.setAllowNewlines(_allowSplitInTarget);
       case _splitAfterProperties:
-        writer.setIndent(_indent);
+        writer.pushIndent(_indent);
         writer.setAllowNewlines(_allowSplitInTarget);
       case _blockFormatTrailingCall:
         writer.setAllowNewlines(_allowSplitInTarget);
       case State.split:
-        writer.setIndent(_indent);
+        writer.pushIndent(_indent);
     }
 
     writer.format(_target);
@@ -182,6 +182,10 @@ class ChainPiece extends Piece {
         _ => false,
       };
       writer.format(_calls[i]._call, separate: separate);
+    }
+
+    if (state == _splitAfterProperties || state == State.split) {
+      writer.popIndent();
     }
   }
 

--- a/lib/src/piece/clause.dart
+++ b/lib/src/piece/clause.dart
@@ -96,16 +96,18 @@ class ClausesPiece extends Piece {
         // Before the leading clause, only split when in the fully split state.
         // A split inside the first clause forces a split before the keyword.
         writer.splitIf(state == State.split);
-        writer.setAllowNewlines(state == State.split);
+        writer.pushAllowNewlines(state == State.split);
       } else {
         // For the other clauses (or if there is no leading one), split in the
         // fully split state and any split inside and clause forces all of them
         // to split.
-        writer.setAllowNewlines(state != State.unsplit);
+        writer.pushAllowNewlines(state != State.unsplit);
         writer.splitIf(state != State.unsplit);
       }
 
       writer.format(clause);
+
+      writer.popAllowNewlines();
     }
 
     writer.popIndent();
@@ -133,7 +135,7 @@ class ClausePiece extends Piece {
   @override
   void format(CodeWriter writer, State state) {
     // If any of the parts inside the clause split, split the list.
-    writer.setAllowNewlines(state != State.unsplit);
+    writer.pushAllowNewlines(state != State.unsplit);
     writer.pushIndent(Indent.expression);
 
     writer.format(_keyword);
@@ -143,6 +145,7 @@ class ClausePiece extends Piece {
     }
 
     writer.popIndent();
+    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/clause.dart
+++ b/lib/src/piece/clause.dart
@@ -89,22 +89,26 @@ class ClausesPiece extends Piece {
 
   @override
   void format(CodeWriter writer, State state) {
+    writer.pushIndent(Indent.expression);
+
     for (var clause in _clauses) {
       if (_allowLeadingClause && clause == _clauses.first) {
         // Before the leading clause, only split when in the fully split state.
         // A split inside the first clause forces a split before the keyword.
-        writer.splitIf(state == State.split, indent: Indent.expression);
+        writer.splitIf(state == State.split);
         writer.setAllowNewlines(state == State.split);
       } else {
         // For the other clauses (or if there is no leading one), split in the
         // fully split state and any split inside and clause forces all of them
         // to split.
         writer.setAllowNewlines(state != State.unsplit);
-        writer.splitIf(state != State.unsplit, indent: Indent.expression);
+        writer.splitIf(state != State.unsplit);
       }
 
       writer.format(clause);
     }
+
+    writer.popIndent();
   }
 
   @override
@@ -130,12 +134,15 @@ class ClausePiece extends Piece {
   void format(CodeWriter writer, State state) {
     // If any of the parts inside the clause split, split the list.
     writer.setAllowNewlines(state != State.unsplit);
+    writer.pushIndent(Indent.expression);
 
     writer.format(_keyword);
     for (var part in _parts) {
-      writer.splitIf(state == State.split, indent: Indent.expression);
+      writer.splitIf(state == State.split);
       writer.format(part);
     }
+
+    writer.popIndent();
   }
 
   @override

--- a/lib/src/piece/constructor.dart
+++ b/lib/src/piece/constructor.dart
@@ -130,9 +130,7 @@ class ConstructorPiece extends Piece {
   void format(CodeWriter writer, State state) {
     // If there's a newline in the header or parameters (like a line comment
     // after the `)`), then don't allow the initializers to remain unsplit.
-    if (_initializers != null && state == State.unsplit) {
-      writer.setAllowNewlines(false);
-    }
+    writer.pushAllowNewlines(_initializers == null || state != State.unsplit);
 
     writer.format(_header);
     writer.format(_parameters);
@@ -143,7 +141,6 @@ class ConstructorPiece extends Piece {
     }
 
     if (_initializers case var initializers?) {
-      writer.setAllowNewlines(state != State.unsplit);
       writer.pushIndent(Indent.block);
       writer.splitIf(state == _splitBeforeInitializers);
 
@@ -162,7 +159,7 @@ class ConstructorPiece extends Piece {
       writer.popIndent();
     }
 
-    writer.setAllowNewlines(true);
+    writer.popAllowNewlines();
     writer.format(_body);
   }
 

--- a/lib/src/piece/constructor.dart
+++ b/lib/src/piece/constructor.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../back_end/code_writer.dart';
+import '../constants.dart';
 import 'piece.dart';
 
 /// A constructor declaration.
@@ -143,24 +144,24 @@ class ConstructorPiece extends Piece {
 
     if (_initializers case var initializers?) {
       writer.setAllowNewlines(state != State.unsplit);
-      writer.splitIf(state == _splitBeforeInitializers, indent: 2);
+      writer.pushIndent(Indent.block);
+      writer.splitIf(state == _splitBeforeInitializers);
 
       writer.format(_initializerSeparator!);
       writer.space();
 
       // Indent subsequent initializers past the `:`.
       if (_hasOptionalParameter && state == _splitBetweenInitializers) {
-        // If the parameter list ends in `]) : init...` then we need to indent
-        // +5 to line up subsequent initializers.
-        writer.setIndent(5);
+        writer.pushIndent(Indent.initializerWithOptionalParameter);
       } else {
-        writer.setIndent(4);
+        writer.pushIndent(Indent.initializer);
       }
 
       writer.format(initializers);
+      writer.popIndent();
+      writer.popIndent();
     }
 
-    writer.setIndent(0);
     writer.setAllowNewlines(true);
     writer.format(_body);
   }

--- a/lib/src/piece/for.dart
+++ b/lib/src/piece/for.dart
@@ -45,10 +45,12 @@ class ForPiece extends Piece {
     if (_hasBlockBody) {
       writer.space();
     } else {
-      writer.splitIf(state == State.split, indent: Indent.block);
+      writer.pushIndent(Indent.block);
+      writer.splitIf(state == State.split);
     }
 
     writer.format(_body);
+    if (!_hasBlockBody) writer.popIndent();
   }
 
   @override

--- a/lib/src/piece/for.dart
+++ b/lib/src/piece/for.dart
@@ -34,9 +34,7 @@ class ForPiece extends Piece {
 
   @override
   void format(CodeWriter writer, State state) {
-    if (!_hasBlockBody && state == State.unsplit) {
-      writer.setAllowNewlines(false);
-    }
+    writer.pushAllowNewlines(_hasBlockBody || state != State.unsplit);
 
     writer.format(_forKeyword);
     writer.space();
@@ -51,6 +49,8 @@ class ForPiece extends Piece {
 
     writer.format(_body);
     if (!_hasBlockBody) writer.popIndent();
+
+    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/function.dart
+++ b/lib/src/piece/function.dart
@@ -57,14 +57,15 @@ class FunctionPiece extends Piece {
   void format(CodeWriter writer, State state) {
     if (_returnType case var returnType?) {
       // A split inside the return type forces splitting after the return type.
-      writer.setAllowNewlines(state == State.split);
-
+      writer.pushAllowNewlines(state == State.split);
       writer.format(returnType);
+      writer.popAllowNewlines();
 
       // A split in the type parameters or parameters does not force splitting
       // after the return type.
-      writer.setAllowNewlines(true);
+      writer.pushAllowNewlines(true);
       writer.splitIf(state == State.split);
+      writer.popAllowNewlines();
     }
 
     writer.format(_signature);

--- a/lib/src/piece/if.dart
+++ b/lib/src/piece/if.dart
@@ -53,7 +53,7 @@ class IfPiece extends Piece {
       var section = _sections[i];
 
       // A split in the condition forces the branches to split.
-      writer.setAllowNewlines(state == State.split);
+      writer.pushAllowNewlines(state == State.split);
       writer.format(section.header);
 
       if (!section.isBlock) {
@@ -70,6 +70,8 @@ class IfPiece extends Piece {
       if (i < _sections.length - 1) {
         writer.splitIf(state == State.split && !section.isBlock);
       }
+
+      writer.popAllowNewlines();
     }
   }
 }

--- a/lib/src/piece/if.dart
+++ b/lib/src/piece/if.dart
@@ -57,16 +57,18 @@ class IfPiece extends Piece {
       writer.format(section.header);
 
       if (!section.isBlock) {
-        writer.splitIf(state == State.split, indent: Indent.block);
+        writer.pushIndent(Indent.block);
+        writer.splitIf(state == State.split);
       }
 
       // TODO(perf): Investigate whether it's worth using `separate:` here.
       writer.format(section.statement);
 
       // Reset the indentation for the subsequent `else` or `} else` line.
+      if (!section.isBlock) writer.popIndent();
+
       if (i < _sections.length - 1) {
-        writer.splitIf(state == State.split && !section.isBlock,
-            indent: Indent.none);
+        writer.splitIf(state == State.split && !section.isBlock);
       }
     }
   }

--- a/lib/src/piece/infix.dart
+++ b/lib/src/piece/infix.dart
@@ -27,7 +27,7 @@ class InfixPiece extends Piece {
     if (state == State.unsplit) {
       writer.setAllowNewlines(false);
     } else {
-      writer.setIndent(Indent.expression);
+      writer.pushIndent(Indent.expression);
     }
 
     for (var i = 0; i < _operands.length; i++) {
@@ -39,6 +39,8 @@ class InfixPiece extends Piece {
       writer.format(_operands[i], separate: separate);
       if (i < _operands.length - 1) writer.splitIf(state == State.split);
     }
+
+    if (state != State.unsplit) writer.popIndent();
   }
 
   @override

--- a/lib/src/piece/infix.dart
+++ b/lib/src/piece/infix.dart
@@ -25,7 +25,7 @@ class InfixPiece extends Piece {
   @override
   void format(CodeWriter writer, State state) {
     if (state == State.unsplit) {
-      writer.setAllowNewlines(false);
+      writer.pushAllowNewlines(false);
     } else {
       writer.pushIndent(Indent.expression);
     }
@@ -40,7 +40,11 @@ class InfixPiece extends Piece {
       if (i < _operands.length - 1) writer.splitIf(state == State.split);
     }
 
-    if (state != State.unsplit) writer.popIndent();
+    if (state == State.unsplit) {
+      writer.popAllowNewlines();
+    } else {
+      writer.popIndent();
+    }
   }
 
   @override

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -116,11 +116,14 @@ class ListPiece extends Piece {
 
       writer.format(before);
 
-      if (state == State.unsplit) writer.setAllowNewlines(false);
+      if (state == State.unsplit) {
+        writer.setAllowNewlines(false);
+      } else {
+        writer.pushIndent(Indent.block);
+      }
 
       // Whitespace after the opening bracket.
       writer.splitIf(state != State.unsplit,
-          indent: Indent.block,
           space: _style.spaceWhenUnsplit && _elements.isNotEmpty);
     }
 
@@ -136,7 +139,7 @@ class ListPiece extends Piece {
       // If this element allows newlines when the list isn't split, add
       // indentation if it requires it.
       if (state == State.unsplit && element.indentWhenBlockFormatted) {
-        writer.setIndent(Indent.expression);
+        writer.pushIndent(Indent.expression);
       }
 
       // We can format each list item separately if the item is on its own line.
@@ -149,7 +152,7 @@ class ListPiece extends Piece {
       writer.format(element, separate: separate);
 
       if (state == State.unsplit && element.indentWhenBlockFormatted) {
-        writer.setIndent(Indent.none);
+        writer.popIndent();
       }
 
       // Write a space or newline between elements.
@@ -163,9 +166,10 @@ class ListPiece extends Piece {
 
     // Format the closing bracket, if any.
     if (_after case var after?) {
+      if (state != State.unsplit) writer.popIndent();
+
       // Whitespace before the closing bracket.
       writer.splitIf(state != State.unsplit,
-          indent: Indent.none,
           space: _style.spaceWhenUnsplit && _elements.isNotEmpty);
 
       writer.setAllowNewlines(true);

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -110,15 +110,15 @@ class ListPiece extends Piece {
   void format(CodeWriter writer, State state) {
     // Format the opening bracket, if there is one.
     if (_before case var before?) {
-      if (_style.splitListIfBeforeSplits && state == State.unsplit) {
-        writer.setAllowNewlines(false);
-      }
+      writer.pushAllowNewlines(
+          !_style.splitListIfBeforeSplits || state != State.unsplit);
 
       writer.format(before);
 
-      if (state == State.unsplit) {
-        writer.setAllowNewlines(false);
-      } else {
+      writer.popAllowNewlines();
+      writer.pushAllowNewlines(state != State.unsplit);
+
+      if (state != State.unsplit) {
         writer.pushIndent(Indent.block);
       }
 
@@ -133,7 +133,8 @@ class ListPiece extends Piece {
 
       // Only some elements (usually a single block element) allow newlines
       // when the list itself isn't split.
-      writer.setAllowNewlines(
+      if (_before != null || i > 0) writer.popAllowNewlines();
+      writer.pushAllowNewlines(
           element.allowNewlinesWhenUnsplit || state == State.split);
 
       // If this element allows newlines when the list isn't split, add
@@ -172,9 +173,12 @@ class ListPiece extends Piece {
       writer.splitIf(state != State.unsplit,
           space: _style.spaceWhenUnsplit && _elements.isNotEmpty);
 
-      writer.setAllowNewlines(true);
+      if (_before != null || _elements.isNotEmpty) writer.popAllowNewlines();
+      writer.pushAllowNewlines(true);
       writer.format(after);
     }
+
+    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/postfix.dart
+++ b/lib/src/piece/postfix.dart
@@ -28,12 +28,8 @@ class PostfixPiece extends Piece {
 
   @override
   void format(CodeWriter writer, State state) {
-    // If any of the operands split, then force the postfix sequence to split
-    // too.
-    // TODO(tall): This will need to be revisited when we use PostfixPiece for
-    // actual postfix operators where this isn't always desired.
-    if (state == State.unsplit) writer.setAllowNewlines(false);
-
+    // If any operand splits, then force the postfix sequence to split too.
+    writer.pushAllowNewlines(state == State.split);
     writer.pushIndent(Indent.expression);
 
     for (var piece in pieces) {
@@ -42,6 +38,7 @@ class PostfixPiece extends Piece {
     }
 
     writer.popIndent();
+    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/postfix.dart
+++ b/lib/src/piece/postfix.dart
@@ -34,10 +34,14 @@ class PostfixPiece extends Piece {
     // actual postfix operators where this isn't always desired.
     if (state == State.unsplit) writer.setAllowNewlines(false);
 
+    writer.pushIndent(Indent.expression);
+
     for (var piece in pieces) {
-      writer.splitIf(state == State.split, indent: Indent.expression);
+      writer.splitIf(state == State.split);
       writer.format(piece);
     }
+
+    writer.popIndent();
   }
 
   @override

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -55,7 +55,7 @@ class SequencePiece extends Piece {
       }
     }
 
-    if (_leftBracket != null || _elements.isNotEmpty) writer.popIndent();
+    if (_leftBracket != null || _elements.length > 1) writer.popIndent();
 
     if (_rightBracket case var rightBracket?) {
       writer.splitIf(state == State.split, space: false);

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -33,8 +33,8 @@ class SequencePiece extends Piece {
 
     if (_leftBracket case var leftBracket?) {
       writer.format(leftBracket);
-      writer.splitIf(state == State.split,
-          space: false, indent: _elements.firstOrNull?._indent ?? 0);
+      writer.pushIndent(_elements.firstOrNull?._indent ?? 0);
+      writer.splitIf(state == State.split, space: false);
     }
 
     for (var i = 0; i < _elements.length; i++) {
@@ -50,13 +50,16 @@ class SequencePiece extends Piece {
       writer.format(element, separate: separate);
 
       if (i < _elements.length - 1) {
-        writer.newline(
-            blank: element.blankAfter, indent: _elements[i + 1]._indent);
+        if (_leftBracket != null || i > 0) writer.popIndent();
+        writer.pushIndent(_elements[i + 1]._indent);
+        writer.newline(blank: element.blankAfter);
       }
     }
 
+    if (_leftBracket != null || _elements.isNotEmpty) writer.popIndent();
+
     if (_rightBracket case var rightBracket?) {
-      writer.splitIf(state == State.split, space: false, indent: Indent.none);
+      writer.splitIf(state == State.split, space: false);
       writer.format(rightBracket);
     }
   }

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../back_end/code_writer.dart';
-import '../constants.dart';
 import 'piece.dart';
 
 /// A piece for a series of statements or members inside a block or declaration
@@ -29,7 +28,7 @@ class SequencePiece extends Piece {
 
   @override
   void format(CodeWriter writer, State state) {
-    writer.setAllowNewlines(state == State.split);
+    writer.pushAllowNewlines(state == State.split);
 
     if (_leftBracket case var leftBracket?) {
       writer.format(leftBracket);
@@ -62,6 +61,8 @@ class SequencePiece extends Piece {
       writer.splitIf(state == State.split, space: false);
       writer.format(rightBracket);
     }
+
+    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/variable.dart
+++ b/lib/src/piece/variable.dart
@@ -66,10 +66,8 @@ class VariablePiece extends Piece {
     // variables and their initializers.
     if (state == _betweenVariables) writer.pushIndent(Indent.expression);
 
-    // Force variables to split if an initializer does.
-    if (_variables.length > 1 && state == State.unsplit) {
-      writer.setAllowNewlines(false);
-    }
+    // Force multiple variables to split if an initializer does.
+    writer.pushAllowNewlines(_variables.length == 1 || state != State.unsplit);
 
     // Split after the type annotation.
     writer.splitIf(state == _afterType);
@@ -83,6 +81,8 @@ class VariablePiece extends Piece {
     }
 
     if (state == _betweenVariables) writer.popIndent();
+
+    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/variable.dart
+++ b/lib/src/piece/variable.dart
@@ -64,7 +64,7 @@ class VariablePiece extends Piece {
 
     // If we split at the variables (but not the type), then indent the
     // variables and their initializers.
-    if (state == _betweenVariables) writer.setIndent(Indent.expression);
+    if (state == _betweenVariables) writer.pushIndent(Indent.expression);
 
     // Force variables to split if an initializer does.
     if (_variables.length > 1 && state == State.unsplit) {
@@ -81,6 +81,8 @@ class VariablePiece extends Piece {
       // TODO(perf): Investigate whether it's worth using `separate:` here.
       writer.format(_variables[i]);
     }
+
+    if (state == _betweenVariables) writer.popIndent();
   }
 
   @override

--- a/test/pattern/constant.stmt
+++ b/test/pattern/constant.stmt
@@ -1,0 +1,18 @@
+40 columns                              |
+>>> Split in qualified name.
+if (object case veryLongPrefix.longIdentifierName) {;}
+<<<
+if (object
+    case veryLongPrefix
+        .longIdentifierName) {
+  ;
+}
+>>> Split in property chain.
+if (object case longPrefix.longType.longIdentifierName) {;}
+<<<
+if (object
+    case longPrefix
+        .longType
+        .longIdentifierName) {
+  ;
+}

--- a/test/pattern/declared_variable_comment.stmt
+++ b/test/pattern/declared_variable_comment.stmt
@@ -42,7 +42,8 @@ if (obj
   ;
 }
 <<<
-if (obj case final // c
+if (obj
+    case final // c
         thisIsReallyQuiteAVeryLongVariableName) {
   ;
 }

--- a/test/pattern/list.stmt
+++ b/test/pattern/list.stmt
@@ -1,5 +1,5 @@
 40 columns                              |
->>> Basic list patterns. 
+>>> Basic list patterns.
 switch (obj) {
 case  [  ]  :
 case  <  int  >  [  ]  :
@@ -86,6 +86,25 @@ if (obj case <
 >[
   element,
   VeryLongElementElementElement,
+]) {
+  ;
+}
+>>> Split inside element forces list to split.
+if (obj case [first,secondLongPattern ||thirdVeryLongPattern]) {;}
+<<<
+if (obj case [
+  first,
+  secondLongPattern ||
+      thirdVeryLongPattern,
+]) {
+  ;
+}
+>>> Split in rest element does not split after "...".
+if (obj case [...firstPattern || secondVeryLongPattern]) {;}
+<<<
+if (obj case [
+  ...firstPattern ||
+      secondVeryLongPattern,
 ]) {
   ;
 }

--- a/test/pattern/logic.stmt
+++ b/test/pattern/logic.stmt
@@ -1,0 +1,51 @@
+40 columns                              |
+>>> Unsplit.
+if (o case 1   ||  2   &&  3  ) {}
+<<<
+if (o case 1 || 2 && 3) {}
+>>> Nested as subpattern.
+if (o case 1   &&  (  2   ||  3   )  ) {}
+<<<
+if (o case 1 && (2 || 3)) {}
+>>> Chain of same logic operator all split together.
+if (object case first || second || third || fourth) {;}
+<<<
+if (object
+    case first ||
+        second ||
+        third ||
+        fourth) {
+  ;
+}
+>>> Chains of different logic operators split separately.
+if (object case first && second || third && fourth && fifth && sixth) {;}
+<<<
+if (object
+    case first && second ||
+        third &&
+            fourth &&
+            fifth &&
+            sixth) {
+  ;
+}
+>>> Chains of different logic operators split separately.
+if (object case first && second && third && fourth || fifth && sixth) {;}
+<<<
+if (object
+    case first &&
+            second &&
+            third &&
+            fourth ||
+        fifth && sixth) {
+  ;
+}
+>>> Multiple split variables as logic operands.
+if (object case SomeVeryLongTypeName anAlsoLongVariableName || AnotherLongTypeName anotherLongVariableName) {;}
+<<<
+if (object
+    case SomeVeryLongTypeName
+        anAlsoLongVariableName ||
+        AnotherLongTypeName
+        anotherLongVariableName) {
+  ;
+}

--- a/test/pattern/map.stmt
+++ b/test/pattern/map.stmt
@@ -56,3 +56,14 @@ if (e case {
   a: longPattern1,
   b: veryLongPattern2,
 }) {}
+>>> Split inside value forces map to split.
+if (obj case {firstKey: first, secondKey: secondLongPattern ||thirdLongPattern}) {;}
+<<<
+if (obj case {
+  firstKey: first,
+  secondKey:
+      secondLongPattern ||
+          thirdLongPattern,
+}) {
+  ;
+}


### PR DESCRIPTION
Trying to get infix patterns indenting correctly has proved surprisingly hard. This PR does it, but it does so by first doing some significant refactoring to CodeWriter, and then adding a new indentation mechanism that is only used by if-case. I'm not sure if it's the best approach.

## The problem

The way if-case statements are styled in the new back end is a little unusual. Here are some examples:

```dart
if (object
    case first ||
        second ||
        third ||
        fourth) {
  ;
}

if (object
    case veryLongPrefix
        .longIdentifierName) {
  ;
}

if (obj
    case SomeLongTypeName
        longVariableName) {
  ;
}

if (obj
    case var // c
        x) {
  ;
}
```

In all four examples, the line after the `case` line is indented +4 relative to the previous line. The tricky part is: *Where* does that indentation come from?

Infix operators indent their subsequent operands, so in the first example, the natural answer would be that we let the infix pattern handle it and if-case doesn't need to add any indentation. Likewise the second example.

But in the third example, variable declarations don't increase indentation when they split before the type and name. Likewise in the fourth example. So in those cases, the if-case itself would be responsible for increasing the indentation.

If we make the if-case Piece always increase the indentation, the last two examples look right, but then you get double indentation on the first two:

```dart
if (object
    case first ||
            second ||
            third ||
            fourth) {
  ;
}

if (object
    case veryLongPrefix
            .longIdentifierName) {
  ;
}
```

If we make the if-case Piece never increase the indentation, then the last two examples are wrong:

```dart
if (obj
    case SomeLongTypeName
    longVariableName) {
  ;
}

if (obj
    case var // c
    x) {
  ;
}
```

We could make the if-case Piece look at the AST node of the pattern and determine if that node will increase the indentation. If not, then the if-case Piece will do it, otherwise it lets the pattern handle it. But given that constant patterns can contain any expression, that would mean looking through the whole expression grammar to try to figure out which expression types will indent when they split and which don't.

That seems extremely brittle to me.

## Solution

The solution I implemented here is to add support for a kind of "collapsible" indentation. What we really want for if-case is to always indent +4 and only +4. If both if-case and the pattern try to indent, the two should be merged together, sort of like [margin collapse in CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing).

I have that working and it does neatly fix the problem.

But it feels pretty strange to me for CodeWriter to have this funny little indentation mechanism that's only used here. It's possible we could use it a couple of other places that have similar styling. In particular, the old formatter has some logic to avoid redundant indentation for certain kinds of expression function bodies, like:

```dart
function() =>
    operand +
    another +
    third;
```

Note how `another` isn't indented further than `operand` like it usually would be. We might be able to use collapsible indentation here too.

So this could be an overall nice approach. But the mechanism does feel a little squishy to me and I don't love it. At the same time, I don't have any brilliant ideas for a better approach yet.

## The PR

*   In order to implement collapsible indentation, I first refactored the CodeWriter's indent API to be more explicitly stack-based. That wasn't *strictly* necessary, but Kallen has asked for it to be more push-pop based already and it seemed like the right time to make the change.

    That's the first commit. The resulting API feels a little more explicit, which is good. But I did find it annoying sometimes to correctly keep track of when I need to pop a state, and had a couple of bugs where I forgot to pop or popped too many.

*   Likewise, I made a similar change for the "allow newline" API. That's the second commit.

*   The third commit just reorganizes `ChainPiece.format()` to be a little more redundant but I think easier to read.

*   The fourth commit adds support for logic patterns and parenthesized patterns. It also adds some additional tests for constant patterns and variable patterns. Note that adding the new patterns is trivial: the code is just like infix and parenthesized expressions. The only work needed to get the indentation correct is the one line change in AssignPiece (which is used for `case <pattern>` in if-case) to let its indentation collapse.

Overall, I'm a little on the fence with these changes. But they do work, and we need to do something to get the rest of patterns going.
