### PR TITLE
Format relational, null-check, and null-assert patterns.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -181,11 +181,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitAwaitExpression(AwaitExpression node) {
-    return buildPiece((b) {
-      b.token(node.awaitKeyword);
-      b.space();
-      b.visit(node.expression);
-    });
+    return createPrefix(node.awaitKeyword, space: true, node.expression);
   }
 
   @override
@@ -358,10 +354,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitConstantPattern(ConstantPattern node) {
-    return buildPiece((b) {
-      b.token(node.constKeyword, spaceAfter: true);
-      b.visit(node.expression);
-    });
+    return createPrefix(node.constKeyword, space: true, node.expression);
   }
 
   @override
@@ -1293,12 +1286,12 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitNullAssertPattern(NullAssertPattern node) {
-    throw UnimplementedError();
+    return createPostfix(node.pattern, node.operator);
   }
 
   @override
   Piece visitNullCheckPattern(NullCheckPattern node) {
-    throw UnimplementedError();
+    return createPostfix(node.pattern, node.operator);
   }
 
   @override
@@ -1413,10 +1406,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitPostfixExpression(PostfixExpression node) {
-    return buildPiece((b) {
-      b.visit(node.operand);
-      b.token(node.operator);
-    });
+    return createPostfix(node.operand, node.operator);
   }
 
   @override
@@ -1542,7 +1532,11 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitRelationalPattern(RelationalPattern node) {
-    throw UnimplementedError();
+    return buildPiece((b) {
+      b.token(node.operator);
+      b.space();
+      b.visit(node.operand);
+    });
   }
 
   @override
@@ -1574,10 +1568,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitRestPatternElement(RestPatternElement node) {
-    return buildPiece((b) {
-      b.token(node.operator);
-      b.visit(node.pattern);
-    });
+    return createPrefix(node.operator, node.pattern);
   }
 
   @override
@@ -1631,10 +1622,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitSpreadElement(SpreadElement node) {
-    return buildPiece((b) {
-      b.token(node.spreadOperator);
-      b.visit(node.expression);
-    });
+    return createPrefix(node.spreadOperator, node.expression);
   }
 
   @override
@@ -1795,11 +1783,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitThrowExpression(ThrowExpression node) {
-    return buildPiece((b) {
-      b.token(node.throwKeyword);
-      b.space();
-      b.visit(node.expression);
-    });
+    return createPrefix(node.throwKeyword, space: true, node.expression);
   }
 
   @override
@@ -1892,11 +1876,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitWhenClause(WhenClause node) {
-    return buildPiece((b) {
-      b.token(node.whenKeyword);
-      b.space();
-      b.visit(node.expression);
-    });
+    return createPrefix(node.whenKeyword, space: true, node.expression);
   }
 
   @override

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -759,6 +759,25 @@ mixin PieceFactory {
     );
   }
 
+  /// Creates a [Piece] for an AST node followed by an unsplittable token.
+  Piece createPostfix(AstNode node, Token? operator) {
+    return buildPiece((b) {
+      b.visit(node);
+      b.token(operator);
+    });
+  }
+
+  /// Creates a [Piece] for an AST node preceded by an unsplittable token.
+  ///
+  /// If [space] is `true` and there is an operator, writes a space between the
+  /// operator and operand.
+  Piece createPrefix(Token? operator, AstNode? node, {bool space = false}) {
+    return buildPiece((b) {
+      b.token(operator, spaceAfter: space);
+      b.visit(node);
+    });
+  }
+
   /// Creates an [AdjacentPiece] for a given record type field.
   Piece createRecordTypeField(RecordTypeAnnotationField node) {
     return createParameter(metadata: node.metadata, node.type, node.name);

--- a/test/pattern/other.stmt
+++ b/test/pattern/other.stmt
@@ -114,3 +114,11 @@ switch (obj) {
   case const (-foo * bar):
     ok;
 }
+>>> Null-check pattern.
+if (o case pattern  ?  ) {}
+<<<
+if (o case pattern?) {}
+>>> Null-assert pattern.
+if (o case pattern  !  ) {}
+<<<
+if (o case pattern!) {}

--- a/test/pattern/other_comment.stmt
+++ b/test/pattern/other_comment.stmt
@@ -66,3 +66,43 @@ if (obj
         )) {
   ;
 }
+>>> Before null-check.
+### Looks weird, but user should move comment.
+if (obj case pattern // c
+?) {;}
+<<<
+if (obj
+    case pattern // c
+        ?) {
+  ;
+}
+>>> After null-check.
+### Looks weird, but user should move comment.
+if (obj case pattern? // c
+) {;}
+<<<
+if (obj
+    case pattern? // c
+        ) {
+  ;
+}
+>>> Before null-assert.
+### Looks weird, but user should move comment.
+if (obj case pattern // c
+!) {;}
+<<<
+if (obj
+    case pattern // c
+        !) {
+  ;
+}
+>>> After null-assert.
+### Looks weird, but user should move comment.
+if (obj case pattern! // c
+) {;}
+<<<
+if (obj
+    case pattern! // c
+        ) {
+  ;
+}

--- a/test/pattern/relational.stmt
+++ b/test/pattern/relational.stmt
@@ -1,0 +1,33 @@
+40 columns                              |
+>>> All relational operators.
+switch (obj) {
+  case   ==   other:
+  case   !=   other:
+  case   <   other:
+  case   <=   other:
+  case   >   other:
+  case   >=   other:
+    body;
+}
+<<<
+switch (obj) {
+  case == other:
+  case != other:
+  case < other:
+  case <= other:
+  case > other:
+  case >= other:
+    body;
+}
+>>> Relational pattern as subpattern.
+if (o case  >  1  &&  <   2 && (  ==   3 )) {}
+<<<
+if (o case > 1 && < 2 && (== 3)) {}
+>>> Split inside constant.
+if (object case != veryLongConstant + expressionThatSplits) {;}
+<<<
+if (object
+    case != veryLongConstant +
+        expressionThatSplits) {
+  ;
+}

--- a/test/pattern/relational_comment.stmt
+++ b/test/pattern/relational_comment.stmt
@@ -1,0 +1,21 @@
+40 columns                              |
+>>> After operator.
+if (obj case <= // c
+someConstant + anotherLongConstant) {;}
+<<<
+if (obj
+    case <= // c
+        someConstant +
+        anotherLongConstant) {
+  ;
+}
+>>> After operand.
+if (obj case <= someConstant + anotherLongConstant // c
+) {;}
+<<<
+if (obj
+    case <= someConstant +
+        anotherLongConstant // c
+        ) {
+  ;
+}


### PR DESCRIPTION
Since `!` and `?` are structurally identical, I added a createPostfix() helper to PieceFactory for them. Then I went ahead and also refactored the existing postfix-like forms to use that.

Likewise with relational operators and createPrefix().

These are the last UnimplementedErrors in the new back end!
