### PR TITLE
Use NodeContext for all downwards contextual formatting.

### DIFF
--- a/lib/src/front_end/adjacent_builder.dart
+++ b/lib/src/front_end/adjacent_builder.dart
@@ -115,11 +115,12 @@ class AdjacentBuilder {
   void visit(AstNode? node,
       {bool spaceBefore = false,
       bool commaAfter = false,
-      bool spaceAfter = false}) {
+      bool spaceAfter = false,
+      NodeContext context = NodeContext.none}) {
     if (node == null) return;
 
     if (spaceBefore) space();
-    add(_visitor.nodePiece(node, commaAfter: commaAfter));
+    add(_visitor.nodePiece(node, commaAfter: commaAfter, context: context));
     if (spaceAfter) space();
   }
 

--- a/test/tall/invocation/cascade.stmt
+++ b/test/tall/invocation/cascade.stmt
@@ -238,11 +238,11 @@ object..firstProperty.secondProperty.thirdProperty
 <<<
 object
   ..firstProperty
-    .secondProperty
-    .thirdProperty
+      .secondProperty
+      .thirdProperty
   ..fourthProperty
-    .fifthProperty
-    .sixthProperty;
+      .fifthProperty
+      .sixthProperty;
 >>> Cascade chained property access setter.
 object..a.b = value;
 <<<


### PR DESCRIPTION
Convert every place where a parent AST node affects how the child node is formatted to use NodeContext instead of calling `.parent` on the AST node.

This addresses the discussion https://github.com/dart-lang/dart_style/pull/1431#discussion_r1540225326 at least for the cases where context flows from parent to child (i.e. the `.parent` calls).

There are still a number of places where context flows from child to parent: splitting collections that contain collections, block arguments, and block calls in chains. Each of those has different enough needs that I think the current solutions for each one are fine.