### PR TITLE
Fix a crash and some formatting bugs in cascades.

### DIFF
--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -266,7 +266,7 @@ class CodeWriter {
   /// writer's [_solution].
   void _formatSeparate(Piece piece) {
     var solution = _cache.find(
-        _pageWidth, piece, _solution.pieceState(piece), _pendingIndent);
+        _pageWidth, piece, _pendingIndent, _solution.pieceStateIfBound(piece));
 
     _pendingIndent = 0;
     _flushWhitespace();

--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -128,11 +128,16 @@ class Solution implements Comparable<Solution> {
     _nextPieceToExpand = nextPieceToExpand;
   }
 
-  /// The state this solution selects for [piece].
+  /// The state that [piece] is pinned to or that this solution selects.
   ///
   /// If no state has been selected, defaults to the first state.
-  State pieceState(Piece piece) =>
-      piece.pinnedState ?? _pieceStates[piece] ?? State.unsplit;
+  State pieceState(Piece piece) => pieceStateIfBound(piece) ?? State.unsplit;
+
+  /// The state that [piece] is pinned to or that this solution selects.
+  ///
+  /// If no state has been selected, returns `null`.
+  State? pieceStateIfBound(Piece piece) =>
+      piece.pinnedState ?? _pieceStates[piece];
 
   /// Whether [piece] has been bound to a state in this set (or is pinned).
   bool isBound(Piece piece) =>
@@ -278,7 +283,7 @@ class Solution implements Comparable<Solution> {
       if (overflow > 0) '($overflow over)',
       if (!isValid) '(invalid)',
       states.join(' '),
-    ].join(' ');
+    ].join(' ').trim();
   }
 
   /// Attempts to add a binding from [piece] to [state] in [boundStates], and
@@ -302,7 +307,7 @@ class Solution implements Comparable<Solution> {
       if (!success) return;
 
       // Apply the new binding if it doesn't conflict with an existing one.
-      switch (boundStates[thisPiece]) {
+      switch (thisPiece.pinnedState ?? boundStates[thisPiece]) {
         case null:
           // Binding a unbound piece to a state.
           additionalCost += thisPiece.stateCost(thisState);

--- a/lib/src/back_end/solution_cache.dart
+++ b/lib/src/back_end/solution_cache.dart
@@ -9,10 +9,10 @@ import 'solver.dart';
 /// Maintains a cache of [Piece] subtrees that have been previously solved.
 ///
 /// If a given [Piece] has newlines before and after it, then (in most cases,
-/// assuming there are no other constraints), then the way it is formatted
-/// really only depends on its leading indentation and state. In that case, we
-/// can format that piece using a separate Solver and insert the results in any
-/// Solution that has that piece at that leading indentation.
+/// assuming there are no other constraints) the way it is formatted only
+/// depends on its leading indentation. In that case, we can format that piece
+/// using a separate Solver and insert the results in any Solution that has
+/// that piece at that leading indentation.
 ///
 /// This cache stores those previously formatted subtree pieces so that
 /// [CodeWriter] can reuse them across [Solution]s.
@@ -27,23 +27,28 @@ class SolutionCache {
 
   /// Returns a previously cached solution for formatting [root] with leading
   /// [indent] or produces a new solution, caches it, and returns it.
-  Solution find(int pageWidth, Piece root, State state, int indent) {
+  ///
+  /// If [root] is already bound to a state in the surrounding piece tree's
+  /// [Solution], then [stateIfBound] is that state. Otherwise, it is treated
+  /// as unbound and the cache will find a state for [root] as well as its
+  /// children.
+  Solution find(int pageWidth, Piece root, int indent, State? stateIfBound) {
     // See if we've already formatted this piece at this indentation. If not,
     // format it and store the result.
     return _cache.putIfAbsent(
-        (root, state, indent: indent),
+        (root, indent: indent),
         () => Solver(this, pageWidth: pageWidth, leadingIndent: indent)
-            .format(root, state));
+            .format(root, stateIfBound));
   }
 }
 
 /// The key used to uniquely identify a previously formatted Piece.
 ///
-/// Each subtree solution depends only on the Piece, the State it's bound to,
-/// and amount of leading indentation in the context where it appears (which
-/// may vary based on how surrounding pieces end up splitting).
+/// Each subtree solution depends only on the Piece and the amount of leading
+/// indentation in the context where it appears (which may vary based on how
+/// surrounding pieces end up splitting).
 ///
 /// In particular, note that if surrounding pieces split in *different* ways
 /// that still end up producing the same overall leading indentation, we are
 /// able to reuse a previously cached Solution for some Piece.
-typedef _Key = (Piece, State, {int indent});
+typedef _Key = (Piece, {int indent});

--- a/lib/src/back_end/solver.dart
+++ b/lib/src/back_end/solver.dart
@@ -51,27 +51,31 @@ class Solver {
   ///
   /// If [rootState] is given, then [root] is bound to that state.
   Solution format(Piece root, [State? rootState]) {
-    var solution = Solution(_cache, root,
-        pageWidth: _pageWidth,
-        leadingIndent: _leadingIndent,
-        rootState: rootState);
     if (debug.traceSolver) {
       var unsolved = <Piece>[];
       void traverse(Piece piece) {
-        if (piece.additionalStates.isNotEmpty &&
-            piece.pinnedState == null &&
-            !solution.isBound(piece)) {
-          unsolved.add(piece);
-        }
+        if (piece.states.length > 1) unsolved.add(piece);
 
         piece.forEachChild(traverse);
       }
 
       traverse(root);
 
-      debug.log(debug.bold('Solving $root for ${unsolved.join(' ')}:'));
+      var label = [
+        'Solving $root',
+        if (rootState != null) 'at state $rootState',
+        if (unsolved.isNotEmpty) 'for ${unsolved.join(', ')}',
+      ].join(' ');
+
+      debug.log(debug.bold('$label:'));
+      debug.indent();
       debug.log(debug.pieceTree(root));
     }
+
+    var solution = Solution(_cache, root,
+        pageWidth: _pageWidth,
+        leadingIndent: _leadingIndent,
+        rootState: rootState);
 
     _queue.add(solution);
 
@@ -87,7 +91,7 @@ class Solver {
       tries++;
 
       if (debug.traceSolver) {
-        debug.log(debug.bold('#$tries $solution'));
+        debug.log(debug.bold('Try #$tries $solution'));
         debug.log(solution.text);
         debug.log('');
       }
@@ -116,6 +120,7 @@ class Solver {
 
     // If we didn't find a solution without overflow, pick the least bad one.
     if (debug.traceSolver) {
+      debug.unindent();
       debug.log(debug.bold('Solved $root to $best:'));
       debug.log(best.text);
       debug.log('');

--- a/lib/src/front_end/chain_builder.dart
+++ b/lib/src/front_end/chain_builder.dart
@@ -171,9 +171,6 @@ class ChainBuilder {
   /// Given [expression], which is the expression for some call chain, traverses
   /// the selectors to fill in the list of [_calls].
   ///
-  /// If [_root] is a [CascadeSection], then this is called once for each
-  /// section in the cascade.
-  ///
   /// Otherwise, it's a method chain, and this recursively calls itself for the
   /// targets to unzip and flatten the nested selector expressions. Then it
   /// initializes [_target] with the innermost subexpression that isn't a part

--- a/test/invocation/cascade.stmt
+++ b/test/invocation/cascade.stmt
@@ -225,3 +225,25 @@ object
   ?..[index]
   ..method()
   ..[index] = value;
+>>> Property chain in cascade.
+object..first.second.third
+    ..fourth.fifth.sixth;
+<<<
+object
+  ..first.second.third
+  ..fourth.fifth.sixth;
+>>> Split property chain in cascade.
+object..firstProperty.secondProperty.thirdProperty
+    ..fourthProperty.fifthProperty.sixthProperty;
+<<<
+object
+  ..firstProperty
+    .secondProperty
+    .thirdProperty
+  ..fourthProperty
+    .fifthProperty
+    .sixthProperty;
+>>> Cascade chained property access setter.
+object..a.b = value;
+<<<
+object..a.b = value;

--- a/test/regression_tall/other/flutter.unit
+++ b/test/regression_tall/other/flutter.unit
@@ -1,0 +1,14 @@
+>>> Unitialized late variable on cascade containing method chains.
+main() {
+  htmlElement
+    ..style.width = '100%'
+    ..style.height = '100%'
+    ..classList.add(_kClassName);
+}
+<<<
+main() {
+  htmlElement
+    ..style.width = '100%'
+    ..style.height = '100%'
+    ..classList.add(_kClassName);
+}


### PR DESCRIPTION
I did a test run of the new formatter on the Flutter repo and it hit some crashes in cascades where a cascade section contains a method chain like `foo..a.b`.

While investigating that, I realized that the existing code for formatting cascades tries to reuse the regular method chain formatting code entirely unnecessarily.

This fixes the crash, and the formatting, and is simpler for handling cascades.
