### PR TITLE
Format null asserts, null checks, and relational patterns.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1293,12 +1293,18 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitNullAssertPattern(NullAssertPattern node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      b.visit(node.pattern);
+      b.token(node.operator);
+    });
   }
 
   @override
   Piece visitNullCheckPattern(NullCheckPattern node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      b.visit(node.pattern);
+      b.token(node.operator);
+    });
   }
 
   @override
@@ -1548,7 +1554,10 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitRelationalPattern(RelationalPattern node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      b.token(node.operator, spaceAfter: true);
+      b.visit(node.operand);
+    });
   }
 
   @override

--- a/test/pattern/null.stmt
+++ b/test/pattern/null.stmt
@@ -1,0 +1,9 @@
+40 columns                              |
+>>> Basic null-check.
+if (o case pattern  ?  ) {}
+<<<
+if (o case pattern?) {}
+>>> Basic null-assert.
+if (o case pattern  !  ) {}
+<<<
+if (o case pattern!) {}

--- a/test/pattern/null_comment.stmt
+++ b/test/pattern/null_comment.stmt
@@ -1,0 +1,41 @@
+40 columns                              |
+>>> Line comment before null-check.
+if (obj case pattern // c
+?) {;}
+<<<
+### Weird, but users rarely write this.
+if (obj
+    case pattern // c
+        ?) {
+  ;
+}
+>>> Line comment after null-check.
+if (obj case pattern? // c
+) {;}
+<<<
+### Weird, but users rarely write this.
+if (obj
+    case pattern? // c
+        ) {
+  ;
+}
+>>> Line comment before null-assert.
+if (obj case pattern // c
+!) {;}
+<<<
+### Weird, but users rarely write this.
+if (obj
+    case pattern // c
+        !) {
+  ;
+}
+>>> Line comment after null-assert.
+if (obj case pattern! // c
+) {;}
+<<<
+### Weird, but users rarely write this.
+if (obj
+    case pattern! // c
+        ) {
+  ;
+}

--- a/test/pattern/relational.stmt
+++ b/test/pattern/relational.stmt
@@ -1,0 +1,33 @@
+40 columns                              |
+>>> Switch with basic relational patterns.
+switch (obj) {
+  case   ==   other:
+  case   !=   other:
+  case   <   other:
+  case   <=   other:
+  case   >   other:
+  case   >=   other:
+    body;
+}
+<<<
+switch (obj) {
+  case == other:
+  case != other:
+  case < other:
+  case <= other:
+  case > other:
+  case >= other:
+    body;
+}
+>>> Relational subpattern.
+if (o case  >  1  &&  <   2 && (  ==   3 )) {}
+<<<
+if (o case > 1 && < 2 && (== 3)) {}
+>>> Split in relational constant expression.
+if (object case != veryLongConstant + expressionThatSplits) {;}
+<<<
+if (object
+    case != veryLongConstant +
+        expressionThatSplits) {
+  ;
+}

--- a/test/pattern/relational_comment.stmt
+++ b/test/pattern/relational_comment.stmt
@@ -1,0 +1,21 @@
+40 columns                              |
+>>> Line comment after relational operator.
+if (obj case <= // c
+someConstant + anotherLongConstant) {;}
+<<<
+if (obj
+    case <= // c
+        someConstant +
+        anotherLongConstant) {
+  ;
+}
+>>> Line comment after relational operand.
+if (obj case <= someConstant + anotherLongConstant // c
+) {;}
+<<<
+if (obj
+    case <= someConstant +
+        anotherLongConstant // c
+        ) {
+  ;
+}


### PR DESCRIPTION
Migrated what tests were left of null-assert, null-check, and relational patterns.
Straightforward implementations for these (I think?).