### PR TITLE
Prefer splitting at ".." instead of in the cascade target.

### DIFF
--- a/lib/src/front_end/chain_builder.dart
+++ b/lib/src/front_end/chain_builder.dart
@@ -102,6 +102,7 @@ class ChainBuilder {
           _calls.length == 1 && _calls.single.canSplit ? 0 : -1;
 
       var chain = ChainPiece(_target, _calls,
+          cascade: true,
           indent: Indent.cascade,
           blockCallIndex: blockCallIndex,
           allowSplitInTarget: _allowSplitInTarget);
@@ -162,6 +163,7 @@ class ChainBuilder {
         _root.parent is CascadeExpression ? Indent.cascade : Indent.expression;
 
     return ChainPiece(_target, _calls,
+        cascade: false,
         indent: indent,
         leadingProperties: leadingProperties,
         blockCallIndex: blockCallIndex,

--- a/test/tall/invocation/cascade.stmt
+++ b/test/tall/invocation/cascade.stmt
@@ -167,15 +167,15 @@ new Foo(
   veryLongElement,
   veryLongElement,
 )..addAll(more);
->>> Prefer splitting inside collection instead of at cascade.
-[element1, element2, element3]
-  ..cascade();
-<<<
+>>> Prefer splitting at cascade instead of inside target.
 [
   element1,
   element2,
   element3,
 ]..cascade();
+<<<
+[element1, element2, element3]
+  ..cascade();
 >>> Don't force cascade to split on collection target if arg splits.
 [1, 2, 3, 4]..cascade(() {;});
 <<<


### PR DESCRIPTION
I'm working on migrating the regression tests and tweaking the new formatting heuristics as I go based on the results I see in those real-world examples.

In a method chain, if the target can be block formatted, we prefer to split in the target and not at the ".". So:

    // Prefer:
    [
      target,
      block,
    ].doStuff();

    // Over:
    [target, block]
        .doStuff();

Prior to this PR, it had the same priority for single-section cascades:

    // Prefer:
    [
      target,
      block,
    ]..doStuff();

    // Over:
    [target, block]
      ..doStuff();

But for cascades, I think the cascade operation is "looser" and generally looks better to put it on its own line and leave the target unsplit when possible. So this change flips priority and prefers:

    [target, block]
      ..doStuff();

In larger more realistic examples, I think it looks better. In general, I think it's almost always better to move cascades onto their own lines. In fact, both the short and tall styles already have a rule that any cascade with more than one section will always unconditionally split every section even if they would otherwise fit. So I think this change is consistent with that.
