### PR TITLE
Force switch expressions to split if they contain a line comment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.3.5-wip
 
+* Ensure switch expressions containing line comments split (#1404).
 * Use language version `3.3` to parse so that code with extension types can be
   formatted.
 * Support formatting the `macro` modifier when the `macros` experiment flag
@@ -11,7 +12,7 @@
   formatting style (#1253).
 * Format extension types.
 * Normalize ignored whitespace and "escaped whitespace" on first line
-  of multiline string literals. (#1235)
+  of multiline string literals (#1235).
 
 ## 2.3.3
 

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -2829,7 +2829,15 @@ class SourceVisitor extends ThrowingAstVisitor {
 
     var hasTrailingComma =
         node.cases.isNotEmpty && node.cases.last.commaAfter != null;
-    _endBody(node.rightBracket, forceSplit: hasTrailingComma);
+
+    // TODO(rnystrom): If there is a line comment at the end of a case, make
+    // sure the switch expression splits. Looking for line comments explicitly
+    // instead of having them harden the surrounding rules is a hack. But this
+    // code will be going away when we move to the new Piece representation, so
+    // going with something expedient.
+    var forceSplit = _containsLineComments(node.cases, node.rightBracket);
+
+    _endBody(node.rightBracket, forceSplit: hasTrailingComma || forceSplit);
   }
 
   @override

--- a/test/regression/1400/1404.stmt
+++ b/test/regression/1400/1404.stmt
@@ -1,0 +1,48 @@
+>>>
+int weird(Object o) {
+  return switch (o) {
+    int i => i, // evil comment
+    _ => 42
+  };
+}
+<<<
+int weird(Object o) {
+  return switch (o) {
+    int i => i, // evil comment
+    _ => 42
+  };
+}
+>>> line comment inside case value expression
+int weird(Object o) {
+  return switch (o) {
+    1 => f(// c
+    ),
+    _ => 42
+  };
+}
+<<<
+int weird(Object o) {
+  return switch (o) {
+    1 => f(// c
+        ),
+    _ => 42
+  };
+}
+>>> line comment inside case pattern
+int weird(Object o) {
+  return switch (o) {
+    [1 // c
+     ] => 2,
+    3 => 4
+  };
+}
+<<<
+int weird(Object o) {
+  return switch (o) {
+    [
+      1 // c
+    ] =>
+      2,
+    3 => 4
+  };
+}


### PR DESCRIPTION
The fix here is pretty hacky, but this is in the old formatter which will be going away hopefully relatively soon. I honestly don't know how to fix it more elegantly and I'm a little worried that any more systemic fix will cause knock-on bugs since I don't have the old code loaded in my head as well as I used to.

Fixes #1404.
