### PR TITLE
Tweak the block formatting rules to disallow `=>` function expressions.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -165,12 +165,10 @@ extension ExpressionExtensions on Expression {
           when cascadeSections.length == 1 && target.canBlockSplit =>
         BlockFormat.invocation,
 
-      // A function expression can use either a non-empty parameter list or a
-      // non-empty block body for block formatting.
-      FunctionExpression(:var parameters?, :var body)
-          when parameters.parameters.canSplit(parameters.rightParenthesis) ||
-              (body is BlockFunctionBody &&
-                  body.block.statements.canSplit(body.block.rightBracket)) =>
+      // A function expression with a non-empty block body can block format.
+      FunctionExpression(:var body)
+          when body is BlockFunctionBody &&
+              body.block.statements.canSplit(body.block.rightBracket) =>
         BlockFormat.function,
 
       // An immediately invoked function expression is formatted like a

--- a/test/invocation/block_argument_kind.stmt
+++ b/test/invocation/block_argument_kind.stmt
@@ -25,46 +25,18 @@ function((parameter) { body; });
 function((parameter) {
   body;
 });
->>> Empty block-bodied function expression with parameters.
+>>> Empty block-bodied function expression with parameters is not a block argument.
 function((parameter, anotherParameter) {});
 <<<
-function((
-  parameter,
-  anotherParameter,
-) {});
->>> Expression-bodied function expression with parameters.
+function(
+  (parameter, anotherParameter) {},
+);
+>>> Expression-bodied function expression with parameters is not a block argument.
 function((parameter, anotherParameter) => body);
 <<<
-function((
-  parameter,
-  anotherParameter,
-) => body);
->>> Block-bodied function expression with block comment in the parameters.
-function((/* very long block comment */) {});
-<<<
-function((
-  /* very long block comment */
-) {});
->>> Block-bodied function expression with line comment in the parameters.
-function((// comment
-) {});
-<<<
-function((
-  // comment
-) {});
->>> Expression-bodied function expression with block comment in the parameters.
-function((/* very long block comment */) => body);
-<<<
-function((
-  /* very long block comment */
-) => body);
->>> Expression-bodied function expression with line comment in the parameters.
-function((// comment
-) => body);
-<<<
-function((
-  // comment
-) => body);
+function(
+  (parameter, anotherParameter) => body,
+);
 >>> An empty block-bodied function expression is not a block argument.
 function_________________________(() {});
 <<<
@@ -177,26 +149,12 @@ function((p, r) { body; }(a, b));
 function((p, r) {
   body;
 }(a, b));
->>> Immediately invoked function with parameters.
+>>> Immediately invoked empty function with parameters is not a block argument.
 function((parameter, anotherParameter) {}());
 <<<
-function((
-  parameter,
-  anotherParameter,
-) {}());
->>> Immediately invoked function with block comment in the parameters.
-function((/* very long block comment */) {}());
-<<<
-function((
-  /* very long block comment */
-) {}());
->>> Immediately invoked function with line comment in the parameters.
-function((// comment
-) {}());
-<<<
-function((
-  // comment
-) {}());
+function(
+  (parameter, anotherParameter) {}(),
+);
 >>> An empty immediately invoked function is not a block argument.
 function_________________________(() {}());
 <<<

--- a/test/invocation/block_argument_kind.stmt
+++ b/test/invocation/block_argument_kind.stmt
@@ -37,6 +37,16 @@ function((parameter, anotherParameter) => body);
 function(
   (parameter, anotherParameter) => body,
 );
+>>> Expression-bodied function expression with many parameters is not a block argument.
+function((parameter, anotherParameter, thirdParameter) => body);
+<<<
+function(
+  (
+    parameter,
+    anotherParameter,
+    thirdParameter,
+  ) => body,
+);
 >>> An empty block-bodied function expression is not a block argument.
 function_________________________(() {});
 <<<

--- a/test/variable/local.stmt
+++ b/test/variable/local.stmt
@@ -224,14 +224,12 @@ var variableName = (
 ) {
   body;
 };
->>> Use block-like splitting for expression-bodied function expressions.
+>>> Don't use block-like splitting for expression-bodied function expressions.
 var variableName = (parameter, parameter, parameter) => body;
 <<<
-var variableName = (
-  parameter,
-  parameter,
-  parameter,
-) => body;
+var variableName =
+    (parameter, parameter, parameter) =>
+        body;
 >>> Use block-like splitting for parenthesized expressions whose inner does.
 var variableName = ([element, element, element]);
 <<<


### PR DESCRIPTION
When I first added support for block formatting arguments in the new style, I allowed function expressions with `=>` bodies if they had parameters with the idea that the parameter list itself would get the block-like formatting, as in:

```dart
function((
  parameter1,
  parameter2,
) => body);
```

I'm honestly not sure why I thought that was a good idea. The old formatter doesn't allow that. I don't think it looks particularly good. And, worst of all, the formatter doesn't actually *require* the parameter list to be the place where the split occurs, so the current implementation allows unwanted output like:

```dart
function((parameter) => operand +
    anotherOperand));
```

This is definitely not intended.

I've started migrating regressions tests and in the examples I've seen where this rule comes into play, I think it looks worse to allow block formatting here. So this PR changes it to not allow block formatting any `=>` body function expression.
