### PR TITLE
Support leading indentation in the new style.

### DIFF
--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -254,7 +254,8 @@ class PieceWriter {
     void traverse(Piece piece) {
       piece.forEachChild(traverse);
 
-      if (piece.fixedStateForPageWidth(_formatter.pageWidth) case var state?) {
+      if (piece.fixedStateForPageWidth(_formatter.pageWidth - _formatter.indent)
+          case var state?) {
         piece.pin(state);
       }
     }
@@ -262,7 +263,8 @@ class PieceWriter {
     traverse(rootPiece);
 
     var cache = SolutionCache();
-    var formatter = Solver(cache, pageWidth: _formatter.pageWidth);
+    var formatter = Solver(cache,
+        pageWidth: _formatter.pageWidth, leadingIndent: _formatter.indent);
     var result = formatter.format(rootPiece);
     var outputCode = result.text;
 


### PR DESCRIPTION
The formatter library API allows you to pass in a number of leading indent spaces that will be applied to all lines of the output. This is used internally for the regression tests (which often need to preserve the indentation of the surrounding context of the original failing code). It's also supported by the API so that some editors which support "format just this selection" can pass in a leading indent of the surrounding context.

This passes that through to the new formatter.

(It wasn't caught by tests because the API and command-line tests are currently not forked to run the new style too.)
