### PR TITLE
Test that the new style doesn't keep line comments flush left.

### DIFF
--- a/test/declaration/class_comment.unit
+++ b/test/declaration/class_comment.unit
@@ -6,6 +6,17 @@ class C { // comment
 class C {
   // comment
 }
+>>> Indent line comment in body.
+### Note: The old formatter had a special rule that line comments starting at
+### column 1 would not be indented even if the surrounding code otherwise
+### required it. The new style deliberately does not have that rule.
+class C {
+// comment
+}
+<<<
+class C {
+  // comment
+}
 >>> Empty class containing inline block comment.
 class C {   /* comment */  }
 <<<

--- a/test/function/comment.unit
+++ b/test/function/comment.unit
@@ -1,0 +1,24 @@
+40 columns                              |
+>>> Indent line comment in body.
+### Note: The old formatter had a special rule that line comments starting at
+### column 1 would not be indented even if the surrounding code otherwise
+### required it. The new style deliberately does not have that rule.
+main() {
+// comment
+{
+// block
+{
+// nested
+}
+}
+}
+<<<
+main() {
+  // comment
+  {
+    // block
+    {
+      // nested
+    }
+  }
+}


### PR DESCRIPTION
The old formatter style had a special rule that any line comment that was already at column 1 (i.e. the left edge) would not be indented, even if the surrounding code would otherwise indent it. So if you wrote:

```dart
class C {
  void foo() {
// comment
  }
}
```

Then the formatter would output:

```dart
class C {
  void foo() {
// comment
  }
}
```

And not:

```dart
class C {
  void foo() {
    // comment
  }
}
```

The intent was that if you commented out a block of code in your editor, like:

```dart
class C {
  void unused() {
//    code();
  }
}
```

Then the formatter wouldn't then add *more* indentation:

```dart
class C {
  void unused() {
    //    code();
  }
}
```

But in the editors I've tested (VS Code, IntelliJ, Sublime Text, emacs), when they comment out code, they all put the line comment markers *after* the leading indentation, not before. So they will comment it out like:

```dart
class C {
  void unused() {
    // code();
  }
}
```

That makes this feature, I think, not useful.

Also, over the years, a number of users have found it surprising and unhelpful. It's really annoying if you are, for example, generating code, and *want* it to indent the comments with the surrounding structure but you don't want to have to generate some amount of leading indentation just to disable this weird behavior.

The new style doesn't implement this feature. And with this PR, I'm testing that it doesn't implement it and claiming that we *shouldn't* implement it either.
