### PR TITLE
Remove TODO about non-inline block comments.

### DIFF
--- a/lib/src/front_end/comment_writer.dart
+++ b/lib/src/front_end/comment_writer.dart
@@ -113,10 +113,6 @@ class CommentWriter {
       } else if (comment.type == TokenType.SINGLE_LINE_COMMENT) {
         type = CommentType.line;
       } else if (commentLine == previousLine || commentLine == tokenLine) {
-        // TODO(tall): I'm not sure if it makes sense to distinguish block
-        // comments with newlines around them from other block comments in the
-        // new Piece representation. Consider merging CommentType.inlineBlock
-        // and CommentType.block into a single type.
         type = CommentType.inlineBlock;
       } else {
         type = CommentType.block;


### PR DESCRIPTION
The TODO questions whether we should make a distinction between C-style block comments that have newlines around them in the original source or not. If we don't, then the formatter would turn code like:

```dart
main() {
  /*
  entireBody();
  commentedOut();
  forSomeReason();
  */
}
```

Into:

```dart
main() {/*
  entireBody();
  commentedOut();
  forSomeReason();
  */}
```

I did a little scraping of a corpus, and there are quite a few block comments like this in the wild, and I think it looks better to keep them on their own lines if the input code has a newline before or after the comment.

Also, the implementation complexity of distinguishing inline block comments and non-inline ones is trivial. Removing support for it would change like three lines of code.

So I think it's best to just keep supporting the distinction because it leads to better output, is consistent with the current formatter, and doesn't add much complexity.
