### PR TITLE
Don't eagerly bind pinned Pieces in Solution.

### DIFF
--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -104,24 +104,6 @@ class Solution implements Comparable<Solution> {
     var pieceStates = <Piece, State>{};
     var cost = 0;
 
-    // Bind every pinned piece to its state and propagate any constraints from
-    // those.
-    void traversePinned(Piece piece) {
-      if (piece.pinnedState case var pinned?) {
-        var additionalCost = _tryBind(pieceStates, piece, pinned);
-
-        // Pieces should be implemented such that they never get pinned into a
-        // conflicting state because then there's no possible solution, so
-        // [_tryBind()] should always succeed and [additionalCost] won't be
-        // `null`.
-        cost += additionalCost!;
-      }
-
-      piece.forEachChild(traversePinned);
-    }
-
-    traversePinned(root);
-
     // If we're formatting a subtree of a larger Piece tree that binds [root]
     // to [rootState], then bind it in this solution too.
     if (rootState != null) {
@@ -149,10 +131,12 @@ class Solution implements Comparable<Solution> {
   /// The state this solution selects for [piece].
   ///
   /// If no state has been selected, defaults to the first state.
-  State pieceState(Piece piece) => _pieceStates[piece] ?? State.unsplit;
+  State pieceState(Piece piece) =>
+      piece.pinnedState ?? _pieceStates[piece] ?? State.unsplit;
 
-  /// Whether [piece] has been bound to a state in this set.
-  bool isBound(Piece piece) => _pieceStates.containsKey(piece);
+  /// Whether [piece] has been bound to a state in this set (or is pinned).
+  bool isBound(Piece piece) =>
+      piece.pinnedState != null || _pieceStates.containsKey(piece);
 
   /// Increases the total overflow for this solution by [overflow].
   ///

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -19,9 +19,7 @@ abstract class Piece {
   /// This is [State.unsplit], which all pieces support, followed by any other
   /// [additionalStates].
   List<State> get states {
-    // Pinned pieces should be bound eagerly in the Solution so we shouldn't
-    // ever need to iterate over their states.
-    assert(_pinnedState == null);
+    if (_pinnedState case var pinned?) return [pinned];
     return [State.unsplit, ...additionalStates];
   }
 
@@ -132,6 +130,12 @@ abstract class Piece {
   /// Forces this piece to always use [state].
   void pin(State state) {
     _pinnedState = state;
+
+    // If this piece's pinned state constrains any child pieces, pin those too,
+    // recursively.
+    applyConstraints(state, (other, constrainedState) {
+      other.pin(constrainedState);
+    });
   }
 
   /// The name of this piece as it appears in debug output.


### PR DESCRIPTION
Before this change, constructor for Solution would recursively traverse the entire piece tree from the root down. It did so looking for pieces that were pinned, so that it could add them to the pieceState map and (more importantly) apply any constraints that the pinned piece's state implies on other child pieces.

Unfortunately, this traversal interacts poorly with the optimization to format some piece subtrees separately. The Solution constructor for the root piece would traverse the whole tree, then Solution constructors for any child pieces being formatted separately would also traverse their piece trees, and so on.

In practice, it was roughly quadratic. Oops. :(

This change removes that traversal completely. Instead, when a piece is pinned, we apply any constraints at that point in time and then pin the constrained pieces.

Then, during solving, Solution looks to see if the piece has a pinned state before looking at its own bound state map. That way, we never have to bother redundantly storing the states of pinned pieces in the state map.

On my machine, this makes the large benchmark about 17% faster.
