### PR TITLE
For loop metadata

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -521,7 +521,14 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
           this,
           const ListStyle(
               spaceWhenUnsplit: true, splitListIfBeforeSplits: true));
-      builder.leftBracket(node.leftBracket, preceding: header);
+
+      var leftBracket = buildPiece((b) {
+        b.add(header);
+        b.space();
+        b.token(node.leftBracket);
+      });
+
+      builder.addLeftBracket(leftBracket);
       node.constants.forEach(builder.visit);
       builder.rightBracket(semicolon: node.semicolon, node.rightBracket);
       metadataBuilder.add(builder.build());
@@ -677,11 +684,13 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
     // If all parameters are optional, put the `[` or `{` right after `(`.
     var builder = DelimitedListBuilder(this);
-    if (node.parameters.isNotEmpty && firstOptional == 0) {
-      builder.leftBracket(node.leftParenthesis, delimiter: node.leftDelimiter);
-    } else {
-      builder.leftBracket(node.leftParenthesis);
-    }
+
+    builder.addLeftBracket(buildPiece((b) {
+      b.token(node.leftParenthesis);
+      if (node.parameters.isNotEmpty && firstOptional == 0) {
+        b.token(node.leftDelimiter);
+      }
+    }));
 
     for (var i = 0; i < node.parameters.length; i++) {
       // If this is the first optional parameter, put the delimiter before it.
@@ -1481,14 +1490,12 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
     var builder = DelimitedListBuilder(this, listStyle);
 
     // If all parameters are optional, put the `{` right after `(`.
-    if (positionalFields.isEmpty && namedFields != null) {
-      builder.leftBracket(
-        node.leftParenthesis,
-        delimiter: namedFields.leftBracket,
-      );
-    } else {
-      builder.leftBracket(node.leftParenthesis);
-    }
+    builder.addLeftBracket(buildPiece((b) {
+      b.token(node.leftParenthesis);
+      if (positionalFields.isEmpty && namedFields != null) {
+        b.token(namedFields.leftBracket);
+      }
+    }));
 
     for (var positionalField in positionalFields) {
       builder.visit(positionalField);
@@ -1678,7 +1685,12 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
     var list = DelimitedListBuilder(this,
         const ListStyle(spaceWhenUnsplit: true, splitListIfBeforeSplits: true));
-    list.leftBracket(node.leftBracket, preceding: value);
+
+    list.addLeftBracket(buildPiece((b) {
+      b.add(value);
+      b.space();
+      b.token(node.leftBracket);
+    }));
 
     for (var member in node.cases) {
       list.visit(member);

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -439,12 +439,11 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitDeclaredIdentifier(DeclaredIdentifier node) {
-    return buildPiece((b) {
-      b.metadata(node.metadata, inline: true);
-      b.modifier(node.keyword);
-      b.visit(node.type, spaceAfter: true);
-      b.token(node.name);
-    });
+    return createParameter(
+        metadata: node.metadata,
+        modifiers: [node.keyword],
+        node.type,
+        node.name);
   }
 
   @override

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1306,14 +1306,16 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitObjectPattern(ObjectPattern node) {
-    return buildPiece((b) {
+    var header = buildPiece((b) {
       b.visit(node.type);
-      b.add(createCollection(
-        node.leftParenthesis,
-        node.fields,
-        node.rightParenthesis,
-      ));
+      b.token(node.leftParenthesis);
     });
+
+    var builder = DelimitedListBuilder(this);
+    builder.addLeftBracket(header);
+    node.fields.forEach(builder.visit);
+    builder.rightBracket(node.rightParenthesis);
+    return builder.build();
   }
 
   @override

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -440,6 +440,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitDeclaredIdentifier(DeclaredIdentifier node) {
     return buildPiece((b) {
+      b.metadata(node.metadata, inline: true);
       b.modifier(node.keyword);
       b.visit(node.type, spaceAfter: true);
       b.token(node.name);
@@ -1385,7 +1386,13 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitPatternVariableDeclaration(PatternVariableDeclaration node) {
     return buildPiece((b) {
-      b.metadata(node.metadata);
+      // If the variable is part of a for loop, it looks weird to force the
+      // metadata to split since it's in a sort of expression-ish location:
+      //
+      //     for (@meta var (x, y) in pairs) ...
+      b.metadata(node.metadata,
+          inline: node.parent is ForEachPartsWithPattern ||
+              node.parent is ForPartsWithPattern);
       b.token(node.keyword);
       b.space();
       b.add(createAssignment(node.pattern, node.equals, node.expression));
@@ -1834,7 +1841,12 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   @override
   Piece visitVariableDeclarationList(VariableDeclarationList node) {
     var header = buildPiece((b) {
-      b.metadata(node.metadata);
+      // If the variable is part of a for loop, it looks weird to force the
+      // metadata to split since it's in a sort of expression-ish location:
+      //
+      //     for (@meta var x in list) ...
+      b.metadata(node.metadata,
+          inline: node.parent is ForPartsWithDeclarations);
       b.modifier(node.lateKeyword);
       b.modifier(node.keyword);
 

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -525,13 +525,12 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
           const ListStyle(
               spaceWhenUnsplit: true, splitListIfBeforeSplits: true));
 
-      var leftBracket = buildPiece((b) {
+      builder.addLeftBracket(buildPiece((b) {
         b.add(header);
         b.space();
         b.token(node.leftBracket);
-      });
+      }));
 
-      builder.addLeftBracket(leftBracket);
       node.constants.forEach(builder.visit);
       builder.rightBracket(semicolon: node.semicolon, node.rightBracket);
       metadataBuilder.add(builder.build());
@@ -1296,13 +1295,13 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitObjectPattern(ObjectPattern node) {
-    var header = buildPiece((b) {
+    var builder = DelimitedListBuilder(this);
+
+    builder.addLeftBracket(buildPiece((b) {
       b.visit(node.type);
       b.token(node.leftParenthesis);
-    });
+    }));
 
-    var builder = DelimitedListBuilder(this);
-    builder.addLeftBracket(header);
     node.fields.forEach(builder.visit);
     builder.rightBracket(node.rightParenthesis);
     return builder.build();

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -14,7 +14,6 @@ import '../piece/adjacent_strings.dart';
 import '../piece/assign.dart';
 import '../piece/case.dart';
 import '../piece/constructor.dart';
-import '../piece/for.dart';
 import '../piece/if.dart';
 import '../piece/infix.dart';
 import '../piece/list.dart';
@@ -707,70 +706,57 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitForElement(ForElement node) {
-    var forKeyword = buildPiece((b) {
-      b.modifier(node.awaitKeyword);
-      b.token(node.forKeyword);
-    });
-
-    var forPartsPiece = createForLoopParts(
-        node.leftParenthesis, node.forLoopParts, node.rightParenthesis);
-    var body = nodePiece(node.body);
-
-    var forPiece = ForPiece(forKeyword, forPartsPiece, body,
-        hasBlockBody: node.body.isSpreadCollection);
-
-    // It looks weird to have multiple nested control flow elements on the same
-    // line, so force the outer one to split if there is an inner one.
-    if (node.body.isControlFlowElement) {
-      forPiece.pin(State.split);
-    }
-
-    return forPiece;
+    return createFor(
+        awaitKeyword: node.awaitKeyword,
+        forKeyword: node.forKeyword,
+        leftParenthesis: node.leftParenthesis,
+        forLoopParts: node.forLoopParts,
+        rightParenthesis: node.rightParenthesis,
+        body: node.body,
+        hasBlockBody: node.body.isSpreadCollection,
+        forceSplitBody: node.body.isControlFlowElement);
   }
 
   @override
   Piece visitForStatement(ForStatement node) {
-    var forKeyword = buildPiece((b) {
-      b.modifier(node.awaitKeyword);
-      b.token(node.forKeyword);
-    });
-
-    var forPartsPiece = createForLoopParts(
-        node.leftParenthesis, node.forLoopParts, node.rightParenthesis);
-    var body = nodePiece(node.body);
-
-    return ForPiece(forKeyword, forPartsPiece, body,
+    return createFor(
+        awaitKeyword: node.awaitKeyword,
+        forKeyword: node.forKeyword,
+        leftParenthesis: node.leftParenthesis,
+        forLoopParts: node.forLoopParts,
+        rightParenthesis: node.rightParenthesis,
+        body: node.body,
         hasBlockBody: node.body is Block);
   }
 
   @override
   Piece visitForEachPartsWithDeclaration(ForEachPartsWithDeclaration node) {
-    throw UnsupportedError('This node is handled by visitForStatement().');
+    throw UnsupportedError('This node is handled by createFor().');
   }
 
   @override
   Piece visitForEachPartsWithIdentifier(ForEachPartsWithIdentifier node) {
-    throw UnsupportedError('This node is handled by visitForStatement().');
+    throw UnsupportedError('This node is handled by createFor().');
   }
 
   @override
   Piece visitForEachPartsWithPattern(ForEachPartsWithPattern node) {
-    throw UnsupportedError('This node is handled by visitForStatement().');
+    throw UnsupportedError('This node is handled by createFor().');
   }
 
   @override
   Piece visitForPartsWithDeclarations(ForPartsWithDeclarations node) {
-    throw UnsupportedError('This node is handled by visitForStatement().');
+    throw UnsupportedError('This node is handled by createFor().');
   }
 
   @override
   Piece visitForPartsWithExpression(ForPartsWithExpression node) {
-    throw UnsupportedError('This node is handled by visitForStatement().');
+    throw UnsupportedError('This node is handled by createFor().');
   }
 
   @override
   Piece visitForPartsWithPattern(ForPartsWithPattern node) {
-    throw UnsupportedError('This node is handled by visitForStatement().');
+    throw UnsupportedError('This node is handled by createFor().');
   }
 
   @override

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -374,8 +374,12 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
     Piece? initializerSeparator;
     Piece? initializers;
     if (node.redirectedConstructor case var constructor?) {
-      redirect = AssignPiece(
-          tokenPiece(node.separator!), nodePiece(constructor),
+      var separator = buildPiece((b) {
+        b.token(node.separator);
+        b.space();
+      });
+
+      redirect = AssignPiece(separator, nodePiece(constructor),
           canBlockSplitRight: false);
     } else if (node.initializers.isNotEmpty) {
       initializerSeparator = tokenPiece(node.separator!);
@@ -1844,15 +1848,19 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
     for (var variable in node.variables) {
       if ((variable.equals, variable.initializer)
           case (var equals?, var initializer?)) {
-        var variablePiece = buildPiece((b) {
-          b.token(variable.name);
+        var variablePiece = tokenPiece(variable.name);
+
+        var equalsPiece = buildPiece((b) {
           b.space();
           b.token(equals);
         });
 
         var initializerPiece = nodePiece(initializer, commaAfter: true);
 
-        variables.add(AssignPiece(variablePiece, initializerPiece,
+        variables.add(AssignPiece(
+            left: variablePiece,
+            equalsPiece,
+            initializerPiece,
             canBlockSplitRight: initializer.canBlockSplit));
       } else {
         variables.add(tokenPiece(variable.name, commaAfter: true));

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -61,23 +61,13 @@ class DelimitedListBuilder {
   }
 
   /// Adds the opening [bracket] to the built list.
-  ///
-  /// If [delimiter] is given, it is a second bracket occurring immediately
-  /// after [bracket]. This is used for parameter lists where all parameters
-  /// are optional or named, as in:
-  ///
-  ///     function([parameter]);
-  ///
-  /// Here, [bracket] will be `(` and [delimiter] will be `[`.
-  void leftBracket(Token bracket, {Piece? preceding, Token? delimiter}) {
-    _leftBracket = _visitor.buildPiece((b) {
-      if (preceding != null) {
-        b.add(preceding);
-        b.space();
-      }
-      b.token(bracket);
-      b.token(delimiter);
-    });
+  void leftBracket(Token bracket) {
+    addLeftBracket(_visitor.tokenPiece(bracket));
+  }
+
+  /// Adds the opening bracket [piece] to the built list.
+  void addLeftBracket(Piece piece) {
+    _leftBracket = piece;
   }
 
   /// Adds the closing [bracket] to the built list along with any comments that

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import '../ast_extensions.dart';
 import '../piece/assign.dart';
 import '../piece/clause.dart';
+import '../piece/for.dart';
 import '../piece/function.dart';
 import '../piece/if_case.dart';
 import '../piece/infix.dart';
@@ -209,10 +210,22 @@ mixin PieceFactory {
     });
   }
 
-  /// Creates a piece for the parentheses and inner parts of a for statement or
-  /// for element.
-  Piece createForLoopParts(Token leftParenthesis, ForLoopParts forLoopParts,
-      Token rightParenthesis) {
+  /// Creates a piece for a for statement or element.
+  Piece createFor(
+      {required Token? awaitKeyword,
+      required Token forKeyword,
+      required Token leftParenthesis,
+      required ForLoopParts forLoopParts,
+      required Token rightParenthesis,
+      required AstNode body,
+      required bool hasBlockBody,
+      bool forceSplitBody = false}) {
+    var forKeywordPiece = buildPiece((b) {
+      b.modifier(awaitKeyword);
+      b.token(forKeyword);
+    });
+
+    Piece forPartsPiece;
     switch (forLoopParts) {
       // Edge case: A totally empty for loop is formatted just as `(;;)` with
       // no splits or spaces anywhere.
@@ -224,7 +237,7 @@ mixin PieceFactory {
             updaters: NodeList(isEmpty: true),
           )
           when rightParenthesis.precedingComments == null:
-        return buildPiece((b) {
+        forPartsPiece = buildPiece((b) {
           b.token(leftParenthesis);
           b.token(forLoopParts.leftSeparator);
           b.token(forLoopParts.rightSeparator);
@@ -285,7 +298,7 @@ mixin PieceFactory {
         }
 
         partsList.rightBracket(rightParenthesis);
-        return partsList.build();
+        forPartsPiece = partsList.build();
 
       case ForEachParts forEachParts &&
             ForEachPartsWithDeclaration(loopVariable: AstNode variable):
@@ -299,7 +312,7 @@ mixin PieceFactory {
         //     ]) {
         //       body;
         //     }
-        // TODO(tall): Passing `allowInnerSplit: true` allows output like:
+        // TODO(tall): Passing `canBlockSplitLeft: true` allows output like:
         //
         //     // 1
         //     for (variable in longExpression +
@@ -326,11 +339,11 @@ mixin PieceFactory {
         //
         // Currently, the formatter prefers 1 over 3. We may want to revisit
         // that and prefer 3 instead. Or perhaps we shouldn't pass
-        // `allowInnerSplit: true` and force the `in` to split if the
+        // `canBlockSplitLeft: true` and force the `in` to split if the
         // initializer does. That would be consistent with how we handle
         // splitting before `case` when the pattern has a newline in an if-case
         // statement or element.
-        return buildPiece((b) {
+        forPartsPiece = buildPiece((b) {
           b.token(leftParenthesis);
           b.add(createAssignment(
               variable, forEachParts.inKeyword, forEachParts.iterable,
@@ -340,7 +353,7 @@ mixin PieceFactory {
 
       case ForEachParts forEachParts &&
             ForEachPartsWithPattern(:var keyword, :var pattern):
-        return buildPiece((b) {
+        forPartsPiece = buildPiece((b) {
           b.token(leftParenthesis);
           b.token(keyword);
           b.space();
@@ -351,6 +364,15 @@ mixin PieceFactory {
           b.token(rightParenthesis);
         });
     }
+
+    var bodyPiece = nodePiece(body);
+
+    var forPiece = ForPiece(forKeywordPiece, forPartsPiece, bodyPiece,
+        hasBlockBody: hasBlockBody);
+
+    if (forceSplitBody) forPiece.pin(State.split);
+
+    return forPiece;
   }
 
   /// Creates a normal (not function-typed) formal parameter with a name and/or

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -1044,26 +1044,21 @@ mixin PieceFactory {
       _ => false
     };
 
-    Piece leftPiece;
-    Piece rightPiece;
-    if (splitBeforeOperator) {
-      leftPiece = nodePiece(leftHandSide);
+    var leftPiece = nodePiece(leftHandSide);
 
-      rightPiece = buildPiece((b) {
-        b.token(operator);
-        b.space();
-        b.visit(rightHandSide, commaAfter: includeComma);
-      });
-    } else {
-      leftPiece = buildPiece((b) {
-        b.visit(leftHandSide);
-        b.token(operator, spaceBefore: spaceBeforeOperator);
-      });
+    var operatorPiece = buildPiece((b) {
+      if (spaceBeforeOperator) b.space();
+      b.token(operator);
+      if (splitBeforeOperator) b.space();
+    });
 
-      rightPiece = nodePiece(rightHandSide, commaAfter: includeComma);
-    }
+    var rightPiece = nodePiece(rightHandSide, commaAfter: includeComma);
 
-    return AssignPiece(leftPiece, rightPiece,
+    return AssignPiece(
+        left: leftPiece,
+        operatorPiece,
+        rightPiece,
+        splitBeforeOperator: splitBeforeOperator,
         canBlockSplitLeft: canBlockSplitLeft,
         canBlockSplitRight: canBlockSplitRight);
   }

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -347,7 +347,7 @@ mixin PieceFactory {
           b.token(leftParenthesis);
           b.add(createAssignment(
               variable, forEachParts.inKeyword, forEachParts.iterable,
-              splitBeforeOperator: true, canBlockSplitLeft: true));
+              splitBeforeOperator: true));
           b.token(rightParenthesis);
         });
 

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -63,10 +63,14 @@ class AssignPiece extends Piece {
 
   /// The left-hand side of the operation. Includes the operator unless it is
   /// `in`.
-  final Piece _left;
+  final Piece? _left;
+
+  final Piece _operator;
 
   /// The right-hand side of the operation.
   final Piece _right;
+
+  final bool _splitBeforeOperator;
 
   /// If `true`, then the left side supports being block-formatted, like:
   ///
@@ -84,9 +88,14 @@ class AssignPiece extends Piece {
   ///     ];
   final bool _canBlockSplitRight;
 
-  AssignPiece(this._left, this._right,
-      {bool canBlockSplitLeft = false, bool canBlockSplitRight = false})
-      : _canBlockSplitLeft = canBlockSplitLeft,
+  AssignPiece(this._operator, this._right,
+      {Piece? left,
+      bool splitBeforeOperator = false,
+      bool canBlockSplitLeft = false,
+      bool canBlockSplitRight = false})
+      : _left = left,
+        _splitBeforeOperator = splitBeforeOperator,
+        _canBlockSplitLeft = canBlockSplitLeft,
         _canBlockSplitRight = canBlockSplitRight;
 
   // TODO(tall): The old formatter allows the first operand of a split
@@ -165,8 +174,11 @@ class AssignPiece extends Piece {
       writer.pushIndent(Indent.expression, canCollapse: collapseIndent);
     }
 
-    writer.format(_left);
+    if (_left case var left?) writer.format(left);
+
+    if (!_splitBeforeOperator) writer.format(_operator);
     writer.splitIf(state == _atOperator);
+    if (_splitBeforeOperator) writer.format(_operator);
 
     if (indentLeft) writer.popIndent();
     writer.popAllowNewlines();
@@ -184,7 +196,8 @@ class AssignPiece extends Piece {
 
   @override
   void forEachChild(void Function(Piece piece) callback) {
-    callback(_left);
+    if (_left case var left?) callback(left);
+    callback(_operator);
     callback(_right);
   }
 }

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -13,7 +13,7 @@ import 'piece.dart';
 /// "block-like" formatting of delimited expressions on the right, and for the
 /// `in` clause in for-in loops.
 ///
-/// These constructs can be formatted three ways:
+/// These constructs can be formatted four ways:
 ///
 /// [State.unsplit] No split at all:
 ///
@@ -26,40 +26,55 @@ import 'piece.dart';
 ///       element,
 ///     ];
 ///
-/// [_blockSplit] Block split in the operands that support it and expression
-/// split in the others. This state requires at least one operand to support
-/// block splitting. Examples:
+/// [_blockSplitLeft] Force the left-hand side, which must be a [ListPiece], to
+/// split. Allow the right side to split or not. Allows all of:
 ///
 ///     var [
 ///       element,
-///     ] = value;
+///     ] = unsplitRhs;
 ///
 ///     var [
 ///       element,
-///     ] = longOperand +
-///         anotherOperand;
+///     ] = [
+///       'block split RHS',
+///     ];
 ///
-///     var (longVariable &&
+///     var [
+///       element,
+///     ] = 'expression split' +
+///         'the right hand side';
+///
+/// [_blockSplitRight] Allow the right-hand side to block split or not, if it
+/// wants. Since [State.unsplit] and [_blockSplitLeft] also allow the
+/// right-hand side to block split, this state is only used when the left-hand
+/// side expression splits, like:
+///
+///     var (variable &&
 ///         anotherVariable) = [
 ///       element,
 ///     ];
 ///
 /// [_atOperator] Split at the `=` or `in` operator and allow expression
-/// splitting in either operand:
+/// splitting in either operand. Allows all of:
 ///
 ///     var (longVariable &&
 ///             anotherVariable) =
 ///         longOperand +
 ///             anotherOperand;
+///
+///     var [unsplitBlock] =
+///         longOperand +
+///             anotherOperand;
 class AssignPiece extends Piece {
-  /// Split at the operator.
-  ///
-  /// This is more costly because it's generally better to block split in one
-  /// or both of the operands.
-  static const State _atOperator = State(1, cost: 2);
+  /// Force the block left-hand side to split and allow the right-hand side to
+  /// split.
+  static const State _blockSplitLeft = State(1);
 
-  /// Block split in one or both of the operands.
-  static const State _blockSplit = State(2);
+  /// Allow the right-hand side to block split.
+  static const State _blockSplitRight = State(2);
+
+  /// Split at the operator.
+  static const State _atOperator = State(3);
 
   /// The left-hand side of the operation. Includes the operator unless it is
   /// `in`.
@@ -137,9 +152,20 @@ class AssignPiece extends Piece {
   List<State> get additionalStates => [
         // If at least one operand can block split, allow splitting in operands
         // without splitting at the operator.
-        if (_canBlockSplitLeft || _canBlockSplitRight) _blockSplit,
+        if (_canBlockSplitLeft) _blockSplitLeft,
+        if (_canBlockSplitRight) _blockSplitRight,
         _atOperator,
       ];
+
+  /// Apply constraints between how the parameters may split and how the
+  /// initializers may split.
+  @override
+  void applyConstraints(State state, Constrain constrain) {
+    switch (state) {
+      case _blockSplitLeft:
+        constrain(_left!, State.split);
+    }
+  }
 
   @override
   void format(CodeWriter writer, State state) {
@@ -162,10 +188,11 @@ class AssignPiece extends Piece {
         indentLeft = true;
         indentRight = true;
 
-      case _blockSplit:
-        // Indent either operand if it doesn't block split.
-        indentLeft = !_canBlockSplitLeft;
+      case _blockSplitLeft:
         indentRight = !_canBlockSplitRight;
+        collapseIndent = true;
+
+      case _blockSplitRight:
         collapseIndent = true;
     }
 

--- a/lib/src/piece/if.dart
+++ b/lib/src/piece/if.dart
@@ -26,7 +26,7 @@ class IfPiece extends Piece {
 
   @override
   void applyConstraints(State state, Constrain constrain) {
-    // If an if element, any spread collection's split state must follow the
+    // In an if element, any spread collection's split state must follow the
     // surrounding if element's: we either split all the spreads or none of
     // them. And if any of the non-spread then or else branches split, then the
     // spreads do too.

--- a/test/expression/collection_for_in.stmt
+++ b/test/expression/collection_for_in.stmt
@@ -27,7 +27,8 @@ f() async {
 var list = [for (a in sequenceExpression + thatDoesNotFit) body];
 <<<
 var list = [
-  for (a in sequenceExpression +
-      thatDoesNotFit)
+  for (a
+      in sequenceExpression +
+          thatDoesNotFit)
     body,
 ];

--- a/test/expression/collection_for_metadata.stmt
+++ b/test/expression/collection_for_metadata.stmt
@@ -1,0 +1,86 @@
+40 columns                              |
+>>> On for-in loop variable.
+var list = [
+  for (   @a  @b    var i in list) i
+];
+<<<
+var list = [
+  for (@a @b var i in list) i,
+];
+>>> Split on for-in loop variable.
+var list = [
+  for (@Annotation @VeryLongMetadataAnnotation(1, 2) var i in veryLong.iterator + expression) i
+];
+<<<
+var list = [
+  for (@Annotation
+      @VeryLongMetadataAnnotation(1, 2)
+      var i
+      in veryLong.iterator + expression)
+    i,
+];
+>>> On for loop.
+var list = [
+  for (   @a  @b    var i = x;;) i
+];
+<<<
+var list = [for (@a @b var i = x; ;) i];
+>>> Split on for loop.
+var list = [
+  for (@Annotation @VeryLongMetadataAnnotation(1, 2) var i = veryLong.iterator + expression;;) i
+];
+<<<
+var list = [
+  for (
+    @Annotation
+    @VeryLongMetadataAnnotation(1, 2)
+    var i =
+        veryLong.iterator + expression;
+    ;
+  )
+    i,
+];
+>>> On pattern for-in loop.
+var list = [
+  for (   @a  @b    var [i] in list) i
+];
+<<<
+var list = [
+  for (@a @b var [i] in list) i,
+];
+>>> Split on pattern for-in loop.
+var list = [
+  for (@Annotation @VeryLongMetadataAnnotation(1, 2) var [i] in veryLong.iterator + longExpression) i
+];
+<<<
+var list = [
+  for (@Annotation
+      @VeryLongMetadataAnnotation(1, 2)
+      var [i]
+      in veryLong.iterator +
+          longExpression)
+    i,
+];
+>>> On pattern for loop.
+var list = [
+  for (   @a  @b    var [i] = x;;) i
+];
+<<<
+var list = [
+  for (@a @b var [i] = x; ;) i,
+];
+>>> Split on pattern for loop.
+var list = [
+  for (@Annotation @VeryLongMetadataAnnotation(1, 2) var [i] = veryLong.iterator + expression;;) i
+];
+<<<
+var list = [
+  for (
+    @Annotation
+    @VeryLongMetadataAnnotation(1, 2)
+    var [i] =
+        veryLong.iterator + expression;
+    ;
+  )
+    i,
+];

--- a/test/function/expression_body.unit
+++ b/test/function/expression_body.unit
@@ -69,12 +69,11 @@ function(
   longElement,
   longElement,
 ];
->>> Prefer splitting parameters instead of after `=>`.
+>>> Prefer splitting at `=>` instead of parameters.
 LongReturnType function(parameter) => longFunctionBody;
 <<<
-LongReturnType function(
-  parameter,
-) => longFunctionBody;
+LongReturnType function(parameter) =>
+    longFunctionBody;
 >>> Prefer splitting after `=>` instead of after return type.
 LongReturnType function() => longFunctionBody;
 <<<

--- a/test/function/generic.unit
+++ b/test/function/generic.unit
@@ -29,9 +29,18 @@ longFunctionName<
   LongTypeParameterT,
   LongTypeParameterS
 >() => body;
->>> Split type parameters and value parameters, with expression body.
+>>> Split type parameters, with expression body.
 longFunctionName<LongTypeParameterT, LongTypeParameterS>(
 longParameter1, longParameter2) => body;
+<<<
+longFunctionName<
+  LongTypeParameterT,
+  LongTypeParameterS
+>(longParameter1, longParameter2) =>
+    body;
+>>> Split type parameters and value parameters, with expression body.
+longFunctionName<LongTypeParameterT, LongTypeParameterS>(
+longParameter1, longParameter2, longParameter3) => body;
 <<<
 longFunctionName<
   LongTypeParameterT,
@@ -39,4 +48,5 @@ longFunctionName<
 >(
   longParameter1,
   longParameter2,
+  longParameter3,
 ) => body;

--- a/test/function/operator.unit
+++ b/test/function/operator.unit
@@ -7,9 +7,8 @@ class A {
 }
 <<<
 class A {
-  bool operator ==(
-    Object other,
-  ) => true;
+  bool operator ==(Object other) =>
+      true;
   int operator +(int other) {
     return value + other;
   }

--- a/test/pattern/object.stmt
+++ b/test/pattern/object.stmt
@@ -183,14 +183,18 @@ if (obj case Foo<First, Second>(
 )) {
   ;
 }
->>> Split in type argument but not field subpatterns.
+>>> Split in type argument forces fields to split too.
 if (obj case LongClassName<First, Second, Third>(first: 1, second: 2, third: 3)) {;}
 <<<
 if (obj case LongClassName<
   First,
   Second,
   Third
->(first: 1, second: 2, third: 3)) {
+>(
+  first: 1,
+  second: 2,
+  third: 3,
+)) {
   ;
 }
 >>> Split in type arguments and field subpatterns.

--- a/test/statement/for_declaration.stmt
+++ b/test/statement/for_declaration.stmt
@@ -98,3 +98,15 @@ for (
 ) {
   ;
 }
+>>> Split between type and variable name.
+for (SomeReallyLongTypeName someLongVariable; someLongVariable < 100;
+someLongVariable++) {;}
+<<<
+for (
+  SomeReallyLongTypeName
+  someLongVariable;
+  someLongVariable < 100;
+  someLongVariable++
+) {
+  ;
+}

--- a/test/statement/for_in.stmt
+++ b/test/statement/for_in.stmt
@@ -61,8 +61,9 @@ for (var identifier
 >>> Split inside initializer.
 for (var identifier in someVeryLong + iterableExpression) { body; }
 <<<
-for (var identifier in someVeryLong +
-    iterableExpression) {
+for (var identifier
+    in someVeryLong +
+        iterableExpression) {
   body;
 }
 >>> Prefer block-like splitting after `in`.
@@ -120,5 +121,14 @@ for (var (longIdentifier &&
     in longValueExpression +
         anotherOperand +
         aThirdOperand) {
+  ;
+}
+>>> If pattern doesn't block split, then split in right splits at `in` too.
+for (var [i] in veryLongIterator +
+        longExpression) {;}
+<<<
+for (var [i]
+    in veryLongIterator +
+        longExpression) {
   ;
 }

--- a/test/statement/for_in.stmt
+++ b/test/statement/for_in.stmt
@@ -51,6 +51,14 @@ foo() async {
     body;
   }
 }
+>>> Split between variable type and name.
+for (VeryLongClassName reallyLongIdentifier in iteratableExpression) { body; }
+<<<
+for (VeryLongClassName
+    reallyLongIdentifier
+    in iteratableExpression) {
+  body;
+}
 >>> Split before `in`.
 for (var identifier in iteratableExpression) { body; }
 <<<
@@ -85,6 +93,14 @@ for (i in sequence) somethingMuchLonger(i);
 <<<
 for (i in sequence)
   somethingMuchLonger(i);
+>>> Split between type and variable name.
+for (SomeReallyLongTypeName andALongVariable in list) {;}
+<<<
+for (SomeReallyLongTypeName
+    andALongVariable
+    in list) {
+  ;
+}
 >>> Expression split in pattern.
 for (var (longIdentifier && anotherLongOne) in obj) {;}
 <<<

--- a/test/statement/for_metadata.stmt
+++ b/test/statement/for_metadata.stmt
@@ -1,0 +1,141 @@
+40 columns                              |
+>>> Single metadata on for-in loop variable.
+main() {
+  for (   @a    var i in list) {;}
+}
+<<<
+main() {
+  for (@a var i in list) {
+    ;
+  }
+}
+>>> Multiple metadata on for-in loop variable.
+main() {
+  for (   @a  @b    var i in list) {;}
+}
+<<<
+main() {
+  for (@a @b var i in list) {
+    ;
+  }
+}
+>>> Long metadata on for-in loop variable.
+main() {
+  for (@Annotation @VeryLongMetadataAnnotation(1, 2) var i in veryLong.iterator + expression) {;}
+}
+<<<
+main() {
+  for (@Annotation
+      @VeryLongMetadataAnnotation(1, 2)
+      var i
+      in veryLong.iterator +
+          expression) {
+    ;
+  }
+}
+>>> Single metadata on for loop.
+main() {
+  for (   @a    var i = x;;) {;}
+}
+<<<
+main() {
+  for (@a var i = x; ;) {
+    ;
+  }
+}
+>>> Multiple metadata on for loop.
+main() {
+  for (   @a  @b    var i = x;;) {;}
+}
+<<<
+main() {
+  for (@a @b var i = x; ;) {
+    ;
+  }
+}
+>>> Long metadata on for loop.
+main() {
+  for (@Annotation @VeryLongMetadataAnnotation(1, 2) var i = veryLong.iterator + expression;;) {;}
+}
+<<<
+main() {
+  for (
+    @Annotation
+    @VeryLongMetadataAnnotation(1, 2)
+    var i =
+        veryLong.iterator + expression;
+    ;
+  ) {
+    ;
+  }
+}
+>>> Single metadata on pattern for-in loop.
+main() {
+  for (   @a    var [i] in list) {;}
+}
+<<<
+main() {
+  for (@a var [i] in list) {
+    ;
+  }
+}
+>>> Multiple metadata on pattern for-in loop.
+main() {
+  for (   @a  @b    var [i] in list) {;}
+}
+<<<
+main() {
+  for (@a @b var [i] in list) {
+    ;
+  }
+}
+>>> Long metadata on pattern for-in loop.
+main() {
+  for (@Annotation @VeryLongMetadataAnnotation(1, 2) var [i] in veryLong.iterator + expression) {;}
+}
+<<<
+main() {
+  for (@Annotation
+      @VeryLongMetadataAnnotation(1, 2)
+      var [i]
+      in veryLong.iterator +
+          expression) {
+    ;
+  }
+}
+>>> Single metadata on pattern for loop.
+main() {
+  for (   @a    var [i] = x;;) {;}
+}
+<<<
+main() {
+  for (@a var [i] = x; ;) {
+    ;
+  }
+}
+>>> Multiple metadata on pattern for loop.
+main() {
+  for (   @a  @b    var [i] = x;;) {;}
+}
+<<<
+main() {
+  for (@a @b var [i] = x; ;) {
+    ;
+  }
+}
+>>> Long metadata on pattern for loop.
+main() {
+  for (@Annotation @VeryLongMetadataAnnotation(1, 2) var [i] = veryLong.iterator + expression;;) {;}
+}
+<<<
+main() {
+  for (
+    @Annotation
+    @VeryLongMetadataAnnotation(1, 2)
+    var [i] =
+        veryLong.iterator + expression;
+    ;
+  ) {
+    ;
+  }
+}

--- a/test/variable/pattern.stmt
+++ b/test/variable/pattern.stmt
@@ -21,6 +21,13 @@ var [
   fourth,
   fifth,
 ] = value;
+>>> Split in initializer but not block-splittable pattern.
+var [first] = expression + anotherOperand + aThirdOperand;
+<<<
+var [first] =
+    expression +
+        anotherOperand +
+        aThirdOperand;
 >>> Split in map pattern.
 var {first: second, third: fourth, fifth: sixth} = value;
 <<<


### PR DESCRIPTION
When I added support for metadata, I skipped metadata on for loop variables because I thought it would be a little annoying and wanted to do it separately. Boy was I right.

Jamming metadata in there highlighted a handful of other formatting bugs in for loops, which in turn made some general bugs in how block-like constructs to the left of assignments (which includes `=`, `=>`, and `in`) are handled. There were a lot of tests, but there are just so many combinations of kinds of syntax on the left of an assignment-like thing and expressions on the right that's hard to cover everything.

So I revamped that first. Then I added support for for loop metadata.

To make it easier to review, I tried to break it into bite-sized meaningful commits.