### PR TITLE
Format `with` and `implements` in enum declarations.

### DIFF
--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -1100,8 +1100,8 @@ mixin PieceFactory {
       ImplementsClause? implementsClause,
       NativeClause? nativeClause,
       (Token, TypeAnnotation)? onType,
-      ({Token leftBracket, List<AstNode> members, Token rightBracket})? body,
-      Token? semicolon}) {
+      TypeBodyType bodyType = TypeBodyType.block,
+      required Piece Function() body}) {
     var metadataBuilder = AdjacentBuilder(this);
     metadataBuilder.metadata(metadata);
 
@@ -1179,15 +1179,10 @@ mixin PieceFactory {
           allowLeadingClause: extendsClause != null || onClause != null);
     }
 
-    Piece bodyPiece;
-    if (body != null) {
-      bodyPiece = createBody(body.leftBracket, body.members, body.rightBracket);
-    } else {
-      bodyPiece = tokenPiece(semicolon!);
-    }
+    var bodyPiece = body();
 
     metadataBuilder
-        .add(TypePiece(header, clausesPiece, bodyPiece, hasBody: body != null));
+        .add(TypePiece(header, clausesPiece, bodyPiece, bodyType: bodyType));
 
     return metadataBuilder.build();
   }

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -119,9 +119,7 @@ class ListPiece extends Piece {
   void format(CodeWriter writer, State state) {
     // Format the opening bracket, if there is one.
     if (_before case var before?) {
-      writer.format(before,
-          allowNewlines:
-              !_style.splitListIfBeforeSplits || state == State.split);
+      writer.format(before);
 
       if (state != State.unsplit) writer.pushIndent(Indent.block);
 
@@ -449,36 +447,6 @@ class ListStyle {
   ///     //              ^                      ^
   final bool spaceWhenUnsplit;
 
-  /// Whether a split in the [_before] piece should force the list to split too.
-  /// Most of the time, this isn't relevant because the before part is usually
-  /// just a single bracket character.
-  ///
-  /// For collection literals with explicit type arguments, the [_before] piece
-  /// contains the type arguments. If those split, this is `false` to allow the
-  /// list itself to remain unsplit as in:
-  ///
-  ///     <
-  ///       VeryLongTypeName,
-  ///       AnotherLongTypeName,
-  ///     >{a: 1};
-  ///
-  /// For switch expressions, the `switch (value) {` part is in [_before] and
-  /// the body is the list. In that case, if the value splits, we want to force
-  /// the body to split too:
-  ///
-  ///     // Disallowed:
-  ///     e = switch (
-  ///       "a long string that must wrap"
-  ///     ) { 0 => "ok" };
-  ///
-  ///     // Instead:
-  ///     e = switch (
-  ///       "a long string that must wrap"
-  ///     ) {
-  ///       0 => "ok",
-  ///     };
-  final bool splitListIfBeforeSplits;
-
   /// Whether an element in the list is allowed to have block-like formatting,
   /// as in:
   ///
@@ -492,6 +460,5 @@ class ListStyle {
       {this.commas = Commas.trailing,
       this.splitCost = Cost.normal,
       this.spaceWhenUnsplit = false,
-      this.splitListIfBeforeSplits = false,
       this.allowBlockElement = false});
 }

--- a/lib/src/piece/type.dart
+++ b/lib/src/piece/type.dart
@@ -18,18 +18,36 @@ class TypePiece extends Piece {
   /// The `native` clause, if any, and the type body.
   final Piece _body;
 
-  /// Whether the type has a `{ ... }` body or just a `;` at the end (for a
-  /// mixin application class).
-  final bool _hasBody;
+  /// What kind of body the type has.
+  final TypeBodyType _bodyType;
 
-  TypePiece(this._header, this._clauses, this._body, {required bool hasBody})
-      : _hasBody = hasBody;
+  TypePiece(this._header, this._clauses, this._body,
+      {required TypeBodyType bodyType})
+      : _bodyType = bodyType;
+
+  @override
+  List<State> get additionalStates =>
+      [if (_bodyType == TypeBodyType.list) State.split];
+
+  @override
+  void applyConstraints(State state, Constrain constrain) {
+    // If the body may or may not split, force it to split when the header does.
+    if (state == State.split) constrain(_body, State.split);
+  }
 
   @override
   void format(CodeWriter writer, State state) {
-    writer.format(_header);
-    if (_clauses case var clauses?) writer.format(clauses);
-    if (_hasBody) writer.space();
+    // If the body may or may not split, then a newline in the header or
+    // clauses forces the body to split.
+    var allowSplitInHeader =
+        _bodyType != TypeBodyType.list || state == State.split;
+
+    writer.format(_header, allowNewlines: allowSplitInHeader);
+    if (_clauses case var clauses?) {
+      writer.format(clauses, allowNewlines: allowSplitInHeader);
+    }
+
+    if (_bodyType != TypeBodyType.semicolon) writer.space();
     writer.format(_body);
   }
 
@@ -39,4 +57,18 @@ class TypePiece extends Piece {
     if (_clauses case var clauses?) callback(clauses);
     callback(_body);
   }
+}
+
+/// What kind of body is used for the type.
+enum TypeBodyType {
+  /// An always-split block body, as in a class declaration.
+  block,
+
+  /// A curly-brace delimited list that may or may not split.
+  ///
+  /// Used for enums with constants but no members.
+  list,
+
+  /// A single `;` body, used for mixin application classes.
+  semicolon,
 }

--- a/test/tall/declaration/enum_clause.unit
+++ b/test/tall/declaration/enum_clause.unit
@@ -1,0 +1,43 @@
+40 columns                              |
+>>> Unsplit with clause.
+enum E with M {a,b,c}
+<<<
+enum E with M { a, b, c }
+>>> Unsplit implements clause.
+enum E implements I {a,b,c}
+<<<
+enum E implements I { a, b, c }
+>>> Unsplit both clauses.
+enum E with M implements I {a,b,c}
+<<<
+enum E with M implements I { a, b, c }
+>>> Split with clause.
+enum VeryLongEnumTypeName with LongMixin {a,b,c}
+<<<
+enum VeryLongEnumTypeName
+    with LongMixin {
+  a,
+  b,
+  c,
+}
+>>> Split implements clause.
+enum VeryLongEnumTypeName implements LongInterface {a,b,c}
+<<<
+enum VeryLongEnumTypeName
+    implements LongInterface {
+  a,
+  b,
+  c,
+}
+>>> Both clauses split.
+enum SomeEnum with SomeLongMixin, AnotherMixin<int> implements SomeInterface<String, bool>, AnotherInterface {a}
+<<<
+enum SomeEnum
+    with
+        SomeLongMixin,
+        AnotherMixin<int>
+    implements
+        SomeInterface<String, bool>,
+        AnotherInterface {
+  a,
+}


### PR DESCRIPTION
There was an old test for this but somehow I must have dropped the clause parts of that test when migrating it and then forgot to implement clauses on enums.

Handling this required juggling some code around because, unlike most other type declarations, we allow the body of an enum to not split if it only contains values and no members. But we also want to force the enum values to split if there is a split in the header. (This is almost never relevant because if you have a `with` or `implements` clause in an enum, you almost certainly want to define some members too, but the formatter should do the right thing regardless.)

In the process of working on this, I noticed that
ListStyle.splitListIfBeforeSplits is no longer used, so I removed that.
