### PR TITLE
Remove pushAllowNewlines() and popAllowNewlines() from CodeWriter.

### DIFF
--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -173,29 +173,31 @@ class AssignPiece extends Piece {
         collapseIndent = true;
     }
 
-    writer.pushAllowNewlines(allowNewlinesInLeft);
     if (indentLeft) {
       writer.pushIndent(Indent.expression, canCollapse: collapseIndent);
     }
 
-    if (_left case var left?) writer.format(left);
+    if (_left case var left?) {
+      writer.format(left, allowNewlines: allowNewlinesInLeft);
+    }
 
-    if (!_splitBeforeOperator) writer.format(_operator);
-    writer.splitIf(state == _atOperator);
-    if (_splitBeforeOperator) writer.format(_operator);
+    if (_splitBeforeOperator) {
+      writer.splitIf(state == _atOperator);
+      writer.format(_operator, allowNewlines: allowNewlinesInLeft);
+    } else {
+      writer.format(_operator, allowNewlines: allowNewlinesInLeft);
+      writer.splitIf(state == _atOperator);
+    }
 
     if (indentLeft) writer.popIndent();
-    writer.popAllowNewlines();
 
-    writer.pushAllowNewlines(allowNewlinesInRight);
     if (indentRight) {
       writer.pushIndent(Indent.expression, canCollapse: collapseIndent);
     }
 
-    writer.format(_right);
+    writer.format(_right, allowNewlines: allowNewlinesInRight);
 
     if (indentRight) writer.popIndent();
-    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -164,57 +164,45 @@ class ChainPiece extends Piece {
   void format(CodeWriter writer, State state) {
     switch (state) {
       case State.unsplit:
-        _formatTarget(writer);
+        writer.format(_target, allowNewlines: _allowSplitInTarget);
 
-        writer.pushAllowNewlines(false);
         for (var i = 0; i < _calls.length; i++) {
-          _formatCall(writer, state, i);
+          _formatCall(writer, state, i, allowNewlines: false);
         }
-        writer.popAllowNewlines();
 
       case _splitAfterProperties:
         writer.pushIndent(_indent);
-        _formatTarget(writer);
+        writer.format(_target, allowNewlines: _allowSplitInTarget);
 
         for (var i = 0; i < _calls.length; i++) {
-          writer.pushAllowNewlines(i >= _leadingProperties);
           writer.splitIf(i >= _leadingProperties, space: false);
-          _formatCall(writer, state, i);
-          writer.popAllowNewlines();
+          _formatCall(writer, state, i, allowNewlines: i >= _leadingProperties);
         }
 
         writer.popIndent();
 
       case _blockFormatTrailingCall:
-        _formatTarget(writer);
+        writer.format(_target, allowNewlines: _allowSplitInTarget);
 
         for (var i = 0; i < _calls.length; i++) {
-          writer.pushAllowNewlines(i == _blockCallIndex);
-          _formatCall(writer, state, i);
-          writer.popAllowNewlines();
+          _formatCall(writer, state, i, allowNewlines: i == _blockCallIndex);
         }
 
       case State.split:
         writer.pushIndent(_indent);
         writer.format(_target);
 
-        writer.pushAllowNewlines(true);
         for (var i = 0; i < _calls.length; i++) {
           writer.newline();
           _formatCall(writer, state, i);
         }
-        writer.popAllowNewlines();
+
         writer.popIndent();
     }
   }
 
-  void _formatTarget(CodeWriter writer) {
-    writer.pushAllowNewlines(_allowSplitInTarget);
-    writer.format(_target);
-    writer.popAllowNewlines();
-  }
-
-  void _formatCall(CodeWriter writer, State state, int i) {
+  void _formatCall(CodeWriter writer, State state, int i,
+      {bool allowNewlines = true}) {
     // If the chain is fully split, then every call except for the last will
     // be on its own line. If the chain is split after properties, then
     // every non-property call except the last will be on its own line.
@@ -224,7 +212,8 @@ class ChainPiece extends Piece {
       _ => false,
     };
 
-    writer.format(_calls[i]._call, separate: separate);
+    writer.format(_calls[i]._call,
+        separate: separate, allowNewlines: allowNewlines);
   }
 
   @override

--- a/lib/src/piece/clause.dart
+++ b/lib/src/piece/clause.dart
@@ -96,18 +96,14 @@ class ClausesPiece extends Piece {
         // Before the leading clause, only split when in the fully split state.
         // A split inside the first clause forces a split before the keyword.
         writer.splitIf(state == State.split);
-        writer.pushAllowNewlines(state == State.split);
+        writer.format(clause, allowNewlines: state == State.split);
       } else {
         // For the other clauses (or if there is no leading one), split in the
         // fully split state and any split inside and clause forces all of them
         // to split.
-        writer.pushAllowNewlines(state != State.unsplit);
         writer.splitIf(state != State.unsplit);
+        writer.format(clause, allowNewlines: state != State.unsplit);
       }
-
-      writer.format(clause);
-
-      writer.popAllowNewlines();
     }
 
     writer.popIndent();
@@ -135,17 +131,15 @@ class ClausePiece extends Piece {
   @override
   void format(CodeWriter writer, State state) {
     // If any of the parts inside the clause split, split the list.
-    writer.pushAllowNewlines(state != State.unsplit);
     writer.pushIndent(Indent.expression);
 
-    writer.format(_keyword);
+    writer.format(_keyword, allowNewlines: state == State.split);
     for (var part in _parts) {
       writer.splitIf(state == State.split);
-      writer.format(part);
+      writer.format(part, allowNewlines: state == State.split);
     }
 
     writer.popIndent();
-    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/constructor.dart
+++ b/lib/src/piece/constructor.dart
@@ -130,21 +130,21 @@ class ConstructorPiece extends Piece {
   void format(CodeWriter writer, State state) {
     // If there's a newline in the header or parameters (like a line comment
     // after the `)`), then don't allow the initializers to remain unsplit.
-    writer.pushAllowNewlines(_initializers == null || state != State.unsplit);
+    var allowNewlines = _initializers == null || state != State.unsplit;
 
-    writer.format(_header);
-    writer.format(_parameters);
+    writer.format(_header, allowNewlines: allowNewlines);
+    writer.format(_parameters, allowNewlines: allowNewlines);
 
     if (_redirect case var redirect?) {
       writer.space();
-      writer.format(redirect);
+      writer.format(redirect, allowNewlines: allowNewlines);
     }
 
     if (_initializers case var initializers?) {
       writer.pushIndent(Indent.block);
       writer.splitIf(state == _splitBeforeInitializers);
 
-      writer.format(_initializerSeparator!);
+      writer.format(_initializerSeparator!, allowNewlines: allowNewlines);
       writer.space();
 
       // Indent subsequent initializers past the `:`.
@@ -154,12 +154,11 @@ class ConstructorPiece extends Piece {
         writer.pushIndent(Indent.initializer);
       }
 
-      writer.format(initializers);
+      writer.format(initializers, allowNewlines: allowNewlines);
       writer.popIndent();
       writer.popIndent();
     }
 
-    writer.popAllowNewlines();
     writer.format(_body);
   }
 

--- a/lib/src/piece/for.dart
+++ b/lib/src/piece/for.dart
@@ -49,16 +49,16 @@ class ForPiece extends Piece {
 
   @override
   void format(CodeWriter writer, State state) {
-    writer.pushAllowNewlines(_hasBlockBody || state != State.unsplit);
+    var allowNewlines = _hasBlockBody || state == State.split;
 
-    writer.format(_forKeyword);
+    writer.format(_forKeyword, allowNewlines: allowNewlines);
     writer.space();
 
     if (_indentForParts) {
       writer.pushIndent(Indent.expression, canCollapse: true);
     }
 
-    writer.format(_forParts);
+    writer.format(_forParts, allowNewlines: allowNewlines);
 
     if (_indentForParts) writer.popIndent();
 
@@ -69,10 +69,8 @@ class ForPiece extends Piece {
       writer.splitIf(state == State.split);
     }
 
-    writer.format(_body);
+    writer.format(_body, allowNewlines: allowNewlines);
     if (!_hasBlockBody) writer.popIndent();
-
-    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/function.dart
+++ b/lib/src/piece/function.dart
@@ -57,15 +57,11 @@ class FunctionPiece extends Piece {
   void format(CodeWriter writer, State state) {
     if (_returnType case var returnType?) {
       // A split inside the return type forces splitting after the return type.
-      writer.pushAllowNewlines(state == State.split);
-      writer.format(returnType);
-      writer.popAllowNewlines();
+      writer.format(returnType, allowNewlines: state == State.split);
 
       // A split in the type parameters or parameters does not force splitting
       // after the return type.
-      writer.pushAllowNewlines(true);
       writer.splitIf(state == State.split);
-      writer.popAllowNewlines();
     }
 
     writer.format(_signature);

--- a/lib/src/piece/if.dart
+++ b/lib/src/piece/if.dart
@@ -53,8 +53,7 @@ class IfPiece extends Piece {
       var section = _sections[i];
 
       // A split in the condition forces the branches to split.
-      writer.pushAllowNewlines(state == State.split);
-      writer.format(section.header);
+      writer.format(section.header, allowNewlines: state == State.split);
 
       if (!section.isBlock) {
         writer.pushIndent(Indent.block);
@@ -62,7 +61,7 @@ class IfPiece extends Piece {
       }
 
       // TODO(perf): Investigate whether it's worth using `separate:` here.
-      writer.format(section.statement);
+      writer.format(section.statement, allowNewlines: state == State.split);
 
       // Reset the indentation for the subsequent `else` or `} else` line.
       if (!section.isBlock) writer.popIndent();
@@ -70,8 +69,6 @@ class IfPiece extends Piece {
       if (i < _sections.length - 1) {
         writer.splitIf(state == State.split && !section.isBlock);
       }
-
-      writer.popAllowNewlines();
     }
   }
 }

--- a/lib/src/piece/if_case.dart
+++ b/lib/src/piece/if_case.dart
@@ -99,29 +99,23 @@ class IfCasePiece extends Piece {
 
     if (state != State.unsplit) writer.pushIndent(Indent.expression);
 
-    writer.pushAllowNewlines(allowNewlineInValue);
-    writer.format(_value);
-    writer.popAllowNewlines();
+    writer.format(_value, allowNewlines: allowNewlineInValue);
 
     // The case clause and pattern.
-    writer.pushAllowNewlines(allowNewlineInPattern);
     writer.splitIf(state == _beforeCase || state == _beforeCaseAndWhen);
 
     if (!_canBlockSplitPattern) {
       writer.pushIndent(Indent.expression, canCollapse: true);
     }
 
-    writer.format(_pattern);
+    writer.format(_pattern, allowNewlines: allowNewlineInPattern);
 
     if (!_canBlockSplitPattern) writer.popIndent();
-    writer.popAllowNewlines();
 
     // The guard clause.
     if (_guard case var guard?) {
-      writer.pushAllowNewlines(allowNewlineInGuard);
       writer.splitIf(state == _beforeWhen || state == _beforeCaseAndWhen);
-      writer.format(guard);
-      writer.popAllowNewlines();
+      writer.format(guard, allowNewlines: allowNewlineInGuard);
     }
 
     if (state != State.unsplit) writer.popIndent();

--- a/lib/src/piece/infix.dart
+++ b/lib/src/piece/infix.dart
@@ -50,17 +50,11 @@ class InfixPiece extends Piece {
   @override
   void format(CodeWriter writer, State state) {
     // Comments before the operands don't force the operator to split.
-    writer.pushAllowNewlines(true);
     for (var comment in _leadingComments) {
-      writer.format(comment);
+      writer.format(comment, allowNewlines: true);
     }
-    writer.popAllowNewlines();
 
-    if (state == State.unsplit) {
-      writer.pushAllowNewlines(false);
-    } else if (_indent) {
-      writer.pushIndent(Indent.expression);
-    }
+    if (_indent) writer.pushIndent(Indent.expression);
 
     for (var i = 0; i < _operands.length; i++) {
       // We can format each operand separately if the operand is on its own
@@ -68,15 +62,12 @@ class InfixPiece extends Piece {
       // or last operand.
       var separate = state == State.split && i > 0 && i < _operands.length - 1;
 
-      writer.format(_operands[i], separate: separate);
+      writer.format(_operands[i],
+          separate: separate, allowNewlines: state == State.split);
       if (i < _operands.length - 1) writer.splitIf(state == State.split);
     }
 
-    if (state == State.unsplit) {
-      writer.popAllowNewlines();
-    } else if (_indent) {
-      writer.popIndent();
-    }
+    if (_indent) writer.popIndent();
   }
 
   @override

--- a/lib/src/piece/postfix.dart
+++ b/lib/src/piece/postfix.dart
@@ -29,16 +29,14 @@ class PostfixPiece extends Piece {
   @override
   void format(CodeWriter writer, State state) {
     // If any operand splits, then force the postfix sequence to split too.
-    writer.pushAllowNewlines(state == State.split);
     writer.pushIndent(Indent.expression);
 
     for (var piece in pieces) {
       writer.splitIf(state == State.split);
-      writer.format(piece);
+      writer.format(piece, allowNewlines: state == State.split);
     }
 
     writer.popIndent();
-    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -28,10 +28,8 @@ class SequencePiece extends Piece {
 
   @override
   void format(CodeWriter writer, State state) {
-    writer.pushAllowNewlines(state == State.split);
-
     if (_leftBracket case var leftBracket?) {
-      writer.format(leftBracket);
+      writer.format(leftBracket, allowNewlines: state == State.split);
       writer.pushIndent(_elements.firstOrNull?._indent ?? 0);
       writer.splitIf(state == State.split, space: false);
     }
@@ -46,7 +44,8 @@ class SequencePiece extends Piece {
           (i > 0 || _leftBracket != null) &&
           (i < _elements.length - 1 || _rightBracket != null);
 
-      writer.format(element, separate: separate);
+      writer.format(element,
+          separate: separate, allowNewlines: state == State.split);
 
       if (i < _elements.length - 1) {
         if (_leftBracket != null || i > 0) writer.popIndent();
@@ -59,10 +58,8 @@ class SequencePiece extends Piece {
 
     if (_rightBracket case var rightBracket?) {
       writer.splitIf(state == State.split, space: false);
-      writer.format(rightBracket);
+      writer.format(rightBracket, allowNewlines: state == State.split);
     }
-
-    writer.popAllowNewlines();
   }
 
   @override

--- a/lib/src/piece/variable.dart
+++ b/lib/src/piece/variable.dart
@@ -66,9 +66,6 @@ class VariablePiece extends Piece {
     // variables and their initializers.
     if (state == _betweenVariables) writer.pushIndent(Indent.expression);
 
-    // Force multiple variables to split if an initializer does.
-    writer.pushAllowNewlines(_variables.length == 1 || state != State.unsplit);
-
     // Split after the type annotation.
     writer.splitIf(state == _afterType);
 
@@ -77,12 +74,12 @@ class VariablePiece extends Piece {
       if (i > 0) writer.splitIf(state != State.unsplit);
 
       // TODO(perf): Investigate whether it's worth using `separate:` here.
-      writer.format(_variables[i]);
+      // Force multiple variables to split if an initializer does.
+      writer.format(_variables[i],
+          allowNewlines: _variables.length == 1 || state != State.unsplit);
     }
 
     if (state == _betweenVariables) writer.popIndent();
-
-    writer.popAllowNewlines();
   }
 
   @override


### PR DESCRIPTION
One of the main ways that formatting rules are expressed is by a parent piece controlling whether a child piece may contain newlines when the parent is in a certain state. The API for this was stateful: Pieces could push or pop onto a stack to say whether they allow or disallow newlines. When child pieces are formatted, we use the top of the stack to determine whether the solution should be invalidated if the child ended up containing a newline.

I *thought* there was a compelling need for this API to be stateful because if a parent piece doesn't push anything onto the stack, then it will inherit the constraint of its parent. In that way, newlines would percolate up until reaching a piece that cared. It turns out that isn't necessary: Each parent piece will either directly invalidate based on its immediate children or not.

So I got rid of the stack and the stateful API completely. When calling CodeWriter.format() to format a child piece, the parent passes in right then whether or not it allows a newline in the child. At least according to the current tests, that seems to be sufficient.

I think this simplifies reasoning about the formatting code in each piece, because you don't have to mentally track the allow newline stack.

Also, I'm working on some larger changes to be able to express "a newline is allowed here but only from block splitting, not expression splitting", which we need to prevent some annoying incorrect format. I believe this will get the codebase in a better state to be able to express that.
