### PR TITLE
Format metadata annotations.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -117,7 +117,14 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitAnnotation(Annotation node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      b.token(node.atSign);
+      b.visit(node.name);
+      b.visit(node.typeArguments);
+      b.token(node.period);
+      b.visit(node.constructorName);
+      b.visit(node.arguments);
+    });
   }
 
   @override
@@ -360,6 +367,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitConstructorDeclaration(ConstructorDeclaration node) {
     var header = buildPiece((b) {
+      b.metadata(node.metadata);
       b.modifier(node.externalKeyword);
       b.modifier(node.constKeyword);
       b.modifier(node.factoryKeyword);
@@ -500,7 +508,8 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitEnumDeclaration(EnumDeclaration node) {
-    if (node.metadata.isNotEmpty) throw UnimplementedError();
+    var metadataBuilder = AdjacentBuilder(this);
+    metadataBuilder.metadata(node.metadata);
 
     var header = buildPiece((b) {
       b.token(node.enumKeyword);
@@ -512,6 +521,9 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
     if (node.members.isEmpty) {
       // If there are no members, format the constants like a delimited list.
       // This keeps the enum declaration on one line if it fits.
+      // TODO(tall): The old style preserves blank lines and newlines between
+      // enum values. A newline will also force the enum to split even if it
+      // would otherwise fit. Do we want to do that with the new style too?
       var builder = DelimitedListBuilder(
           this,
           const ListStyle(
@@ -519,41 +531,43 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
       builder.leftBracket(node.leftBracket, preceding: header);
       node.constants.forEach(builder.visit);
       builder.rightBracket(semicolon: node.semicolon, node.rightBracket);
-      return builder.build();
+      metadataBuilder.add(builder.build());
     } else {
-      var builder = AdjacentBuilder(this);
-      builder.add(header);
-      builder.space();
+      metadataBuilder.add(buildPiece((b) {
+        b.add(header);
+        b.space();
 
-      // If there are members, format it like a block where each constant and
-      // member is on its own line.
-      var sequence = SequenceBuilder(this);
-      sequence.leftBracket(node.leftBracket);
+        // If there are members, format it like a block where each constant and
+        // member is on its own line.
+        var members = SequenceBuilder(this);
+        members.leftBracket(node.leftBracket);
 
-      for (var constant in node.constants) {
-        sequence.addCommentsBefore(constant.firstNonCommentToken);
-        sequence.add(createEnumConstant(constant,
-            hasMembers: true,
-            isLastConstant: constant == node.constants.last,
-            semicolon: node.semicolon));
-      }
+        for (var constant in node.constants) {
+          members.addCommentsBefore(constant.firstNonCommentToken);
+          members.add(createEnumConstant(constant,
+              hasMembers: true,
+              isLastConstant: constant == node.constants.last,
+              semicolon: node.semicolon));
+        }
 
-      // Insert a blank line between the constants and members.
-      sequence.addBlank();
+        // Insert a blank line between the constants and members.
+        members.addBlank();
 
-      for (var node in node.members) {
-        sequence.visit(node);
+        for (var node in node.members) {
+          members.visit(node);
 
-        // If the node has a non-empty braced body, then require a blank line
-        // between it and the next node.
-        if (node.hasNonEmptyBody) sequence.addBlank();
-      }
+          // If the node has a non-empty braced body, then require a blank line
+          // between it and the next node.
+          if (node.hasNonEmptyBody) members.addBlank();
+        }
 
-      sequence.rightBracket(node.rightBracket);
+        members.rightBracket(node.rightBracket);
 
-      builder.add(sequence.build());
-      return builder.build();
+        b.add(members.build());
+      }));
     }
+
+    return metadataBuilder.build();
   }
 
   @override
@@ -606,6 +620,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitFieldDeclaration(FieldDeclaration node) {
     return buildPiece((b) {
+      b.metadata(node.metadata);
       b.modifier(node.externalKeyword);
       b.modifier(node.staticKeyword);
       b.modifier(node.abstractKeyword);
@@ -739,6 +754,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitFunctionDeclaration(FunctionDeclaration node) {
     return createFunction(
+        metadata: node.metadata,
         modifiers: [node.externalKeyword],
         returnType: node.returnType,
         propertyKeyword: node.propertyKeyword,
@@ -784,11 +800,11 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitFunctionTypeAlias(FunctionTypeAlias node) {
-    if (node.metadata.isNotEmpty) throw UnimplementedError();
-
     return buildPiece((b) {
+      b.metadata(node.metadata);
       b.token(node.typedefKeyword);
       b.space();
+      b.visit(node.returnType, spaceAfter: true);
       b.token(node.name);
       b.visit(node.typeParameters);
       b.visit(node.parameters);
@@ -815,9 +831,8 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitGenericTypeAlias(GenericTypeAlias node) {
-    if (node.metadata.isNotEmpty) throw UnimplementedError();
-
     return buildPiece((b) {
+      b.metadata(node.metadata);
       b.token(node.typedefKeyword);
       b.space();
       b.token(node.name);
@@ -1088,7 +1103,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitLibraryDirective(LibraryDirective node) {
     return buildPiece((b) {
-      createDirectiveMetadata(node);
+      b.metadata(node.metadata);
       b.token(node.libraryKeyword);
       b.visit(node.name2, spaceBefore: true);
       b.token(node.semicolon);
@@ -1177,6 +1192,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitMethodDeclaration(MethodDeclaration node) {
     return createFunction(
+        metadata: node.metadata,
         modifiers: [node.externalKeyword, node.modifierKeyword],
         returnType: node.returnType,
         propertyKeyword: node.operatorKeyword ?? node.propertyKeyword,
@@ -1302,7 +1318,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitPartDirective(PartDirective node) {
     return buildPiece((b) {
-      createDirectiveMetadata(node);
+      b.metadata(node.metadata);
       b.token(node.partKeyword);
       b.space();
       b.visit(node.uri);
@@ -1313,8 +1329,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitPartOfDirective(PartOfDirective node) {
     return buildPiece((b) {
-      createDirectiveMetadata(node);
-
+      b.metadata(node.metadata);
       b.token(node.partKeyword);
       b.space();
       b.token(node.ofKeyword);
@@ -1352,13 +1367,27 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitPatternVariableDeclaration(PatternVariableDeclaration node) {
-    throw UnimplementedError();
+    // TODO(tall): This is just a basic implementation for the metadata tests.
+    // It still needs a full implementation and tests.
+    return buildPiece((b) {
+      b.metadata(node.metadata);
+      b.token(node.keyword);
+      b.space();
+      b.visit(node.pattern);
+      b.space();
+      b.token(node.equals);
+      b.space();
+      b.visit(node.expression);
+    });
   }
 
   @override
   Piece visitPatternVariableDeclarationStatement(
       PatternVariableDeclarationStatement node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      b.visit(node.declaration);
+      b.token(node.semicolon);
+    });
   }
 
   @override
@@ -1733,6 +1762,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
     return buildPiece((b) {
+      b.metadata(node.metadata);
       b.modifier(node.externalKeyword);
       b.visit(node.variables);
       b.token(node.semicolon);
@@ -1752,6 +1782,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitTypeParameter(TypeParameter node) {
     return buildPiece((b) {
+      b.metadata(node.metadata, inline: true);
       b.token(node.name);
       if (node.bound case var bound?) {
         b.space();
@@ -1775,10 +1806,8 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitVariableDeclarationList(VariableDeclarationList node) {
-    // TODO(tall): Format metadata.
-    if (node.metadata.isNotEmpty) throw UnimplementedError();
-
     var header = buildPiece((b) {
+      b.metadata(node.metadata);
       b.modifier(node.lateKeyword);
       b.modifier(node.keyword);
 

--- a/lib/src/front_end/sequence_builder.dart
+++ b/lib/src/front_end/sequence_builder.dart
@@ -41,7 +41,16 @@ class SequenceBuilder {
   bool _mustSplit = false;
   bool get mustSplit => _mustSplit;
 
-  SequencePiece build({bool forceSplit = false}) {
+  Piece build({bool forceSplit = false}) {
+    // If the sequence only contains a single piece, just return it directly
+    // and discard the unnecessary wrapping.
+    if (_leftBracket == null &&
+        _elements.length == 1 &&
+        _elements.single.hangingComments.isEmpty &&
+        _rightBracket == null) {
+      return _elements.single.piece;
+    }
+
     // Discard any trailing blank line after the last element.
     if (_elements.isNotEmpty) {
       _elements.last.blankAfter = false;
@@ -83,9 +92,10 @@ class SequenceBuilder {
 
   /// Visits [node] and adds the resulting [Piece] to this sequence, handling
   /// any comments or blank lines that appear before it.
-  void visit(AstNode node, {int? indent}) {
+  void visit(AstNode node, {int? indent, bool allowBlankAfter = true}) {
     addCommentsBefore(node.firstNonCommentToken);
-    add(_visitor.nodePiece(node), indent: indent);
+    add(_visitor.nodePiece(node),
+        indent: indent, allowBlankAfter: allowBlankAfter);
   }
 
   /// Appends a blank line before the next piece in the sequence.

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -487,3 +487,10 @@ class ListStyle {
       this.splitListIfBeforeSplits = false,
       this.allowBlockElement = false});
 }
+
+enum E {
+  a,
+
+  b,
+  c,
+}

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -487,10 +487,3 @@ class ListStyle {
       this.splitListIfBeforeSplits = false,
       this.allowBlockElement = false});
 }
-
-enum E {
-  a,
-
-  b,
-  c,
-}

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -89,7 +89,7 @@ class SequenceElementPiece extends Piece {
   final int _indent;
 
   /// The [Piece] for the element.
-  final Piece _piece;
+  final Piece piece;
 
   /// The comments that should appear at the end of this element's line.
   final List<Piece> hangingComments = [];
@@ -97,11 +97,11 @@ class SequenceElementPiece extends Piece {
   /// Whether there should be a blank line after this element.
   bool blankAfter = false;
 
-  SequenceElementPiece(this._indent, this._piece);
+  SequenceElementPiece(this._indent, this.piece);
 
   @override
   void format(CodeWriter writer, State state) {
-    writer.format(_piece);
+    writer.format(piece);
 
     for (var comment in hangingComments) {
       writer.space();
@@ -111,7 +111,7 @@ class SequenceElementPiece extends Piece {
 
   @override
   void forEachChild(void Function(Piece piece) callback) {
-    callback(_piece);
+    callback(piece);
     for (var comment in hangingComments) {
       callback(comment);
     }

--- a/test/README.md
+++ b/test/README.md
@@ -68,6 +68,7 @@ declaration/  - Typedef, class, enum, extension, mixin, and member declarations.
                 but not functions and variables, which are in their own
                 directories below.
 expression/   - Expressions and collection elements.
+function/     - Function declarations.
 invocation/   - Function and member invocations.
 pattern/      - Patterns.
 selection/    - Test preserving selection information.

--- a/test/declaration/enum_metadata.unit
+++ b/test/declaration/enum_metadata.unit
@@ -1,0 +1,38 @@
+40 columns                              |
+>>> On enum.
+@Awesome @Fierce("really")
+enum Primate{bonobo,chimp,gorilla}
+<<<
+@Awesome
+@Fierce("really")
+enum Primate { bonobo, chimp, gorilla }
+>>> On enum cases.
+enum Foo { a, @meta b, @meta1 @meta2 c}
+<<<
+enum Foo {
+  a,
+  @meta
+  b,
+  @meta1
+  @meta2
+  c,
+}
+>>> Remove blank lines before enum case with metadata.
+enum Foo { a,
+
+
+
+@meta b}
+<<<
+enum Foo {
+  a,
+  @meta
+  b,
+}
+>>> Metadata on enum case forces enum to split.
+enum Foo { @m a }
+<<<
+enum Foo {
+  @m
+  a,
+}

--- a/test/declaration/member_metadata.unit
+++ b/test/declaration/member_metadata.unit
@@ -1,0 +1,87 @@
+40 columns                              |
+>>> On members.
+class X {
+  @meta   var _x;
+  @meta       X.y();
+  @meta   factory X(x) => null;
+  @meta  int x() => null;
+}
+<<<
+class X {
+  @meta
+  var _x;
+  @meta
+  X.y();
+  @meta
+  factory X(x) => null;
+  @meta
+  int x() => null;
+}
+>>> Put member annotations on their own lines.
+class X {
+  @meta @another  var _x;
+  @meta @another       X.y();
+  @meta @another  factory X(x) => null;
+  @meta @another  int x() => null;
+}
+<<<
+class X {
+  @meta
+  @another
+  var _x;
+  @meta
+  @another
+  X.y();
+  @meta
+  @another
+  factory X(x) => null;
+  @meta
+  @another
+  int x() => null;
+}
+>>> On covariant field.
+class Foo {
+@wat  covariant    int zoop;
+}
+<<<
+class Foo {
+  @wat
+  covariant int zoop;
+}
+>>> On late fields.
+class B {
+  @meta late int c;
+  method() {
+    @meta late int d;
+  }
+}
+<<<
+class B {
+  @meta
+  late int c;
+  method() {
+    @meta
+    late int d;
+  }
+}
+>>> On external field.
+class C {
+  @meta  external static   var  x;
+  @meta  external var x;
+}
+<<<
+class C {
+  @meta
+  external static var x;
+  @meta
+  external var x;
+}
+>>> On abstract field.
+class C {
+  @meta  abstract var x;
+}
+<<<
+class C {
+  @meta
+  abstract var x;
+}

--- a/test/declaration/metadata.unit
+++ b/test/declaration/metadata.unit
@@ -1,0 +1,74 @@
+40 columns                              |
+>>> Collapse newlines between annotations.
+@a
+
+
+@b
+
+
+
+@c
+
+
+class A {}
+<<<
+@a
+@b
+@c
+class A {}
+>>> On class.
+@meta class X {}
+
+@a @b class A {}
+
+@meta class Y = X with Z;
+<<<
+@meta
+class X {}
+
+@a
+@b
+class A {}
+
+@meta
+class Y = X with Z;
+>>> On mixin.
+@meta   mixin M {}
+
+@meta  base   mixin N {}
+<<<
+@meta
+mixin M {}
+
+@meta
+base mixin N {}
+>>> On extension
+@meta extension A on B {}
+<<<
+@meta
+extension A on B {}
+>>> On old style typedef.
+@meta typedef void X(y);
+<<<
+@meta
+typedef void X(y);
+>>> On function typedef.
+@foo typedef Fn = Function();
+<<<
+@foo
+typedef Fn = Function();
+>>> On non-function typedef.
+@foo typedef Hash< @a  K, @b(  1  )  V  >  =  Map < K ,  V >   ;
+<<<
+@foo
+typedef Hash<@a K, @b(1) V> = Map<K, V>;
+>>> On type parameter.
+class Foo<
+
+@a
+
+@b
+
+T> {}
+<<<
+class Foo<@a @b T> {}

--- a/test/declaration/metadata_comment.unit
+++ b/test/declaration/metadata_comment.unit
@@ -1,0 +1,19 @@
+40 columns                              |
+>>> Comment after metadata.
+@DomName('DatabaseCallback')
+@Experimental() // deprecated
+class C {}
+<<<
+@DomName('DatabaseCallback')
+@Experimental() // deprecated
+class C {}
+>>> Comment between metadata.
+@DomName('DatabaseCallback') // deprecated
+@Experimental()
+class C {}
+<<<
+@DomName(
+  'DatabaseCallback',
+) // deprecated
+@Experimental()
+class C {}

--- a/test/function/metadata.unit
+++ b/test/function/metadata.unit
@@ -1,0 +1,90 @@
+40 columns                              |
+>>> Splitting in one parameter's metadata doesn't force others to split.
+function(@Annotation longParameter,
+  // Comment.
+@Annotation @Other @Third longParameter2,) {}
+<<<
+function(
+  @Annotation longParameter,
+  // Comment.
+  @Annotation
+  @Other
+  @Third
+  longParameter2,
+) {}
+>>> Split after metadata.
+@meta foo() {}
+<<<
+@meta
+foo() {}
+>>> Split after each annotation.
+@meta @another foo() {}
+<<<
+@meta
+@another
+foo() {}
+>>> Unsplit on parameter.
+foo(
+
+@a
+
+@b
+
+param) {}
+<<<
+foo(@a @b param) {}
+>>> Keep "covariant" with parameter.
+class A { function(@Annotation @VeryLongMetadataAnnotation covariant longParameter) {} }
+<<<
+class A {
+  function(
+    @Annotation
+    @VeryLongMetadataAnnotation
+    covariant longParameter,
+  ) {}
+}
+>>> Keep "required" with parameter.
+class A { function({@Annotation @VeryLongMetadataAnnotation required longParameter}) {} }
+<<<
+class A {
+  function({
+    @Annotation
+    @VeryLongMetadataAnnotation
+    required longParameter,
+  }) {}
+}
+>>> On function-typed formal parameter.
+withReturnType(@foo @bar int fn(@foo param)) {}
+withoutReturnType(@foo @bar fn(@foo param)) {}
+<<<
+withReturnType(
+  @foo @bar int fn(@foo param),
+) {}
+withoutReturnType(
+  @foo @bar fn(@foo param),
+) {}
+>>> On default formal parameter.
+positional([@foo bar]) {}
+named({@foo bar}) {}
+<<<
+positional([@foo bar]) {}
+named({@foo bar}) {}
+>>> On initializing formal.
+class Foo {
+  Foo(@bar this.field);
+}
+<<<
+class Foo {
+  Foo(@bar this.field);
+}
+>>> On "super." parameter.
+class Foo {
+  Foo(@bar super.field, [  @foo()   @baz   super.another  ]);
+}
+<<<
+class Foo {
+  Foo(
+    @bar super.field, [
+    @foo() @baz super.another,
+  ]);
+}

--- a/test/top_level/metadata.unit
+++ b/test/top_level/metadata.unit
@@ -1,0 +1,42 @@
+40 columns                              |
+>>> Split before directives.
+@deprecated library foo;
+
+@deprecated import 'dart:io';
+
+@deprecated export 'dart:io';
+<<<
+@deprecated
+library foo;
+
+@deprecated
+import 'dart:io';
+
+@deprecated
+export 'dart:io';
+>>> On part.
+@foo part "part.dart";
+<<<
+@foo
+part "part.dart";
+>>> On part of.
+@foo part of bar;
+<<<
+@foo
+part of bar;
+>>> Remove blank lines between metadata and directive.
+@foo
+
+
+
+import 'foo.dart';
+
+@bar
+
+import 'bar.dart';
+<<<
+@foo
+import 'foo.dart';
+
+@bar
+import 'bar.dart';

--- a/test/type/metadata.stmt
+++ b/test/type/metadata.stmt
@@ -1,0 +1,26 @@
+40 columns                              |
+>>> On unsplit function type parameters.
+Function(@a @b int c, int d) func;
+<<<
+Function(@a @b int c, int d) func;
+>>> On split function type parameters.
+Function(@annotation int param1, int param2, @annotation int param3, int param4) func;
+<<<
+Function(
+  @annotation int param1,
+  int param2,
+  @annotation int param3,
+  int param4,
+) func;
+>>> On unsplit record type field.
+(@a int, {@a double d}) record;
+<<<
+(@a int, {@a double d}) record;
+>>> On split record type field.
+(@anno @tation int, @annotation String s, {@annotation double d}) record;
+<<<
+(
+  @anno @tation int,
+  @annotation String s, {
+  @annotation double d,
+}) record;

--- a/test/variable/metadata.unit
+++ b/test/variable/metadata.unit
@@ -1,0 +1,158 @@
+40 columns                              |
+>>> On top-level variable.
+@DomName('DatabaseCallback')
+@Experimental()
+var variable;
+<<<
+@DomName('DatabaseCallback')
+@Experimental()
+var variable;
+>>> On local variable.
+main() {
+@DomName('DatabaseCallback')
+@Experimental()
+var variable;
+}
+<<<
+main() {
+  @DomName('DatabaseCallback')
+  @Experimental()
+  var variable;
+}
+>>> Unsplit.
+@a.B<C,D>(e,f,g) int i = 0;
+<<<
+@a.B<C, D>(e, f, g)
+int i = 0;
+>>> Split type arguments.
+@BigLongClassName<First, Second, Third>() int i = 0;
+<<<
+@BigLongClassName<
+  First,
+  Second,
+  Third
+>()
+int i = 0;
+>>> Prefer to split value arguments over type arguments.
+@SomeBigClass<
+  TypeArgument
+>(valueArgument)
+int i = 0;
+<<<
+@SomeBigClass<TypeArgument>(
+  valueArgument,
+)
+int i = 0;
+>>> Split both type and value arguments.
+@SomeBigClass<First, Second, Third, Fourth, Fifth>(
+  first, second, third, fourth, fifth, sixth) int i = 0;
+<<<
+@SomeBigClass<
+  First,
+  Second,
+  Third,
+  Fourth,
+  Fifth
+>(
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+  sixth,
+)
+int i = 0;
+>>> Prefer to split at arguments rather than prefix.
+@veryLongPrefix.VeryLongClassName<VeryLongTypeArgument,OtherVeryLongTypeArgument>(veryLongArgument,otherVeryLongArgument,thirdVeryLongArgument) int i = 0;
+<<<
+@veryLongPrefix.VeryLongClassName<
+  VeryLongTypeArgument,
+  OtherVeryLongTypeArgument
+>(
+  veryLongArgument,
+  otherVeryLongArgument,
+  thirdVeryLongArgument,
+)
+int i = 0;
+>>> Nested type arguments without splitting.
+@A<B<C,D>,E<F,G>>() int i = 0;
+<<<
+@A<B<C, D>, E<F, G>>()
+int i = 0;
+>>> Nested type arguments, split at outer level.
+@Aaaa<Bbbb<Cccc,Dddd>,Eeee<Ffff,Gggg>>() int i = 0;
+<<<
+@Aaaa<
+  Bbbb<Cccc, Dddd>,
+  Eeee<Ffff, Gggg>
+>()
+int i = 0;
+>>> Nested type arguments, split at inner level.
+@Aaaaaaaaa<Bbbbbbbbbbb<Ccccccccccc,Dddddddddddd>,Eeeeeeeee<Fffffffff,Ggggggggg>>() int i = 0;
+<<<
+@Aaaaaaaaa<
+  Bbbbbbbbbbb<
+    Ccccccccccc,
+    Dddddddddddd
+  >,
+  Eeeeeeeee<Fffffffff, Ggggggggg>
+>()
+int i = 0;
+>>> Prefixed type.
+@prefix.A<int,String>()int x;
+<<<
+@prefix.A<int, String>()
+int x;
+>>> Named constructor.
+@A<int,String>.constructor()int x;
+<<<
+@A<int, String>.constructor()
+int x;
+>>> Prefixed named constructor.
+@prefix.A<int,String>.constructor()int x;
+<<<
+@prefix.A<int, String>.constructor()
+int x;
+>>> On pattern variable, moves to own line.
+main() {
+  @meta var (x, y) = o;
+}
+<<<
+main() {
+  @meta
+  var (x, y) = o;
+}
+>>> Split after metadata.
+main() {
+  @meta var a;
+
+  @meta
+  var b;
+
+  @a @b
+
+
+  var c;
+}
+<<<
+main() {
+  @meta
+  var a;
+
+  @meta
+  var b;
+
+  @a
+  @b
+  var c;
+}
+>>> On external variable.
+@meta  external var x;
+<<<
+@meta
+external var x;
+>>> On late variable.
+@meta late int a;
+<<<
+@meta
+late int a;


### PR DESCRIPTION
This handles metadata everywhere except on for loop variables. I'll do that later after patterns in for loops are supported.

Since there were some metadata tests on pattern variable declarations, this also includes a trivial implementation of that. There's a TODO to revisit it and add real tests, but it's enough for the metadata tests.

Figuring out where to put the metadata-handling code was a little tricky since so many places in the language can have metadata. I ultimately decided to put it into AdjacentBuilder. Every place that was working with metadata also had one of those builders in play, so that made it easy to add a simple call to `b.metadata()` and get the metadata working.

It does mean that AdjacentBuilder isn't strictly about adjacent pieces anymore, but I think that's OK. In practice, it's used mostly as a general "build pieces out of smaller things" builder.
