### PR TITLE
Require analyzer 6.3.0 and remove corresponding hack.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.7-wip
+
+* Remove temporary work around for analyzer 6.2.0 from dart_style 2.3.6.
+
 ## 2.3.6
 
 * Fix compile error when using dart_style with analyzer 6.2.0.

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -409,25 +409,3 @@ extension PatternExtensions on DartPattern {
         _ => false,
       };
 }
-
-// TODO(rnystrom): This is a gross hack because dart_style 2.3.5 has a bad
-// analyzer constraint which allows dart_style to be used with a version of
-// analyzer that doesn't publicly expose the `.macroKeyword` getter.
-// Fortunately, the oldest analyzer that dart_style allows *does* have the
-// getter on the ClassDeclarationImpl class.
-//
-// To get users off that bad version, we're publishing a new version of
-// dart_style that has the same constraint and gracefully handles that getter
-// not statically being visible.
-//
-// This hack will be removed immediately after publishing a version with that
-// fix.
-extension ClassDeclarationExtensions on ClassDeclaration {
-  /// If the [ClassDeclaration] is from a version of analyzer that has the
-  /// `macroKeyword` getter and the class has a `macro` keyword, returns that
-  /// token.
-  ///
-  /// Otherwise, returns `null`.
-  Token? get hackMacroKeywordForOlderAnalyzer =>
-      (this as dynamic).macroKeyword as Token?;
-}

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -248,7 +248,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
           node.interfaceKeyword,
           node.finalKeyword,
           node.sealedKeyword,
-          node.hackMacroKeywordForOlderAnalyzer,
+          node.macroKeyword,
           node.mixinKeyword,
           node.classKeyword,
         ],

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -592,7 +592,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     modifier(node.finalKeyword);
     modifier(node.sealedKeyword);
     modifier(node.mixinKeyword);
-    modifier(node.hackMacroKeywordForOlderAnalyzer);
+    modifier(node.macroKeyword);
     token(node.classKeyword);
     space();
     token(node.name);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.6
+version: 2.3.7-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.
@@ -9,7 +9,7 @@ environment:
   sdk: "^3.0.0"
 
 dependencies:
-  analyzer: '^6.2.0'
+  analyzer: '^6.3.0'
   args: ">=1.0.0 <3.0.0"
   collection: "^1.17.0"
   path: ^1.0.0


### PR DESCRIPTION
I introduced a hack to fix #1413. This bumps the analyzer constraint and removes that hack.
