### PR TITLE
Format pattern variable declarations, including in for loops.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1394,8 +1394,6 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitPatternVariableDeclaration(PatternVariableDeclaration node) {
-    // TODO(tall): This is just a basic implementation for the metadata tests.
-    // It still needs a full implementation and tests.
     return buildPiece((b) {
       b.metadata(node.metadata);
       b.token(node.keyword);

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -384,7 +384,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
     if (node.redirectedConstructor case var constructor?) {
       redirect = AssignPiece(
           tokenPiece(node.separator!), nodePiece(constructor),
-          allowInnerSplit: false);
+          canBlockSplitRight: false);
     } else if (node.initializers.isNotEmpty) {
       initializerSeparator = tokenPiece(node.separator!);
       initializers = createList(node.initializers,
@@ -586,7 +586,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
       var expression = nodePiece(node.expression);
 
       b.add(AssignPiece(operatorPiece, expression,
-          allowInnerSplit: node.expression.canBlockSplit));
+          canBlockSplitRight: node.expression.canBlockSplit));
       b.token(node.semicolon);
     });
   }
@@ -1400,11 +1400,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
       b.metadata(node.metadata);
       b.token(node.keyword);
       b.space();
-      b.visit(node.pattern);
-      b.space();
-      b.token(node.equals);
-      b.space();
-      b.visit(node.expression);
+      b.add(createAssignment(node.pattern, node.equals, node.expression));
     });
   }
 
@@ -1879,7 +1875,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
         var initializerPiece = nodePiece(initializer, commaAfter: true);
 
         variables.add(AssignPiece(variablePiece, initializerPiece,
-            allowInnerSplit: initializer.canBlockSplit));
+            canBlockSplitRight: initializer.canBlockSplit));
       } else {
         variables.add(tokenPiece(variable.name, commaAfter: true));
       }

--- a/test/expression/collection_for.stmt
+++ b/test/expression/collection_for.stmt
@@ -139,3 +139,29 @@ var l = [for (;;) [if (c) d]];
 var l = [for (;;) [for (c in d) e]];
 <<<
 var l = [for (;;) [for (c in d) e]];
+>>> Pattern for-in.
+var list = [
+for (var (longIdentifier && anotherLongOne) in obj) element
+];
+<<<
+var list = [
+  for (var (longIdentifier &&
+          anotherLongOne)
+      in obj)
+    element,
+];
+>>> Pattern for.
+var list = [
+for (var (longIdentifier && anotherLongOne) = obj; cond; inc) element
+];
+<<<
+var list = [
+  for (
+    var (longIdentifier &&
+            anotherLongOne) =
+        obj;
+    cond;
+    inc
+  )
+    element,
+];

--- a/test/statement/for.stmt
+++ b/test/statement/for.stmt
@@ -15,3 +15,57 @@ for (i = 0; i < 10; i) somethingLonger(i);
 <<<
 for (i = 0; i < 10; i)
   somethingLonger(i);
+>>> Expression split in pattern.
+for (var (longIdentifier && anotherLongOne) = obj; cond; inc) {;}
+<<<
+for (
+  var (longIdentifier &&
+          anotherLongOne) =
+      obj;
+  cond;
+  inc
+) {
+  ;
+}
+>>> Block split in pattern.
+for (var [longIdentifier, anotherReallyLongOne] = obj; cond; inc) {;}
+<<<
+for (
+  var [
+    longIdentifier,
+    anotherReallyLongOne,
+  ] = obj;
+  cond;
+  inc
+) {
+  ;
+}
+>>> With pattern, split in initializer.
+for (var (first, second, third) = longValueExpression + anotherOperand +
+aThirdOperand; cond; inc) {;}
+<<<
+for (
+  var (first, second, third) =
+      longValueExpression +
+          anotherOperand +
+          aThirdOperand;
+  cond;
+  inc
+) {
+  ;
+}
+>>> Split in pattern and initializer.
+for (var (longIdentifier && anotherAlsoLongOne) = longValueExpression +
+anotherOperand + aThirdOperand; cond; inc) {;}
+<<<
+for (
+  var (longIdentifier &&
+          anotherAlsoLongOne) =
+      longValueExpression +
+          anotherOperand +
+          aThirdOperand;
+  cond;
+  inc
+) {
+  ;
+}

--- a/test/statement/for_in.stmt
+++ b/test/statement/for_in.stmt
@@ -84,3 +84,41 @@ for (i in sequence) somethingMuchLonger(i);
 <<<
 for (i in sequence)
   somethingMuchLonger(i);
+>>> Expression split in pattern.
+for (var (longIdentifier && anotherLongOne) in obj) {;}
+<<<
+for (var (longIdentifier &&
+        anotherLongOne)
+    in obj) {
+  ;
+}
+>>> Block split in pattern.
+for (var [longIdentifier, anotherLongOne] in obj) {;}
+<<<
+for (var [
+  longIdentifier,
+  anotherLongOne,
+] in obj) {
+  ;
+}
+>>> With pattern, split in value.
+for (var (first, second, third) in longValueExpression + anotherOperand +
+aThirdOperand) {;}
+<<<
+for (var (first, second, third)
+    in longValueExpression +
+        anotherOperand +
+        aThirdOperand) {
+  ;
+}
+>>> Split in pattern and value.
+for (var (longIdentifier && anotherAlsoLongOne) in longValueExpression +
+anotherOperand + aThirdOperand) {;}
+<<<
+for (var (longIdentifier &&
+        anotherAlsoLongOne)
+    in longValueExpression +
+        anotherOperand +
+        aThirdOperand) {
+  ;
+}

--- a/test/variable/pattern.stmt
+++ b/test/variable/pattern.stmt
@@ -1,0 +1,105 @@
+40 columns                              |
+### Pattern variable declaration statements.
+>>> Prefer to split at "=" instead of pattern.
+var (longIdentifier && anotherOne) = value;
+<<<
+var (longIdentifier && anotherOne) =
+    value;
+>>> Split in infix pattern.
+var (longIdentifier && anotherAlsoLongOne) = value;
+<<<
+var (longIdentifier &&
+        anotherAlsoLongOne) =
+    value;
+>>> Split in list pattern.
+var [first, second, third, fourth, fifth] = value;
+<<<
+var [
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+] = value;
+>>> Split in map pattern.
+var {first: second, third: fourth, fifth: sixth} = value;
+<<<
+var {
+  first: second,
+  third: fourth,
+  fifth: sixth,
+} = value;
+>>> Split in record pattern.
+var (first, second, third, fourth, fifth) = value;
+<<<
+var (
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+) = value;
+>>> Split in object pattern.
+var Foo(:first, :second, :third, :fourth, :fifth) = value;
+<<<
+var Foo(
+  :first,
+  :second,
+  :third,
+  :fourth,
+  :fifth,
+) = value;
+>>> Split in value.
+var (first, second, third) = longValueExpression + anotherOperand + aThirdOperand;
+<<<
+var (first, second, third) =
+    longValueExpression +
+        anotherOperand +
+        aThirdOperand;
+>>> Expression split in both.
+var (longIdentifier && anotherAlsoLongOne) = longValueExpression + anotherOperand + aThirdOperand;
+<<<
+var (longIdentifier &&
+        anotherAlsoLongOne) =
+    longValueExpression +
+        anotherOperand +
+        aThirdOperand;
+>>> Block split in both.
+var (first, second, third, fourth, fifth) = (first, second, third, fourth, fifth);
+<<<
+var (
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+) = (
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+);
+>>> Expression split in pattern, block split in value.
+var (longIdentifier && anotherAlsoLongOne) = (first, second, third, fourth, fifth);
+<<<
+var (longIdentifier &&
+    anotherAlsoLongOne) = (
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+);
+>>> Block split in pattern, expression split in value.
+var (first, second, third, fourth, fifth) = longValueExpression + anotherOperand + aThirdOperand;
+<<<
+var (
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+) = longValueExpression +
+    anotherOperand +
+    aThirdOperand;


### PR DESCRIPTION
This required pretty significantly revamping AssignPiece since now there can be complex syntax on the left side of the `=` too. It went through several iterations but I think I managed to simplify it down to something reasonable that still passes all of the tests.

This PR doesn't do pattern assignment, but that should hopefully be a trivial change after this.
