### PR TITLE
Preserve newlines (or lack of) in collections with line comments.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -125,6 +125,25 @@ extension AstIterableExtensions on Iterable<AstNode> {
   /// but allow a split if there are elements or comments inside.
   bool canSplit(Token rightBracket) =>
       isNotEmpty || rightBracket.precedingComments != null;
+
+  /// Returns `true` if the collection containing these elements and terminated
+  /// by [rightBracket] contains any line comments before, between, or after
+  /// any elements.
+  ///
+  /// Comments within an element are ignored.
+  bool containsLineComments([Token? rightBracket]) {
+    // Look before each element.
+    for (var element in this) {
+      if (element.beginToken.hasLineCommentBefore) return true;
+    }
+
+    // Look before the closing bracket.
+    if (rightBracket != null) {
+      if (rightBracket.hasLineCommentBefore) return true;
+    }
+
+    return false;
+  }
 }
 
 extension ExpressionExtensions on Expression {
@@ -408,4 +427,17 @@ extension PatternExtensions on DartPattern {
           fields.canSplit(rightParenthesis),
         _ => false,
       };
+}
+
+extension TokenExtensions on Token {
+  /// Whether this token has a preceding comment that is a line comment.
+  bool get hasLineCommentBefore {
+    for (Token? comment = precedingComments;
+        comment != null;
+        comment = comment.next) {
+      if (comment.type == TokenType.SINGLE_LINE_COMMENT) return true;
+    }
+
+    return false;
+  }
 }

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -131,19 +131,9 @@ extension AstIterableExtensions on Iterable<AstNode> {
   /// any elements.
   ///
   /// Comments within an element are ignored.
-  bool containsLineComments([Token? rightBracket]) {
-    // Look before each element.
-    for (var element in this) {
-      if (element.beginToken.hasLineCommentBefore) return true;
-    }
-
-    // Look before the closing bracket.
-    if (rightBracket != null) {
-      if (rightBracket.hasLineCommentBefore) return true;
-    }
-
-    return false;
-  }
+  bool containsLineComments([Token? rightBracket]) =>
+      any((element) => element.beginToken.hasLineCommentBefore) ||
+      (rightBracket?.hasLineCommentBefore ?? false);
 }
 
 extension ExpressionExtensions on Expression {

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1131,6 +1131,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
       node.elements,
       node.rightBracket,
       splitOnNestedCollection: true,
+      preserveNewlines: true,
     );
   }
 
@@ -1464,6 +1465,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
       node.leftParenthesis,
       node.fields,
       node.rightParenthesis,
+      preserveNewlines: true,
     );
   }
 
@@ -1597,6 +1599,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
       node.elements,
       node.rightBracket,
       splitOnNestedCollection: true,
+      preserveNewlines: true,
     );
   }
 

--- a/lib/src/front_end/comment_writer.dart
+++ b/lib/src/front_end/comment_writer.dart
@@ -130,6 +130,10 @@ class CommentWriter {
     return comments;
   }
 
+  /// Whether there are any newlines between [from] and [to].
+  bool hasNewlineBetween(Token from, Token to) =>
+      _endLine(from) < _startLine(to);
+
   /// Gets the 1-based line number that the beginning of [token] lies on.
   int _startLine(Token token) => _lineInfo.getLocation(token.offset).lineNumber;
 

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -903,9 +903,6 @@ mixin PieceFactory {
         builder.add(lineBuilder.build());
         lineBuilder = DelimitedListBuilder(this, lineStyle);
         atLineStart = true;
-      } else if (!atLineStart) {
-        // This element follows another on the same line.
-        // lineBuilder.space();
       }
 
       // Let the main list builder handle comments that occur between elements

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -911,12 +911,6 @@ mixin PieceFactory {
       // that aren't on the same line.
       if (atLineStart) builder.addCommentsBefore(element.beginToken);
 
-      // If the next element is on this same line, then include the comma in
-      // the row. Otherwise, let the surrounding DelimitedListBuilder handle
-      // it.
-      var includeComma = i < elements.length - 1 &&
-          !comments.hasNewlineBetween(
-              element.endToken, elements[i + 1].beginToken);
       lineBuilder.visit(element);
 
       // There is an element on this line now.

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -72,7 +72,7 @@ mixin PieceFactory {
 
   /// Creates a [ListPiece] for an argument list.
   Piece createArgumentList(
-      Token leftBracket, Iterable<AstNode> elements, Token rightBracket) {
+      Token leftBracket, List<AstNode> elements, Token rightBracket) {
     return createList(
         leftBracket: leftBracket,
         elements,
@@ -159,6 +159,17 @@ mixin PieceFactory {
   ///
   /// We don't do this for patterns because it's better to fit a pattern on a
   /// single line when possible for parallel cases in switches.
+  ///
+  /// If [preserveNewlines] is `true`, then any newlines or lack of newlines
+  /// between pairs of elements in the input are preserved in the output. This
+  /// is used for collection literals that contain line comments to preserve
+  /// the author's deliberate structuring, as in:
+  ///
+  ///     matrix = [
+  ///       1, 2, 3,
+  ///       4, 5, 6,
+  ///       7, 8, 9,
+  ///     ];
   Piece createCollection(
     Token leftBracket,
     List<AstNode> elements,
@@ -167,21 +178,11 @@ mixin PieceFactory {
     TypeArgumentList? typeArguments,
     ListStyle style = const ListStyle(),
     bool splitOnNestedCollection = false,
+    bool preserveNewlines = false,
   }) {
     return buildPiece((b) {
       b.modifier(constKeyword);
       b.visit(typeArguments);
-
-      // TODO(tall): Support a line comment inside a collection literal as a
-      // signal to preserve internal newlines. So if you have:
-      //
-      //     var list = [
-      //       1, 2, 3, // comment
-      //       4, 5, 6,
-      //     ];
-      //
-      // The formatter will preserve the newline after element 3 and the lack of
-      // them after the other elements.
 
       if (splitOnNestedCollection) {
         // If this collection isn't empty, force all of the surrounding
@@ -199,6 +200,7 @@ mixin PieceFactory {
         elements,
         rightBracket: rightBracket,
         style: style,
+        preserveNewlines: preserveNewlines,
       );
 
       // If there is a collection inside this one, force this one to split.
@@ -828,15 +830,100 @@ mixin PieceFactory {
   }
 
   /// Creates a [ListPiece] for the given bracket-delimited set of elements.
-  Piece createList(Iterable<AstNode> elements,
+  ///
+  /// If [preserveNewlines] is `true`, then any newlines or lack of newlines
+  /// between pairs of elements in the input are preserved in the output. This
+  /// is used for collection literals that contain line comments to preserve
+  /// the author's deliberate structuring, as in:
+  ///
+  ///     matrix = [
+  ///       1, 2, 3,
+  ///       4, 5, 6,
+  ///       7, 8, 9,
+  ///     ];
+  Piece createList(List<AstNode> elements,
       {Token? leftBracket,
       Token? rightBracket,
-      ListStyle style = const ListStyle()}) {
+      ListStyle style = const ListStyle(),
+      bool preserveNewlines = false}) {
     var builder = DelimitedListBuilder(this, style);
+
     if (leftBracket != null) builder.leftBracket(leftBracket);
-    elements.forEach(builder.visit);
+
+    if (preserveNewlines && elements.containsLineComments(rightBracket!)) {
+      _preserveNewlinesInCollection(elements, builder);
+    } else {
+      elements.forEach(builder.visit);
+    }
+
     if (rightBracket != null) builder.rightBracket(rightBracket);
     return builder.build();
+  }
+
+  /// Writes [elements] into [builder], preserving the original newlines (or
+  /// lack thereof) between elements.
+  ///
+  /// This is used for formatting collection literals that contain at least one
+  /// line comment between elements. In that case, we use the line comment as a
+  /// single to prefer the author's chosen newlines between elements. For
+  /// example, if the user writes:
+  ///
+  ///     list = [
+  ///       1,2,   3, 4,
+  ///       // comment
+  ///       5,6,    7
+  ///     ];
+  ///
+  /// The formatter produces:
+  ///
+  ///     list = [
+  ///       1, 2, 3, 4,
+  ///       // comment
+  ///       5, 6, 7
+  ///     ];
+  void _preserveNewlinesInCollection(
+      List<AstNode> elements, DelimitedListBuilder builder) {
+    // Builder for all of the elements on a single line. We use a ListPiece for
+    // this too because even though we prefer to keep all elements that are on
+    // a single line in the input also on a single line in the output, we will
+    // split them if they don't fit.
+    var lineStyle = const ListStyle(commas: Commas.nonTrailing);
+    var lineBuilder = DelimitedListBuilder(this, lineStyle);
+    var atLineStart = true;
+
+    for (var i = 0; i < elements.length; i++) {
+      var element = elements[i];
+
+      if (!atLineStart &&
+          comments.hasNewlineBetween(
+              elements[i - 1].endToken, element.beginToken)) {
+        // This element begins a new line. Add the elements on the previous
+        // line to the list builder and start a new line.
+        builder.add(lineBuilder.build());
+        lineBuilder = DelimitedListBuilder(this, lineStyle);
+        atLineStart = true;
+      } else if (!atLineStart) {
+        // This element follows another on the same line.
+        // lineBuilder.space();
+      }
+
+      // Let the main list builder handle comments that occur between elements
+      // that aren't on the same line.
+      if (atLineStart) builder.addCommentsBefore(element.beginToken);
+
+      // If the next element is on this same line, then include the comma in
+      // the row. Otherwise, let the surrounding DelimitedListBuilder handle
+      // it.
+      var includeComma = i < elements.length - 1 &&
+          !comments.hasNewlineBetween(
+              element.endToken, elements[i + 1].beginToken);
+      lineBuilder.visit(element);
+
+      // There is an element on this line now.
+      atLineStart = false;
+    }
+
+    if (!atLineStart) builder.add(lineBuilder.build());
   }
 
   /// Create a [VariablePiece] for a named or wildcard variable pattern.
@@ -887,6 +974,7 @@ mixin PieceFactory {
     List<AstNode> fields,
     Token rightParenthesis, {
     Token? constKeyword,
+    bool preserveNewlines = false,
   }) {
     var style = switch (fields) {
       // Record types or patterns with a single named field don't add a trailing
@@ -925,6 +1013,7 @@ mixin PieceFactory {
       fields,
       rightParenthesis,
       style: style,
+      preserveNewlines: preserveNewlines,
     );
   }
 
@@ -1050,7 +1139,7 @@ mixin PieceFactory {
 
   /// Creates a [ListPiece] for a type argument or type parameter list.
   Piece createTypeList(
-      Token leftBracket, Iterable<AstNode> elements, Token rightBracket) {
+      Token leftBracket, List<AstNode> elements, Token rightBracket) {
     return createList(
         leftBracket: leftBracket,
         elements,

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -837,7 +837,7 @@ mixin PieceFactory {
   /// the author's deliberate structuring, as in:
   ///
   ///     matrix = [
-  ///       1, 2, 3,
+  ///       1, 2, 3, //
   ///       4, 5, 6,
   ///       7, 8, 9,
   ///     ];

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -166,6 +166,7 @@ mixin PieceFactory {
   /// the author's deliberate structuring, as in:
   ///
   ///     matrix = [
+  ///       // X, Y, Z:
   ///       1, 2, 3,
   ///       4, 5, 6,
   ///       7, 8, 9,

--- a/lib/src/source_visitor.dart
+++ b/lib/src/source_visitor.dart
@@ -1071,7 +1071,7 @@ class SourceVisitor extends ThrowingAstVisitor {
             // the constants is the hard rule used by the entire block and its
             // hardening state doesn't actually change. Instead, look
             // explicitly for a line comment here.
-            _containsLineComments(node.constants));
+            node.constants.containsLineComments());
   }
 
   @override
@@ -2835,7 +2835,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     // instead of having them harden the surrounding rules is a hack. But this
     // code will be going away when we move to the new Piece representation, so
     // going with something expedient.
-    var forceSplit = _containsLineComments(node.cases, node.rightBracket);
+    var forceSplit = node.cases.containsLineComments(node.rightBracket);
 
     _endBody(node.rightBracket, forceSplit: hasTrailingComma || forceSplit);
   }
@@ -3669,7 +3669,7 @@ class SourceVisitor extends ThrowingAstVisitor {
     // If a collection contains a line comment, we assume it's a big complex
     // blob of data with some documented structure. In that case, the user
     // probably broke the elements into lines deliberately, so preserve those.
-    if (_containsLineComments(elements, rightBracket)) {
+    if (elements.containsLineComments(rightBracket)) {
       // Newlines are significant, so we'll explicitly write those. Elements
       // on the same line all share an argument-list-like rule that allows
       // splitting between zero, one, or all of them. This is faster in long
@@ -4007,35 +4007,6 @@ class SourceVisitor extends ThrowingAstVisitor {
     if (rightHandSide is CascadeExpression) return Cost.assignBlock;
 
     return Cost.assign;
-  }
-
-  /// Returns `true` if the collection with [elements] delimited by
-  /// [rightBracket] contains any line comments.
-  ///
-  /// This only looks for comments at the element boundary. Comments within an
-  /// element are ignored.
-  bool _containsLineComments(Iterable<AstNode> elements,
-      [Token? rightBracket]) {
-    bool hasLineCommentBefore(Token token) {
-      Token? comment = token.precedingComments;
-      for (; comment != null; comment = comment.next) {
-        if (comment.type == TokenType.SINGLE_LINE_COMMENT) return true;
-      }
-
-      return false;
-    }
-
-    // Look before each element.
-    for (var element in elements) {
-      if (hasLineCommentBefore(element.beginToken)) return true;
-    }
-
-    // Look before the closing bracket.
-    if (rightBracket != null) {
-      if (hasLineCommentBefore(rightBracket)) return true;
-    }
-
-    return false;
   }
 
   /// Begins writing a bracket-delimited body whose contents are a nested

--- a/test/expression/list_preserve_newlines.stmt
+++ b/test/expression/list_preserve_newlines.stmt
@@ -1,0 +1,83 @@
+40 columns                              |
+### Tests for how a line comment in a list literal causes newlines to be kept.
+>>> Preserve newlines if list contains a line comment.
+var list = [
+  a,b,c,d,
+  // yeah
+  e,f,g,h
+];
+<<<
+var list = [
+  a, b, c, d,
+  // yeah
+  e, f, g, h,
+];
+>>> Detect comment before first element.
+var list = [ // c
+  a,b,
+  c,d
+];
+<<<
+var list = [
+  // c
+  a, b,
+  c, d,
+];
+>>> Detect comment after last element.
+var list = [
+  a,b,
+  c,d// c
+];
+<<<
+var list = [
+  a, b,
+  c, d, // c
+];
+>>> Move brackets to their own lines.
+var list = [a,b,// c
+d,e,f];
+<<<
+var list = [
+  a, b, // c
+  d, e, f,
+];
+>>> Don't preserve newlines if line comment is inside an element.
+var list = [
+  1, 2, 3,
+  f(
+    arg // c
+  ),
+];
+<<<
+var list = [
+  1,
+  2,
+  3,
+  f(
+    arg, // c
+  ),
+];
+>>> Wrap between elements when newlines are preserved if they don't fit.
+var list = [
+  element1, element2, element3, element4, element5,
+
+  element6, element7,
+
+  // comment
+  element8, element9, element10, element11,
+];
+<<<
+var list = [
+  element1,
+  element2,
+  element3,
+  element4,
+  element5,
+  element6, element7,
+
+  // comment
+  element8,
+  element9,
+  element10,
+  element11,
+];

--- a/test/expression/map_preserve_newlines.stmt
+++ b/test/expression/map_preserve_newlines.stmt
@@ -1,0 +1,52 @@
+40 columns                              |
+### Tests for how a line comment in a map literal causes newlines to be kept.
+>>> Preserve newlines if map contains a line comment.
+var map = {
+  // yeah
+  a:1,b:2,c:3,d:4,
+  e:5,f:6,g:7,h:8
+};
+<<<
+var map = {
+  // yeah
+  a: 1, b: 2, c: 3, d: 4,
+  e: 5, f: 6, g: 7, h: 8,
+};
+>>> Don't preserve newlines if line comment is inside an element.
+var map = {
+  a: 1, b: 2, c: 3,
+  d: // c
+  4,
+};
+<<<
+var map = {
+  a: 1,
+  b: 2,
+  c: 3,
+  d: // c
+      4,
+};
+>>> Wrap between elements when newlines are preserved if they don't fit.
+var map = {
+  element1: 1, element2: 2, element3: 3, element4: 4, element5: 5,
+
+  element6: 6, element7: 7,
+
+  // comment
+  element8: 8, element9: 9, element10: 10, element11: 11,
+};
+<<<
+var map = {
+  element1: 1,
+  element2: 2,
+  element3: 3,
+  element4: 4,
+  element5: 5,
+  element6: 6, element7: 7,
+
+  // comment
+  element8: 8,
+  element9: 9,
+  element10: 10,
+  element11: 11,
+};

--- a/test/expression/record_preserve_newlines.stmt
+++ b/test/expression/record_preserve_newlines.stmt
@@ -1,0 +1,54 @@
+40 columns                              |
+### Tests for how a line comment in a record literal causes newlines to be kept.
+>>> Preserve newlines if record contains a line comment.
+record = (
+  // yeah
+  a,b,c,d,
+  e,f,g,h
+);
+<<<
+record = (
+  // yeah
+  a, b, c, d,
+  e, f, g, h,
+);
+>>> Don't preserve newlines if line comment is inside an element.
+record = (
+  1, 2, 3,
+  f(
+    arg // c
+  ),
+);
+<<<
+record = (
+  1,
+  2,
+  3,
+  f(
+    arg, // c
+  ),
+);
+>>> Wrap between elements when newlines are preserved if they don't fit.
+record = (
+  element1, element2, element3, element4, element5,
+
+  element6, element7,
+
+  // comment
+  element8, element9, element10, element11,
+);
+<<<
+record = (
+  element1,
+  element2,
+  element3,
+  element4,
+  element5,
+  element6, element7,
+
+  // comment
+  element8,
+  element9,
+  element10,
+  element11,
+);

--- a/test/expression/set_preserve_newlines.stmt
+++ b/test/expression/set_preserve_newlines.stmt
@@ -1,0 +1,54 @@
+40 columns                              |
+### Tests for how a line comment in a set literal causes newlines to be kept.
+>>> Preserve newlines if set contains a line comment.
+var set = {
+  // yeah
+  a,b,c,d,
+  e,f,g,h
+};
+<<<
+var set = {
+  // yeah
+  a, b, c, d,
+  e, f, g, h,
+};
+>>> Don't preserve newlines if line comment is inside an element.
+var set = {
+  1, 2, 3,
+  f(
+    arg // c
+  ),
+};
+<<<
+var set = {
+  1,
+  2,
+  3,
+  f(
+    arg, // c
+  ),
+};
+>>> Wrap between elements when newlines are preserved if they don't fit.
+var set = {
+  element1, element2, element3, element4, element5,
+
+  element6, element7,
+
+  // comment
+  element8, element9, element10, element11,
+};
+<<<
+var set = {
+  element1,
+  element2,
+  element3,
+  element4,
+  element5,
+  element6, element7,
+
+  // comment
+  element8,
+  element9,
+  element10,
+  element11,
+};

--- a/test/invocation/block_argument_comment.stmt
+++ b/test/invocation/block_argument_comment.stmt
@@ -66,7 +66,8 @@ function(
 );
 >>> Line comment inside block argument.
 function(first, [// comment
-second, third]);
+second,
+third]);
 <<<
 function(first, [
   // comment
@@ -74,7 +75,8 @@ function(first, [
   third,
 ]);
 >>>
-function(first, [second, third // comment
+function(first, [second,
+third // comment
 ]);
 <<<
 function(first, [

--- a/test/invocation/comment.stmt
+++ b/test/invocation/comment.stmt
@@ -70,3 +70,21 @@ function(
   // five
   another,
 );
+>>> Don't preserve newlines in argument lists with line comment.
+### For collection literals, a line comment is a signal to preserve the user's
+### original newlines. This test is just to validate that we *don't* do that
+### for argument lists.
+function(// yeah
+first, second, third,
+fourth, fifth,
+sixth);
+<<<
+function(
+  // yeah
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+  sixth,
+);


### PR DESCRIPTION
Large collection literals often have some internal structure that the author wants to highlight by having multiple elements on one line, sort of like a matrix.

The old style has a sort of hacky but in practice useful heuristic to enable that: if a collection literal contains a line comment, then the newlines (or lack of) between pairs of elements are preserved:

https://github.com/dart-lang/dart_style/wiki/FAQ#why-does-the-formatter-mess-up-my-collection-literals

This implements that same heuristic in the new style. The behavior is slightly different in the new style. In the old style, an argument list can be split in a variety of ways:

```dart
// 1. All on one line:
f(argument1, argument2, argument3, argument4)

// 2. Split into two lines at after any particular argument:
f(argument1, argument2, argument3,
    argument4)
f(argument1, argument2,
    argument3, argument4)
f(argument1,
    argument2, argument3, argument4)

// 3. Split every argument into its own line:
f(
    argument1,
    argument2,
    argument3,
    argument4)
```

It uses that same logic for the elements on a single line in a collection formatted with this rule. That kicks in if the authored code has all of the elements on one line but they don't actually fit. In that case, the formatter will still split them to try to fit. With the old style, it may use any of the above approaches to try to fit.

In the new style, argument lists don't support splitting between an arbitrary pair of elements like (2) above. So you just get:

```dart
// 1. All on one line:
f(argument1, argument2, argument3, argument4)

// 3. Split every argument into its own line:
f(
  argument1,
  argument2,
  argument3,
  argument4,
)
```

Likewise for collection literals containing a line comment. If all of the elements on a single line don't fit, it will split all of them onto their own lines instead of trying to split just between one pair of them.

Longer-term, I intend to support opting regions of code out of formatting completely. I expect users will use that for large matrix-like collections where they want to control both line splitting and aligning things into columns. So the specific behavior of this hack won't matter as much.

But it *is* a widely relied on rule today, so this part preserves it.
