### PR TITLE
Tweak the heuristics on which expressions allow block formatting.

### DIFF
--- a/benchmark/case/flutter_scrollbar_test.expect
+++ b/benchmark/case/flutter_scrollbar_test.expect
@@ -1,0 +1,45 @@
+// This test is from a particularly slow to format part of:
+//
+// flutter/packages/test/material/scrollbar_test.dart.
+void main() {
+  testWidgets(
+    "Scrollbar doesn't show when scroll the inner scrollable widget",
+    (WidgetTester tester) async {
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: ScrollConfiguration(
+            behavior: const NoScrollbarBehavior(),
+            child: Scrollbar(
+              key: key2,
+              child: SingleChildScrollView(
+                key: outerKey,
+                child: SizedBox(
+                  height: 1000.0,
+                  width: double.infinity,
+                  child: Column(children: <Widget>[Scrollbar(
+                    key: key1,
+                    child: SizedBox(
+                      height: 300.0,
+                      width: double.infinity,
+                      child: SingleChildScrollView(
+                        key: innerKey,
+                        child: const SizedBox(
+                          key: Key('Inner scrollable'),
+                          height: 1000.0,
+                          width: double.infinity,
+                        ),
+                      ),
+                    ),
+                  )]),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ));
+    },
+    variant: TargetPlatformVariant.all(),
+  );
+}

--- a/benchmark/case/flutter_scrollbar_test.expect_short
+++ b/benchmark/case/flutter_scrollbar_test.expect_short
@@ -1,0 +1,48 @@
+// This test is from a particularly slow to format part of:
+//
+// flutter/packages/test/material/scrollbar_test.dart.
+void main() {
+  testWidgets("Scrollbar doesn't show when scroll the inner scrollable widget",
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: ScrollConfiguration(
+            behavior: const NoScrollbarBehavior(),
+            child: Scrollbar(
+              key: key2,
+              child: SingleChildScrollView(
+                key: outerKey,
+                child: SizedBox(
+                  height: 1000.0,
+                  width: double.infinity,
+                  child: Column(
+                    children: <Widget>[
+                      Scrollbar(
+                        key: key1,
+                        child: SizedBox(
+                          height: 300.0,
+                          width: double.infinity,
+                          child: SingleChildScrollView(
+                            key: innerKey,
+                            child: const SizedBox(
+                              key: Key('Inner scrollable'),
+                              height: 1000.0,
+                              width: double.infinity,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }, variant: TargetPlatformVariant.all());
+}

--- a/benchmark/case/flutter_scrollbar_test.unit
+++ b/benchmark/case/flutter_scrollbar_test.unit
@@ -1,0 +1,46 @@
+// This test is from a particularly slow to format part of:
+//
+// flutter/packages/test/material/scrollbar_test.dart.
+void main() {
+  testWidgets("Scrollbar doesn't show when scroll the inner scrollable widget", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: ScrollConfiguration(
+            behavior: const NoScrollbarBehavior(),
+            child: Scrollbar(
+              key: key2,
+              child: SingleChildScrollView(
+                key: outerKey,
+                child: SizedBox(
+                  height: 1000.0,
+                  width: double.infinity,
+                  child: Column(
+                    children: <Widget>[
+                      Scrollbar(
+                        key: key1,
+                        child: SizedBox(
+                          height: 300.0,
+                          width: double.infinity,
+                          child: SingleChildScrollView(
+                            key: innerKey,
+                            child: const SizedBox(
+                              key: Key('Inner scrollable'),
+                              height: 1000.0,
+                              width: double.infinity,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }, variant: TargetPlatformVariant.all());
+}

--- a/benchmark/case/large.expect
+++ b/benchmark/case/large.expect
@@ -325,10 +325,10 @@ class BacktrackingSolver {
           javaBooleanAnd(
             javaBooleanAnd(
               javaBooleanAnd(
-                javaBooleanAnd(javaBooleanAnd(), _isEqualTokens(
-                  node.period,
-                  toNode.period,
-                )),
+                javaBooleanAnd(
+                  javaBooleanAnd(),
+                  _isEqualTokens(node.period, toNode.period),
+                ),
                 _isEqualNodes(node.name, toNode.name),
               ),
               _isEqualNodes(node.parameters, toNode.parameters),

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -156,12 +156,10 @@ extension ExpressionExtensions on Expression {
   /// When this expression is in an argument list, what kind of block formatting
   /// category it belongs to.
   BlockFormat get blockFormatType {
-    // Unwrap named expressions to get the real expression inside.
-    if (this case NamedExpression named) {
-      return named.expression.blockFormatType;
-    }
-
     return switch (this) {
+      // Unwrap named expressions to get the real expression inside.
+      NamedExpression(:var expression) => expression.blockFormatType,
+
       // Allow the target of a single-section cascade to be block formatted.
       CascadeExpression(:var target, :var cascadeSections)
           when cascadeSections.length == 1 && target.canBlockSplit =>

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -53,7 +53,8 @@ class DelimitedListBuilder {
   /// elements, and style.
   Piece build() {
     // To simplify the piece tree, if there are no elements, just return the
-    // brackets concatenated together.
+    // brackets concatenated together. We don't have to worry about comments
+    // here since they would be in the [_elements] list if there were any.
     if (_elements.isEmpty) {
       return _visitor.buildPiece((b) {
         if (_leftBracket case var bracket?) b.add(bracket);

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -55,8 +55,9 @@ class ListPiece extends Piece {
   /// The details of how this particular list should be formatted.
   final ListStyle _style;
 
-  ListPiece(this._before, this._elements, this._blanksAfter, this._after,
-      this._style) {
+  ListPiece(
+      this._before, this._elements, this._blanksAfter, this._after, this._style)
+      : assert(_elements.isNotEmpty) {
     // For most elements, we know whether or not it will have a comma based
     // only on the comma style and its position in the list, so pin those here.
     for (var i = 0; i < _elements.length; i++) {
@@ -89,12 +90,12 @@ class ListPiece extends Piece {
   }
 
   @override
-  List<State> get additionalStates => [if (_elements.isNotEmpty) State.split];
+  List<State> get additionalStates => const [State.split];
 
   @override
   void applyConstraints(State state, Constrain constrain) {
     // Give the last element a trailing comma only if the list is split.
-    if (_style.commas == Commas.trailing && _elements.isNotEmpty) {
+    if (_style.commas == Commas.trailing) {
       constrain(_elements.last,
           state == State.split ? ListElementPiece._appendComma : State.unsplit);
     }
@@ -367,6 +368,9 @@ final class ListElementPiece extends Piece {
     if (_content case var content?) callback(content);
     _hangingComments.forEach(callback);
   }
+
+  @override
+  String get debugName => 'ListElem';
 }
 
 /// Where commas should be added in a [ListPiece].
@@ -388,13 +392,20 @@ enum Commas {
 
 /// What kind of block formatting style can be applied to the element.
 enum BlockFormat {
-  /// The element is a function expression, which takes priority over other
-  /// kinds of block formatted elements.
+  /// The element is a function expression or immediately invoked function
+  /// expression, which takes priority over other kinds of block formatted
+  /// elements.
   function,
 
-  /// The element is a collection literal or some other kind expression that
-  /// can be block formatted.
-  block,
+  /// The element is a collection literal.
+  ///
+  /// These can be block formatted even when there are other arguments.
+  collection,
+
+  /// A function or method invocation.
+  ///
+  /// We only allow block formatting these if there are no other arguments.
+  invocation,
 
   /// The element is an adjacent strings expression that's in an list that
   /// requires its subsequent lines to be indented (because there are other

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -5,7 +5,7 @@ import '../back_end/code_writer.dart';
 import '../constants.dart';
 import 'piece.dart';
 
-/// A piece for a splittable series of items.
+/// A piece for a non-empty splittable series of items.
 ///
 /// Items may optionally be delimited with brackets and may have commas added
 /// after elements.
@@ -55,6 +55,10 @@ class ListPiece extends Piece {
   /// The details of how this particular list should be formatted.
   final ListStyle _style;
 
+  /// Creates a new [ListPiece].
+  ///
+  /// [_elements] must not be empty. (If there are no elements, just concatenate
+  /// the brackets directly.)
   ListPiece(
       this._before, this._elements, this._blanksAfter, this._after, this._style)
       : assert(_elements.isNotEmpty) {

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -116,4 +116,7 @@ class SequenceElementPiece extends Piece {
       callback(comment);
     }
   }
+
+  @override
+  String get debugName => 'SeqElem';
 }

--- a/test/invocation/block_argument_kind.stmt
+++ b/test/invocation/block_argument_kind.stmt
@@ -65,19 +65,6 @@ function((// comment
 function((
   // comment
 ) => body);
->>> Empty block-bodied function expression with a block comment.
-function(() { /* fairly long comment */ });
-<<<
-function(() {
-  /* fairly long comment */
-});
->>> Empty block-bodied function expression with a line comment.
-function(() { // comment
-});
-<<<
-function(() {
-  // comment
-});
 >>> An empty block-bodied function expression is not a block argument.
 function_________________________(() {});
 <<<
@@ -164,6 +151,57 @@ function________________(new SomeClass());
 <<<
 function________________(
   new SomeClass(),
+);
+>>> Immediately invoked function.
+function(() { body; }());
+<<<
+function(() {
+  body;
+}());
+>>> Empty immediately invoked function with a block comment.
+function(() { /* fairly long comment */ }());
+<<<
+function(() {
+  /* fairly long comment */
+}());
+>>> Empty immediately invoked function with a line comment.
+function(() { // comment
+}());
+<<<
+function(() {
+  // comment
+}());
+>>> Immediately invoked function with parameters and arguments.
+function((p, r) { body; }(a, b));
+<<<
+function((p, r) {
+  body;
+}(a, b));
+>>> Immediately invoked function with parameters.
+function((parameter, anotherParameter) {}());
+<<<
+function((
+  parameter,
+  anotherParameter,
+) {}());
+>>> Immediately invoked function with block comment in the parameters.
+function((/* very long block comment */) {}());
+<<<
+function((
+  /* very long block comment */
+) {}());
+>>> Immediately invoked function with line comment in the parameters.
+function((// comment
+) {}());
+<<<
+function((
+  // comment
+) {}());
+>>> An empty immediately invoked function is not a block argument.
+function_________________________(() {}());
+<<<
+function_________________________(
+  () {}(),
 );
 >>> Function expression call.
 function((expression)(veryLongArgumentExpression));

--- a/test/invocation/block_argument_multiple.stmt
+++ b/test/invocation/block_argument_multiple.stmt
@@ -24,6 +24,12 @@ function([1, 2], () { body; }, {3, 4});
 function([1, 2], () {
   body;
 }, {3, 4});
+>>> Immediately invoked function takes precedence over other kinds of block arguments.
+function([1, 2], () { body; }(), {3, 4});
+<<<
+function([1, 2], () {
+  body;
+}(), {3, 4});
 >>> Multiple collections prevent block formatting.
 function([element, element], {key: value});
 <<<
@@ -38,19 +44,95 @@ function([], [
   element,
   element,
 ], <String>{});
->>> Multiple calls prevent block formatting.
-function(inner(argument), new SomeClass(argument));
+>>> Can't block format a function call with any preceding arguments.
+function(arg, innerFunction(veryLongArgumentExpression));
 <<<
 function(
-  inner(argument),
-  new SomeClass(argument),
+  arg,
+  innerFunction(
+    veryLongArgumentExpression,
+  ),
 );
->>> Empty and non-empty calls.
-function(a(), inner(argument), const C());
+>>> Can't block format a function call with any subsequent arguments.
+function(innerFunction(veryLongArgumentExpression), arg);
 <<<
-function(a(), inner(
-  argument,
-), const C());
+function(
+  innerFunction(
+    veryLongArgumentExpression,
+  ),
+  arg,
+);
+>>> Can't block format a method call with any preceding arguments.
+function(arg, target.inner(veryLongArgumentExpression));
+<<<
+function(
+  arg,
+  target.inner(
+    veryLongArgumentExpression,
+  ),
+);
+>>> Can't block format a method call with any subsequent arguments.
+function(target.inner(veryLongArgumentExpression), arg);
+<<<
+function(
+  target.inner(
+    veryLongArgumentExpression,
+  ),
+  arg,
+);
+>>> Can't block format an instance creation with any preceding arguments.
+function(arg, new SomeClass(veryLongArgumentExpression));
+<<<
+function(
+  arg,
+  new SomeClass(
+    veryLongArgumentExpression,
+  ),
+);
+>>> Can't block format an instance creation with any subsequent arguments.
+function(new SomeClass(veryLongArgumentExpression), arg);
+<<<
+function(
+  new SomeClass(
+    veryLongArgumentExpression,
+  ),
+  arg,
+);
+>>> List literal with other non-block arguments.
+function(before, [veryLongElement, anotherLongElement], after);
+<<<
+function(before, [
+  veryLongElement,
+  anotherLongElement,
+], after);
+>>> Map literal with other non-block arguments.
+function(before, {1: veryLongElement, 2: anotherLongElement}, after);
+<<<
+function(before, {
+  1: veryLongElement,
+  2: anotherLongElement,
+}, after);
+>>> Set literal with other non-block arguments.
+function(before, {veryLongElement, anotherLongElement}, after);
+<<<
+function(before, {
+  veryLongElement,
+  anotherLongElement,
+}, after);
+>>> Record literal with other non-block arguments.
+function(before, (veryLongElement, anotherLongElement), after);
+<<<
+function(before, (
+  veryLongElement,
+  anotherLongElement,
+), after);
+>>> Switch expression with other non-block arguments.
+function(before, switch (n) {1 => veryLongElement, 2 => anotherLongElement}, after);
+<<<
+function(before, switch (n) {
+  1 => veryLongElement,
+  2 => anotherLongElement,
+}, after);
 >>> Multiple switches prevent block formatting.
 function(switch (a) { 1 => 2 }, switch (b) { 1 => 2 });
 <<<

--- a/test/invocation/block_argument_other.stmt
+++ b/test/invocation/block_argument_other.stmt
@@ -1,28 +1,5 @@
 40 columns                              |
 ### Test other behavior related to block arguments.
->>> Can have non-block arguments before the block argument.
-function(first, second, [third, fourth, fifth]);
-<<<
-function(first, second, [
-  third,
-  fourth,
-  fifth,
-]);
->>> Can have non-block arguments after the block argument.
-function([first, second, third], fourth, fifth);
-<<<
-function([
-  first,
-  second,
-  third,
-], fourth, fifth);
->>> Can have non-block arguments before and after the block argument.
-function(first, second, [third, fourth], fifth);
-<<<
-function(first, second, [
-  third,
-  fourth,
-], fifth);
 >>> Don't block argument format if it fits better to not.
 function('a long leading argument', <String>[element, element]);
 <<<

--- a/test/statement/assert.stmt
+++ b/test/statement/assert.stmt
@@ -65,10 +65,22 @@ assert(inner(
   argument,
 ));
 >>> Allow block formatting of message.
-assert(true, inner(argument, argument, argument));
+assert(true, () {
+  return someSlowMessageComputation();
+}());
 <<<
-assert(true, inner(
-  argument,
-  argument,
-  argument,
-));
+assert(true, () {
+  return someSlowMessageComputation();
+}());
+>>> Block format immediately invoked function as condition.
+assert(() { return someSlow() + computation(); }());
+<<<
+assert(() {
+  return someSlow() + computation();
+}());
+>>> Block format immediately invoked function as condition with message.
+assert(() { return someSlow() + computation(); }(), 'Message.');
+<<<
+assert(() {
+  return someSlow() + computation();
+}(), 'Message.');


### PR DESCRIPTION
I was trying out the new formatting on Flutter and noticed a few issues:

**1. Immediately-invoked functions in asserts are common.**

Prior to this change, these were not block format candidates, giving you:

```dart
assert(
  () {
    // Some slow computation...
  }(),
  'Message.',
);
```

With this change, they're treated like (uninvoked) function expressions:

```dart
assert(() {
  // Some slow computation...
}(), 'Message.');
```

**2. Formatting large deep widget trees looks weird.**

Prior to this change, a function call inside an argument list can be treated like a block argument even if there are other arguments. That tends to pack things in strangely in widget code, like:

```dart
SizedBox(height: 1000.0, width: double.infinity, child: Column(
  children: <Widget>[Scrollbar(key: key1, child: SizedBox(
    height: 300.0,
    width: double.infinity,
    child: SingleChildScrollView(key: innerKey, child: const SizedBox(key: Key(
      'Inner scrollable',
    ), height: 1000.0, width: double.infinity)),
  ))],
));
```

With this change, a function or method call inside an argument list is only block formatted if there are no other arguments. In other words, you can block format a function call if the outer call is a pure wrapper around the call, but not otherwise. That leads to:

```dart
SizedBox(
  height: 1000.0,
  width: double.infinity,
  child: Column(children: <Widget>[Scrollbar(
    key: key1,
    child: SizedBox(
      height: 300.0,
      width: double.infinity,
      child: SingleChildScrollView(
        key: innerKey,
        child: const SizedBox(
          key: Key('Inner scrollable'),
          height: 1000.0,
          width: double.infinity,
        ),
      ),
    ),
  )]),
);
```

I think that looks a lot nicer.

**3. Deep, complex argument lists are combinatorially slow.**

We have an optimization to eagerly force an argument list to split if its contents clearly won't fit. But that optimization ignores the size of a potential block argument since the contents of that can be wrapped across multiple lines without forcing the outer argument list to split.

A consequence of that is that big deeply nested function calls end up slow if it happens that each one only has a single block-formattable call. That turns out to be very common in Flutter code where you have a deep chain of nested widgets along with a bunch of other arguments.

The above change to disallow block formatting function calls if there are any other arguments conveniently fixes that performance issue in most cases. (Though I expect we will want to do more work here to handle pathological cases.)
