### PR TITLE
Migrate more tests over to the new style.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -141,13 +141,13 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   Piece visitAssertInitializer(AssertInitializer node) {
     return buildPiece((b) {
       b.token(node.assertKeyword);
-      b.add(createList(
-        leftBracket: node.leftParenthesis,
+      b.add(createArgumentList(
+        node.leftParenthesis,
         [
           node.condition,
           if (node.message case var message?) message,
         ],
-        rightBracket: node.rightParenthesis,
+        node.rightParenthesis,
       ));
     });
   }

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -62,7 +62,7 @@ class DelimitedListBuilder {
       });
     }
 
-    _setBlockElementFormatting();
+    if (_style.allowBlockElement) _setBlockElementFormatting();
 
     var piece =
         ListPiece(_leftBracket, _elements, _blanksAfter, _rightBracket, _style);

--- a/test/declaration/constructor_assert.unit
+++ b/test/declaration/constructor_assert.unit
@@ -80,3 +80,19 @@ class Foo {
          'a message',
        );
 }
+>>> Allow block-formatting the assert arguments.
+class Foo {
+  Foo()
+    : assert(
+        () {
+          slowComputation();
+        }(),
+      );
+}
+<<<
+class Foo {
+  Foo()
+    : assert(() {
+        slowComputation();
+      }());
+}

--- a/test/expression/collection_if.stmt
+++ b/test/expression/collection_if.stmt
@@ -133,6 +133,23 @@ var list = [
   if (condition)
     if (another) longThingHereThatsLong,
 ];
+>>> Split outer if when subelement is for.
+var list = [
+  if (a) for (var b in c) thing
+];
+<<<
+var list = [
+  if (a)
+    for (var b in c) thing,
+];
+>>> Don't force split outer when subelement is nested inside collection.
+var list = [
+  if (a) [for (var b in c) d]
+];
+<<<
+var list = [
+  if (a) [for (var b in c) d],
+];
 >>> Nested if inside list doesn't force outer if to split.
 var list = [if (a) [if (b) c]];
 <<<

--- a/test/expression/collection_spread.stmt
+++ b/test/expression/collection_spread.stmt
@@ -53,3 +53,13 @@ var list = [
   }(),
   4,
 ];
+>>> Spread cascade.
+var list = [1, ...thing..cascade()..another(), 4];
+<<<
+var list = [
+  1,
+  ...thing
+    ..cascade()
+    ..another(),
+  4,
+];

--- a/test/expression/list.stmt
+++ b/test/expression/list.stmt
@@ -117,3 +117,14 @@ thirdElement];
     >
   >
 >[1, 2, 3];
+>>> Force split because of contained block.
+[first, () {"fn";},third,fourth];
+<<<
+[
+  first,
+  () {
+    "fn";
+  },
+  third,
+  fourth,
+];

--- a/test/expression/map.stmt
+++ b/test/expression/map.stmt
@@ -139,3 +139,13 @@ const {first: 1, second: 2};
     AnotherLongTypeName
   >
 >{1: 'one', 2: 'two'};
+>>> Force split because of contained block.
+var m = {first: 1, fn: () {"fn";},third:fourth};
+<<<
+var m = {
+  first: 1,
+  fn: () {
+    "fn";
+  },
+  third: fourth,
+};

--- a/test/expression/map_comment.stmt
+++ b/test/expression/map_comment.stmt
@@ -9,10 +9,17 @@ var map = {
 var map = {
   // comment
 };
->>> Inline block comment.
+>>> Inline block comment in empty map.
 var map = {  /* comment */  };
 <<<
 var map = {/* comment */};
+>>> Inline block comment after entry.
+var map = {first: one /* bang */, second: two};
+<<<
+var map = {
+  first: one /* bang */,
+  second: two,
+};
 >>> After entry.
 ({key: value // comment
 });

--- a/test/expression/record.stmt
+++ b/test/expression/record.stmt
@@ -117,3 +117,14 @@ var record = (
     veryLongElement__________,
   ),
 );
+>>> Force split because of contained block.
+(first, () {"fn";},third,fourth);
+<<<
+(
+  first,
+  () {
+    "fn";
+  },
+  third,
+  fourth,
+);

--- a/test/expression/set.stmt
+++ b/test/expression/set.stmt
@@ -34,3 +34,16 @@ var set =
         Sixth
       >
     >{};
+>>> Force split because of contained block.
+var s = {first, 1, fn, () {"fn";},third,fourth};
+<<<
+var s = {
+  first,
+  1,
+  fn,
+  () {
+    "fn";
+  },
+  third,
+  fourth,
+};

--- a/test/invocation/chain.stmt
+++ b/test/invocation/chain.stmt
@@ -100,3 +100,36 @@ prefix._Foo.named()
     .method()
     .method()
     .method();
+>>> Split type arguments in chain.
+receiver.method<First, Second, Third, Fourth, Fifth>
+    (first, second, third, fourth, fifth)
+.method<First, Second, Third, Fourth, Fifth>
+    (first, second, third, fourth, fifth);
+<<<
+receiver
+    .method<
+      First,
+      Second,
+      Third,
+      Fourth,
+      Fifth
+    >(
+      first,
+      second,
+      third,
+      fourth,
+      fifth,
+    )
+    .method<
+      First,
+      Second,
+      Third,
+      Fourth,
+      Fifth
+    >(
+      first,
+      second,
+      third,
+      fourth,
+      fifth,
+    );

--- a/test/pattern/cast.stmt
+++ b/test/pattern/cast.stmt
@@ -1,10 +1,23 @@
 40 columns                              |
->>> Basic cast pattern. 
+>>> Basic cast pattern.
 if (object case x as int) {;}
 <<<
 if (object case x as int) {
   ;
 }
+>>> More complex type.
+if (o case   1   as   List < int > ?  ) {}
+<<<
+if (o case 1 as List<int>?) {}
+>>> Split inside type annotation.
+if (obj case value as SomeLongClass<FirstTypeArgument, SecondTypeArgument>) {}
+<<<
+if (obj
+    case value
+        as SomeLongClass<
+          FirstTypeArgument,
+          SecondTypeArgument
+        >) {}
 >>> Split before 'case'.
 if (object case constant as VeryLongType) {;}
 <<<

--- a/test/statement/switch_legacy.stmt
+++ b/test/statement/switch_legacy.stmt
@@ -1,0 +1,65 @@
+40 columns                              |
+### Tests syntax that used to be valid in a switch case before Dart 3.0 but is
+### invalid in 3.0 and later.
+>>> Handle cases that are not valid patterns.
+switch (obj) {
+  case {1, 2}:
+  case -pi:
+  case !true:
+  case ~1:
+  case 1 != 2:
+  case 1 == 2:
+  case 1 & 2:
+  case 1 | 2:
+  case 1 ^ 2:
+  case 1 ~/ 2:
+  case 1 >> 2:
+  case 1 >>> 2:
+  case 1 << 2:
+  case 1 + 2:
+  case 1 - 2:
+  case 1 * 2:
+  case 1 / 2:
+  case 1 % 2:
+  case 1 < 2:
+  case 1 <= 2:
+  case 1 > 2:
+  case 1 >= 2:
+  case 1 ?? 2:
+  case true ? 1 : 2:
+  case 's'.length:
+  case 1 is int:
+  case 1 is! int:
+    body;
+}
+<<<
+switch (obj) {
+  case {1, 2}:
+  case -pi:
+  case !true:
+  case ~1:
+  case 1 != 2:
+  case 1 == 2:
+  case 1 & 2:
+  case 1 | 2:
+  case 1 ^ 2:
+  case 1 ~/ 2:
+  case 1 >> 2:
+  case 1 >>> 2:
+  case 1 << 2:
+  case 1 + 2:
+  case 1 - 2:
+  case 1 * 2:
+  case 1 / 2:
+  case 1 % 2:
+  case 1 < 2:
+  case 1 <= 2:
+  case 1 > 2:
+  case 1 >= 2:
+  case 1 ?? 2:
+  case true ? 1 : 2:
+  case 's'.length:
+  case 1 is int:
+  case 1 is! int:
+    body;
+}

--- a/test/top_level/trailing_whitespace.unit
+++ b/test/top_level/trailing_whitespace.unit
@@ -1,0 +1,32 @@
+40 columns                              |
+>>> Remove after line comment.
+// trailing spaces after here:×20×20×20×20
+<<<
+// trailing spaces after here:
+>>> Remove from empty line comment.
+//×20×20×20
+<<<
+//
+>>> Preserve inside block comment lines.
+/* one×20×20
+   two×20
+×20×20×20
+   three×20×20×20×20
+*/×20×20
+<<<
+/* one×20×20
+   two×20
+×20×20×20
+   three×20×20×20×20
+*/
+>>> Remove after code.
+main() {×20×20
+×20
+  veryLongExpression    +×20×20×20
+  veryLongStatement;×20×20
+}×20×20×20×20
+<<<
+main() {
+  veryLongExpression +
+      veryLongStatement;
+}

--- a/test/top_level/unicode.unit
+++ b/test/top_level/unicode.unit
@@ -1,0 +1,65 @@
+40 columns                              |
+>>> Preserve unicode whitespace inside comments but trim from the end.
+// control middle: ×09 end: ×09 ×09
+// control middle: ×0b end: ×0b ×0b
+// space middle: ×20 end: ×20 ×20
+// control middle: ×85 end: ×85 ×85
+<<<
+// control middle: ×09 end:
+// control middle: ×0b end:
+// space middle: ×20 end:
+// control middle: ×85 end:
+>>> Preserve unicode whitespace inside comments but trim from the end.
+// no-break space middle: ×a0 end: ×a0 ×a0
+// ogham space mark middle: ×1680 end: ×1680 ×1680
+// en quad middle: ×2000 end: ×2000 ×2000
+// em quad middle: ×2001 end: ×2001 ×2001
+// en space middle: ×2002 end: ×2002 ×2002
+// em space middle: ×2003 end: ×2003 ×2003
+<<<
+// no-break space middle: ×a0 end:
+// ogham space mark middle: ×1680 end:
+// en quad middle: ×2000 end:
+// em quad middle: ×2001 end:
+// en space middle: ×2002 end:
+// em space middle: ×2003 end:
+>>> Preserve unicode whitespace inside comments but trim from the end.
+// three-per-em space middle: ×2004 end: ×2004 ×2004
+// four-per-em space middle: ×2005 end: ×2005 ×2005
+// six-per-em space middle: ×2006 end: ×2006 ×2006
+// figure space middle: ×2007 end: ×2007 ×2007
+// punctuation space middle: ×2008 end: ×2008 ×2008
+// thin space middle: ×2009 end: ×2009 ×2009
+// hair space middle: ×200a end: ×200a ×200a
+<<<
+// three-per-em space middle: ×2004 end:
+// four-per-em space middle: ×2005 end:
+// six-per-em space middle: ×2006 end:
+// figure space middle: ×2007 end:
+// punctuation space middle: ×2008 end:
+// thin space middle: ×2009 end:
+// hair space middle: ×200a end:
+>>> Preserve unicode whitespace inside comments but trim from the end.
+// line separator middle: ×2028 end: ×2028 ×2028
+// paragraph separator middle: ×2029 end: ×2029 ×2029
+// narrow no-break space middle: ×202f end: ×202f ×202f
+// medium mathematical space middle: ×205f end: ×205f ×205f
+// ideographic space middle: ×3000 end: ×3000 ×3000
+// zero width no-break space middle: ×feff end: ×feff ×feff
+<<<
+// line separator middle: ×2028 end:
+// paragraph separator middle: ×2029 end:
+// narrow no-break space middle: ×202f end:
+// medium mathematical space middle: ×205f end:
+// ideographic space middle: ×3000 end:
+// zero width no-break space middle: ×feff end:
+>>> Unicode line endings.
+// line feed middle: ×0a // end: ×0a ×0a
+// form feed middle: ×0c // end: ×0c ×0c
+// carriage return middle: ×0d // end: ×0d ×0d
+<<<
+// line feed middle:
+// end:
+
+// form feed middle: ×0c // end:
+// carriage return middle: // end:

--- a/test/variable/pattern.stmt
+++ b/test/variable/pattern.stmt
@@ -1,5 +1,23 @@
 40 columns                              |
 ### Pattern variable declaration statements.
+>>> Basic syntax.
+{
+  var  (  a  &&  b  )  =  o;
+  var  (  a  as  int  ,  String  ?  b  )  = o;
+  var  (  :  inferred  )  = o;
+  final  [  a  !  ,  Foo  (  :  b  ) , ... ]  = o;
+  final  {  'k'  :  _  ,  ...  } = o;
+  var  Foo  (  prop  :  value  ,  :  inferred  )  = o;
+}
+<<<
+{
+  var (a && b) = o;
+  var (a as int, String? b) = o;
+  var (:inferred) = o;
+  final [a!, Foo(:b), ...] = o;
+  final {'k': _, ...} = o;
+  var Foo(prop: value, :inferred) = o;
+}
 >>> Prefer to split at "=" instead of pattern.
 var (longIdentifier && anotherOne) = value;
 <<<


### PR DESCRIPTION
In the process, I discovered a bug where the formatter would allow any list-like construct (collection literal, etc.) to support block formatting, which is definitely not intended. Only argument lists should allow that.

Fixed that bug.
