### PR TITLE
Indent comments inside switch statement cases.

### DIFF
--- a/lib/src/front_end/sequence_builder.dart
+++ b/lib/src/front_end/sequence_builder.dart
@@ -93,7 +93,7 @@ class SequenceBuilder {
   /// Visits [node] and adds the resulting [Piece] to this sequence, handling
   /// any comments or blank lines that appear before it.
   void visit(AstNode node, {int? indent, bool allowBlankAfter = true}) {
-    addCommentsBefore(node.firstNonCommentToken);
+    addCommentsBefore(node.firstNonCommentToken, indent: indent);
     add(_visitor.nodePiece(node),
         indent: indent, allowBlankAfter: allowBlankAfter);
   }
@@ -109,7 +109,9 @@ class SequenceBuilder {
   ///
   /// Comments between sequence elements get special handling where comments
   /// on their own line become standalone sequence elements.
-  void addCommentsBefore(Token token) {
+  void addCommentsBefore(Token token, {int? indent}) {
+    indent ??= Indent.none;
+
     var comments = _visitor.comments.takeCommentsBefore(token);
 
     // Edge case: if we require a blank line, but there exists one between
@@ -142,7 +144,7 @@ class SequenceBuilder {
         }
 
         // Write the comment as its own sequence piece.
-        _add(Indent.none, comment);
+        _add(indent, comment);
       }
     }
 

--- a/test/tall/expression/switch_comment.stmt
+++ b/test/tall/expression/switch_comment.stmt
@@ -48,6 +48,18 @@ e = switch (n) {
   1 => one, // comment
   2 => two, // comment
 };
+>>> Line comment before case body.
+e = switch (n) {
+0 =>
+// comment
+zero
+};
+<<<
+e = switch (n) {
+  0 =>
+    // comment
+    zero,
+};
 >>> Line comment in empty switch.
 e = switch (n) {
   // comment

--- a/test/tall/statement/switch_comment.stmt
+++ b/test/tall/statement/switch_comment.stmt
@@ -64,6 +64,34 @@ switch (n) {
     one;
   // after last
 }
+>>> Line comments inside case body.
+switch (n) {
+case 0:
+// before
+one;
+// between
+two;
+// more
+// than
+// one
+// comment
+three;
+// after
+}
+<<<
+switch (n) {
+  case 0:
+    // before
+    one;
+    // between
+    two;
+    // more
+    // than
+    // one
+    // comment
+    three;
+  // after
+}
 >>> Line comment in empty cases.
 switch (n) {
   case 0: // comment 0


### PR DESCRIPTION
Before this fix, line comments inside a switch case body would be indented to align with the case, not the body. This aligns them with the case body, except for comments inside a case but after the body. Those are still aligned to the case level because most of the time when comments appear at the end of a case body, they describe the subsequent case, like:

```dart
switch (obj) {
  case 1:
    body;

  // Comment here describes next case:
  case 2:
    body;
}
```
