### PR TITLE
Test that benchmarks produce their expected output.

### DIFF
--- a/benchmark/case/flutter_scrollbar_test.expect
+++ b/benchmark/case/flutter_scrollbar_test.expect
@@ -18,21 +18,23 @@ void main() {
                 child: SizedBox(
                   height: 1000.0,
                   width: double.infinity,
-                  child: Column(children: <Widget>[Scrollbar(
-                    key: key1,
-                    child: SizedBox(
-                      height: 300.0,
-                      width: double.infinity,
-                      child: SingleChildScrollView(
-                        key: innerKey,
-                        child: const SizedBox(
-                          key: Key('Inner scrollable'),
-                          height: 1000.0,
-                          width: double.infinity,
+                  child: Column(children: <Widget>[
+                    Scrollbar(
+                      key: key1,
+                      child: SizedBox(
+                        height: 300.0,
+                        width: double.infinity,
+                        child: SingleChildScrollView(
+                          key: innerKey,
+                          child: const SizedBox(
+                            key: Key('Inner scrollable'),
+                            height: 1000.0,
+                            width: double.infinity,
+                          ),
                         ),
                       ),
                     ),
-                  )]),
+                  ]),
                 ),
               ),
             ),

--- a/benchmark/case/large.expect
+++ b/benchmark/case/large.expect
@@ -766,11 +766,9 @@ class Traverser {
           // Make sure the package doesn't have any bad dependencies.
           for (var dep in deps) {
             if (!dep.isRoot && _solver.sources[dep.source] is UnknownSource) {
-              throw new UnknownSourceException(id.name, [new Dependency(
-                id.name,
-                id.version,
-                dep,
-              )]);
+              throw new UnknownSourceException(id.name, [
+                new Dependency(id.name, id.version, dep),
+              ]);
             }
           }
 

--- a/lib/src/testing/benchmark.dart
+++ b/lib/src/testing/benchmark.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'test_file.dart';
+
+class Benchmark {
+  /// Finds all of the benchmarks in the `benchmark/cases` directory.
+  static Future<List<Benchmark>> findAll() async {
+    var casesDirectory =
+        Directory(p.join(await findPackageDirectory(), 'benchmark/case'));
+
+    var benchmarks = [
+      for (var entry in casesDirectory.listSync())
+        if (p.extension(entry.path) case '.unit' || '.stmt')
+          await read(entry.path)
+    ];
+
+    benchmarks.sort((a, b) => a.name.compareTo(b.name));
+
+    return benchmarks;
+  }
+
+  /// Reads the benchmark from [path].
+  ///
+  /// This should point to a `.unit` or `.stmt` file that has a corresponding
+  /// `.expect` and `expect_short` file in the same directory with those
+  /// expectations.
+  static Future<Benchmark> read(String path) async {
+    var inputLines = await File(path).readAsLines();
+
+    // The first line may have a "|" to indicate the page width.
+    var pageWidth = 80;
+    if (inputLines[0].endsWith('|')) {
+      pageWidth = inputLines[0].indexOf('|');
+      inputLines.removeAt(0);
+    }
+
+    var input = inputLines.join('\n');
+
+    var shortOutput =
+        await File(p.setExtension(path, '.expect_short')).readAsString();
+    var tallOutput = await File(p.setExtension(path, '.expect')).readAsString();
+
+    return Benchmark(
+        name: p.basenameWithoutExtension(path),
+        input: input,
+        pageWidth: pageWidth,
+        isCompilationUnit: p.extension(path) == '.unit',
+        shortOutput: shortOutput,
+        tallOutput: tallOutput);
+  }
+
+  /// The short display name of the benchmark.
+  final String name;
+
+  /// The unformatted input.
+  final String input;
+
+  /// The page width that the input should be formatted at.
+  final int pageWidth;
+
+  /// Whether the benchmark's code is an entire compilation unit or a statement.
+  final bool isCompilationUnit;
+
+  /// The expected formatted output using short style.
+  final String shortOutput;
+
+  /// The expected formatted output using tall style.
+  final String tallOutput;
+
+  Benchmark(
+      {required this.name,
+      required this.input,
+      required this.pageWidth,
+      required this.isCompilationUnit,
+      required this.shortOutput,
+      required this.tallOutput});
+}

--- a/lib/src/testing/test_file.dart
+++ b/lib/src/testing/test_file.dart
@@ -1,3 +1,6 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 import 'dart:io';
 import 'dart:isolate';
 
@@ -10,12 +13,16 @@ final _fixPattern = RegExp(r'\(fix ([a-x-]+)\)');
 final _unicodeUnescapePattern = RegExp(r'×([0-9a-fA-F]{2,4})');
 final _unicodeEscapePattern = RegExp('[\x0a\x0c\x0d]');
 
-/// Get the absolute local file path to the package's "test" directory.
-Future<String> findTestDirectory() async {
+/// Get the absolute local file path to the dart_style package's root directory.
+Future<String> findPackageDirectory() async {
   var libraryUri = await Isolate.resolvePackageUri(
       Uri.parse('package:dart_style/src/testing/test_file.dart'));
-  return p
-      .normalize(p.join(p.dirname(libraryUri!.toFilePath()), '../../../test'));
+  return p.normalize(p.join(p.dirname(libraryUri!.toFilePath()), '../../..'));
+}
+
+/// Get the absolute local file path to the package's "test" directory.
+Future<String> findTestDirectory() async {
+  return p.normalize(p.join(await findPackageDirectory(), 'test'));
 }
 
 /// A file containing a series of formatting tests.

--- a/test/short_format_test.dart
+++ b/test/short_format_test.dart
@@ -17,6 +17,8 @@ void main() async {
   await testDirectory('splitting', tall: false);
   await testDirectory('whitespace', tall: false);
 
+  await testBenchmarks(useTallStyle: false);
+
   test('throws a FormatterException on failed parse', () {
     var formatter = DartFormatter();
     expect(() => formatter.format('wat?!'), throwsA(isA<FormatterException>()));

--- a/test/tall_format_test.dart
+++ b/test/tall_format_test.dart
@@ -23,6 +23,8 @@ void main() async {
   await testDirectory('variable', tall: true);
   await testDirectory('regression_tall', tall: true);
 
+  await testBenchmarks(useTallStyle: true);
+
   test('throws a FormatterException on failed parse', () {
     var formatter = DartFormatter();
     expect(() => formatter.format('wat?!'), throwsA(isA<FormatterException>()));


### PR DESCRIPTION
The benchmark expectations weren't being run as part of the tests which meant that it was easy to break the benchmarks without realizing it. A recent fix to not block format collection literal elements broke a couple of the benchmarks.

This fixes them. It also ensures they won't break again by having the format tests also test all of the benchmarks.

And it adds support to the benchmark runner to run all the benchmarks in one go.
