### PR TITLE
Force list, set, and maps to split if they are nested.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1130,6 +1130,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
       node.leftBracket,
       node.elements,
       node.rightBracket,
+      splitOnNestedCollection: true,
     );
   }
 
@@ -1595,6 +1596,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
       node.leftBracket,
       node.elements,
       node.rightBracket,
+      splitOnNestedCollection: true,
     );
   }
 

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -136,7 +136,7 @@ mixin PieceFactory {
   /// [splitOnNestedCollection] is also `true`, even if the collection would
   /// otherwise not need to split. This is `true` for list, map, and set
   /// expressions because they are often used for composite data structures and
-  /// they're easier to read if they don't get packed to densely:
+  /// they're easier to read if they don't get packed too densely:
   ///
   ///     // Prefer:
   ///     data = {

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -50,6 +50,18 @@ typedef BinaryOperation = (AstNode left, Token operator, AstNode right);
 /// To avoid that, we pick one concrete construct formatted by the function,
 /// usually the most common, and name it after that, as in [createImport()].
 mixin PieceFactory {
+  /// A stack that handles forcing nested list, map, and set literals to split.
+  ///
+  /// Each entry corresponds to a collection currently being visited and the
+  /// value is whether or not it should be forced to split because an inner
+  /// collection was found inside it.
+  ///
+  /// When we begin a collection, we set all of the existing elements to `true`
+  /// then push `false` for the new collection. When done visiting the elements,
+  /// we pop the last value, If it's `true`, we know we visited a nested
+  /// collection so we force this one to split.
+  final List<bool> _collectionSplits = [];
+
   PieceWriter get pieces;
 
   CommentWriter get comments;
@@ -118,6 +130,35 @@ mixin PieceFactory {
   }
 
   /// Creates a [ListPiece] for a collection literal or pattern.
+  ///
+  /// If [splitOnNestedCollection] is `true`, then this collection is forced to
+  /// split if it contains any non-empty collections where
+  /// [splitOnNestedCollection] is also `true`, even if the collection would
+  /// otherwise not need to split. This is `true` for list, map, and set
+  /// expressions because they are often used for composite data structures and
+  /// they're easier to read if they don't get packed to densely:
+  ///
+  ///     // Prefer:
+  ///     data = {
+  ///       'a': [1, 2, 3],
+  ///       'b': [
+  ///         4,
+  ///         [5],
+  ///         6,
+  ///       ]
+  ///       'c': [7, 8],
+  ///     };
+  ///
+  ///     // Over:
+  ///     data = {'a': [1, 2, 3], 'b': [4, [5], 6] 'c': [7, 8]};
+  ///
+  /// We don't do this for record expressions because those are not unbounded
+  /// in size and generally represent aggregations of data where the fields are
+  /// more "closely" bundled together. Record expressions are sort of like
+  /// constructor invocations for an anonymous constructor.
+  ///
+  /// We don't do this for patterns because it's better to fit a pattern on a
+  /// single line when possible for parallel cases in switches.
   Piece createCollection(
     Token leftBracket,
     List<AstNode> elements,
@@ -125,6 +166,7 @@ mixin PieceFactory {
     Token? constKeyword,
     TypeArgumentList? typeArguments,
     ListStyle style = const ListStyle(),
+    bool splitOnNestedCollection = false,
   }) {
     return buildPiece((b) {
       b.modifier(constKeyword);
@@ -141,12 +183,30 @@ mixin PieceFactory {
       // The formatter will preserve the newline after element 3 and the lack of
       // them after the other elements.
 
-      b.add(createList(
+      if (splitOnNestedCollection) {
+        // If this collection isn't empty, force all of the surrounding
+        // collections to split if they care to.
+        if (elements.isNotEmpty) {
+          _collectionSplits.fillRange(0, _collectionSplits.length, true);
+        }
+
+        // Add this collection to the stack.
+        _collectionSplits.add(false);
+      }
+
+      var collection = createList(
         leftBracket: leftBracket,
         elements,
         rightBracket: rightBracket,
         style: style,
-      ));
+      );
+
+      // If there is a collection inside this one, force this one to split.
+      if (splitOnNestedCollection) {
+        if (_collectionSplits.removeLast()) collection.pin(State.split);
+      }
+
+      b.add(collection);
     });
   }
 

--- a/test/expression/collection_for.stmt
+++ b/test/expression/collection_for.stmt
@@ -134,11 +134,15 @@ var map = {
 >>> A control flow element in an inner list doesn't force the outer to split.
 var l = [for (;;) [if (c) d]];
 <<<
-var l = [for (;;) [if (c) d]];
+var l = [
+  for (;;) [if (c) d],
+];
 >>>
 var l = [for (;;) [for (c in d) e]];
 <<<
-var l = [for (;;) [for (c in d) e]];
+var l = [
+  for (;;) [for (c in d) e],
+];
 >>> Pattern for-in.
 var list = [
 for (var (longIdentifier && anotherLongOne) in obj) element

--- a/test/expression/collection_for_spread_list.stmt
+++ b/test/expression/collection_for_spread_list.stmt
@@ -3,7 +3,9 @@
 >>> Spread list inside for stays on one line if it fits.
 var list = [for (;;) ...[1, 2]];
 <<<
-var list = [for (;;) ...[1, 2]];
+var list = [
+  for (;;) ...[1, 2],
+];
 >>> Spread list inside for formats like block if it splits.
 var list = [for (;;) ...[element1, element2, element3]];
 <<<

--- a/test/expression/collection_for_spread_map.stmt
+++ b/test/expression/collection_for_spread_map.stmt
@@ -3,7 +3,9 @@
 >>> Spread list inside for stays on one line if it fits.
 var map = {for (;;) ...{1: 1, 2: 2}};
 <<<
-var map = {for (;;) ...{1: 1, 2: 2}};
+var map = {
+  for (;;) ...{1: 1, 2: 2},
+};
 >>> Spread list inside for formats like block if it splits.
 var map = {for (;;) ...{element1: 1, element2: 2, element3: 3}};
 <<<

--- a/test/expression/collection_for_spread_set.stmt
+++ b/test/expression/collection_for_spread_set.stmt
@@ -3,7 +3,9 @@
 >>> Spread list inside for stays on one line if it fits.
 var set = {for (;;) ...{1, 2}};
 <<<
-var set = {for (;;) ...{1, 2}};
+var set = {
+  for (;;) ...{1, 2},
+};
 >>> Spread list inside for formats like block if it splits.
 var set = {for (;;) ...{element1, element2, element3}};
 <<<

--- a/test/expression/collection_if.stmt
+++ b/test/expression/collection_if.stmt
@@ -153,7 +153,9 @@ var list = [
 >>> Nested if inside list doesn't force outer if to split.
 var list = [if (a) [if (b) c]];
 <<<
-var list = [if (a) [if (b) c]];
+var list = [
+  if (a) [if (b) c],
+];
 >>> Chained if-else.
 var list = [if (condition1) thing1 else if (condition2) thing2];
 <<<

--- a/test/expression/collection_if_spread_list.stmt
+++ b/test/expression/collection_if_spread_list.stmt
@@ -3,11 +3,15 @@
 >>> Spread then element stays unsplit if it fits.
 var list = [if (c) ...[1, 2]];
 <<<
-var list = [if (c) ...[1, 2]];
+var list = [
+  if (c) ...[1, 2],
+];
 >>> Spread else stays unsplit if it fits.
 var list = [if (c) 1 else ...[2, 3]];
 <<<
-var list = [if (c) 1 else ...[2, 3]];
+var list = [
+  if (c) 1 else ...[2, 3],
+];
 >>> Spread then and else stay unsplit if they fit.
 var list = [if (c) ...[1, 2] else ...[3, 4]];
 <<<
@@ -132,9 +136,9 @@ var list = [
 >>> A single-line list that isn't spread.
 var list = [if (a) [b]];
 <<<
-### TODO(tall): This will change if the new style gets the same rule as the old
-### where nested collections force outer ones to split.
-var list = [if (a) [b]];
+var list = [
+  if (a) [b],
+];
 >>> A collection that isn't spread wraps and indents.
 var list = [if (condition) [element1, element2, element3]];
 <<<

--- a/test/expression/collection_if_spread_map.stmt
+++ b/test/expression/collection_if_spread_map.stmt
@@ -3,11 +3,15 @@
 >>> Spread then element stays unsplit if it fits.
 var map = {if (c) ...{1: 1, 2: 2}};
 <<<
-var map = {if (c) ...{1: 1, 2: 2}};
+var map = {
+  if (c) ...{1: 1, 2: 2},
+};
 >>> Spread else stays unsplit if it fits.
 var map = {if (c) 1 else ...{2: 2}};
 <<<
-var map = {if (c) 1 else ...{2: 2}};
+var map = {
+  if (c) 1 else ...{2: 2},
+};
 >>> Spread then and else stay unsplit if they fit.
 var map = {if (c) ...{1: 1, 2: 2} else ...{3: 3}};
 <<<
@@ -132,9 +136,9 @@ var map = {
 >>> A single-line map that isn't spread.
 var map = {if (a) {b: b}};
 <<<
-### TODO(tall): This will change if the new style gets the same rule as the old
-### where nested collections force outer ones to split.
-var map = {if (a) {b: b}};
+var map = {
+  if (a) {b: b},
+};
 >>> A collection that isn't spread wraps and indents.
 var map = {if (condition) {element1: 1, element2: 2}};
 <<<

--- a/test/expression/collection_if_spread_set.stmt
+++ b/test/expression/collection_if_spread_set.stmt
@@ -3,11 +3,15 @@
 >>> Spread then element stays unsplit if it fits.
 var set = {if (c) ...{1, 2}};
 <<<
-var set = {if (c) ...{1, 2}};
+var set = {
+  if (c) ...{1, 2},
+};
 >>> Spread else stays unsplit if it fits.
 var set = {if (c) 1 else ...{2, 3}};
 <<<
-var set = {if (c) 1 else ...{2, 3}};
+var set = {
+  if (c) 1 else ...{2, 3},
+};
 >>> Spread then and else stay unsplit if they fit.
 var set = {if (c) ...{1, 2} else ...{3, 4}};
 <<<
@@ -132,9 +136,9 @@ var set = {
 >>> A single-line list that isn't spread.
 var set = {if (a) {b}};
 <<<
-### TODO(tall): This will change if the new style gets the same rule as the old
-### where nested collections force outer ones to split.
-var set = {if (a) {b}};
+var set = {
+  if (a) {b},
+};
 >>> A collection that isn't spread wraps and indents.
 var set = {if (condition) {element1, element2, element3}};
 <<<

--- a/test/expression/list_nested.stmt
+++ b/test/expression/list_nested.stmt
@@ -1,0 +1,80 @@
+40 columns                              |
+### Tests that nested collections force outer ones to split.
+>>> Nested non-empty list forces outer list to split.
+list = [[inner]];
+<<<
+list = [
+  [inner],
+];
+>>> Nested non-empty map forces outer list to split.
+list = [{key: inner}];
+<<<
+list = [
+  {key: inner},
+];
+>>> Nested non-empty set forces outer list to split.
+list = [{inner}];
+<<<
+list = [
+  {inner},
+];
+>>> Nested non-empty record does not force outer list to split.
+list = [(inner,)];
+<<<
+list = [(inner,)];
+>>> Nested empty collection does not force outer list to split.
+list = [[], {}, ()];
+<<<
+list = [[], {}, ()];
+>>> A spread list literal splits an outer list even if it fits.
+list = [1, ...[2, 3], 4];
+<<<
+list = [
+  1,
+  ...[2, 3],
+  4,
+];
+>>> A spread empty list does not force outer split
+list = [1, ...[], 4];
+<<<
+list = [1, ...[], 4];
+>>> Indirect nesting still forces a split.
+[function([inner])];
+<<<
+[
+  function([inner]),
+];
+>>> Multiple nested collections.
+list = [first, [second, third, fourth], fifth, {sixth, seventh, eighth, nine, tenth,
+    eleventh}];
+<<<
+list = [
+  first,
+  [second, third, fourth],
+  fifth,
+  {
+    sixth,
+    seventh,
+    eighth,
+    nine,
+    tenth,
+    eleventh,
+  },
+];
+>>> Deeply nested collections.
+list = [[{[[argument, argument, argument, argument]]}]];
+<<<
+list = [
+  [
+    {
+      [
+        [
+          argument,
+          argument,
+          argument,
+          argument,
+        ],
+      ],
+    },
+  ],
+];

--- a/test/expression/map_nested.stmt
+++ b/test/expression/map_nested.stmt
@@ -1,0 +1,48 @@
+40 columns                              |
+### Tests that nested collections force outer ones to split.
+>>> Nested non-empty list forces outer map to split.
+map = {key: [inner]};
+<<<
+map = {
+  key: [inner],
+};
+>>> Nested non-empty map forces outer map to split.
+map = {key: {key: inner}};
+<<<
+map = {
+  key: {key: inner},
+};
+>>> Nested non-empty set forces outer map to split.
+map = {key: {inner}};
+<<<
+map = {
+  key: {inner},
+};
+>>> Nested non-empty record does not force outer map to split.
+map = {key: (inner,)};
+<<<
+map = {key: (inner,)};
+>>> Nested empty collection does not force outer map to split.
+map = {a: [], b: {}, c: ()};
+<<<
+map = {a: [], b: {}, c: ()};
+>>> Indirect nesting still forces a split.
+map = {a: function({b: inner})};
+<<<
+map = {
+  a: function({b: inner}),
+};
+>>> Multiple nested collections.
+var m = {first: 1, second: [third, fourth], fifth: 5, nested: {sixth: seventh, eighth: nine,
+    tenth: eleventh}};
+<<<
+var m = {
+  first: 1,
+  second: [third, fourth],
+  fifth: 5,
+  nested: {
+    sixth: seventh,
+    eighth: nine,
+    tenth: eleventh,
+  },
+};

--- a/test/expression/record_nested.stmt
+++ b/test/expression/record_nested.stmt
@@ -1,0 +1,22 @@
+40 columns                              |
+### Tests that nested collections do not force outer records to split.
+>>> Nested non-empty list does not force outer record to split.
+record = ([inner],);
+<<<
+record = ([inner],);
+>>> Nested non-empty map does not force outer record to split.
+record = ({key: inner},);
+<<<
+record = ({key: inner},);
+>>> Nested non-empty set does not force outer record to split.
+record = ({inner},);
+<<<
+record = ({inner},);
+>>> Nested non-empty record does not force outer record to split.
+record = ((inner,),);
+<<<
+record = ((inner,),);
+>>> Nested empty collection does not force outer record to split.
+record = ([], {}, ());
+<<<
+record = ([], {}, ());

--- a/test/expression/set_nested.stmt
+++ b/test/expression/set_nested.stmt
@@ -1,0 +1,76 @@
+40 columns                              |
+### Tests that nested collections force outer ones to split.
+>>> Nested non-empty list forces outer set to split.
+set = {[inner]};
+<<<
+set = {
+  [inner],
+};
+>>> Nested non-empty map forces outer set to split.
+set = {{key: inner}};
+<<<
+set = {
+  {key: inner},
+};
+>>> Nested non-empty set forces outer set to split.
+set = {{inner}};
+<<<
+set = {
+  {inner},
+};
+>>> Nested non-empty record does not force outer set to split.
+set = {(inner,)};
+<<<
+set = {(inner,)};
+>>> Nested empty collection does not force outer set to split.
+set = {[], {}, ()};
+<<<
+set = {[], {}, ()};
+### TODO: Clean up.
+>>> splits outer sets even if they fit
+var s = {a, {b, c}, d, {},
+    e, {f, {g, h} }  };
+<<<
+var s = {
+  a,
+  {b, c},
+  d,
+  {},
+  e,
+  {
+    f,
+    {g, h},
+  },
+};
+>>> split indirect outer
+var s = {a, function({b, inner})};
+<<<
+var s = {
+  a,
+  function({b, inner}),
+};
+>>> empty literal does not force outer split
+var s = {a, <int>{}, b, [], c, () {}};
+<<<
+var s = {a, <int>{}, b, [], c, () {}};
+>>> nested split set
+var s = {first, 1, second, {third, fourth}, fifth, 5, nested, {sixth, seventh, eighth, nine,
+    tenth, eleventh}};
+<<<
+var s = {
+  first,
+  1,
+  second,
+  {third, fourth},
+  fifth,
+  5,
+  nested,
+  {
+    sixth,
+    seventh,
+    eighth,
+    nine,
+    tenth,
+    eleventh,
+  },
+};

--- a/test/pattern/list.stmt
+++ b/test/pattern/list.stmt
@@ -108,3 +108,15 @@ if (obj case [
 ]) {
   ;
 }
+>>> A nested non-empty list pattern doesn't force the list pattern to split.
+var [[v]] = value;
+<<<
+var [[v]] = value;
+>>> A nested non-empty map pattern doesn't force the list pattern to split.
+var [{k: v}] = value;
+<<<
+var [{k: v}] = value;
+>>> A nested non-empty record pattern doesn't force the list pattern to split.
+var [(v,)] = value;
+<<<
+var [(v,)] = value;

--- a/test/pattern/map.stmt
+++ b/test/pattern/map.stmt
@@ -89,3 +89,15 @@ if (obj case {
 }) {
   ;
 }
+>>> A nested non-empty list pattern doesn't force the map pattern to split.
+var {k: [v]} = value;
+<<<
+var {k: [v]} = value;
+>>> A nested non-empty map pattern doesn't force the map pattern to split.
+var {k: {k: v}} = value;
+<<<
+var {k: {k: v}} = value;
+>>> A nested non-empty record pattern doesn't force the map pattern to split.
+var {k: (v,)} = value;
+<<<
+var {k: (v,)} = value;

--- a/test/pattern/record.stmt
+++ b/test/pattern/record.stmt
@@ -1,5 +1,5 @@
 40 columns                              |
->>> Basic record switch. 
+>>> Basic record switch.
 switch (obj) {
   case  (  )  :
   case  (  value  ,  )  :
@@ -164,3 +164,15 @@ if (e case (
   longPattern1,
   veryLongPattern2,
 )) {}
+>>> A nested non-empty list pattern doesn't force the record pattern to split.
+var ([v],) = value;
+<<<
+var ([v],) = value;
+>>> A nested non-empty map pattern doesn't force the record pattern to split.
+var ({k: v},) = value;
+<<<
+var ({k: v},) = value;
+>>> A nested non-empty record pattern doesn't force the record pattern to split.
+var ((v,),) = value;
+<<<
+var ((v,),) = value;


### PR DESCRIPTION
If a list, set, or map literal contains (directly or indirectly) another list, set, or map literal, then force the outer one to split, even if it would otherwise fit.

We don't do this for record expressions, or any kind of pattern because those tend to be smaller and look better when kept closely packed.

The behavior here is exactly the same as in the current formatter.
