### PR TITLE
Don't allow function calls to be block arguments.

### DIFF
--- a/benchmark/case/flutter_popup_menu_test.expect
+++ b/benchmark/case/flutter_popup_menu_test.expect
@@ -1,0 +1,42 @@
+void main() {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: PopupMenuButton<String>(
+            key: popupMenuButtonKey,
+            child: const Text('button'),
+            onSelected: (String result) {},
+            itemBuilder: (BuildContext context) {
+              return <PopupMenuEntry<String>>[
+                // This menu item's height will be 48 because the default minimum height
+                // is 48 and the height of the text is less than 48.
+                const PopupMenuItem<String>(value: '0', child: Text('Item 0')),
+                // This menu item's height parameter specifies its minimum height. The
+                // overall height of the menu item will be 50 because the child's
+                // height 40, is less than 50.
+                const PopupMenuItem<String>(
+                  height: 50,
+                  value: '1',
+                  child: SizedBox(height: 40, child: Text('Item 1')),
+                ),
+                // This menu item's height parameter specifies its minimum height, so the
+                // overall height of the menu item will be 75.
+                const PopupMenuItem<String>(
+                  height: 75,
+                  value: '2',
+                  child: SizedBox(child: Text('Item 2')),
+                ),
+                // This menu item's height will be 100.
+                const PopupMenuItem<String>(
+                  value: '3',
+                  child: SizedBox(height: 100, child: Text('Item 3')),
+                ),
+              ];
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/benchmark/case/flutter_popup_menu_test.expect_short
+++ b/benchmark/case/flutter_popup_menu_test.expect_short
@@ -1,0 +1,53 @@
+void main() {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: PopupMenuButton<String>(
+            key: popupMenuButtonKey,
+            child: const Text('button'),
+            onSelected: (String result) {},
+            itemBuilder: (BuildContext context) {
+              return <PopupMenuEntry<String>>[
+                // This menu item's height will be 48 because the default minimum height
+                // is 48 and the height of the text is less than 48.
+                const PopupMenuItem<String>(
+                  value: '0',
+                  child: Text('Item 0'),
+                ),
+                // This menu item's height parameter specifies its minimum height. The
+                // overall height of the menu item will be 50 because the child's
+                // height 40, is less than 50.
+                const PopupMenuItem<String>(
+                  height: 50,
+                  value: '1',
+                  child: SizedBox(
+                    height: 40,
+                    child: Text('Item 1'),
+                  ),
+                ),
+                // This menu item's height parameter specifies its minimum height, so the
+                // overall height of the menu item will be 75.
+                const PopupMenuItem<String>(
+                  height: 75,
+                  value: '2',
+                  child: SizedBox(
+                    child: Text('Item 2'),
+                  ),
+                ),
+                // This menu item's height will be 100.
+                const PopupMenuItem<String>(
+                  value: '3',
+                  child: SizedBox(
+                    height: 100,
+                    child: Text('Item 3'),
+                  ),
+                ),
+              ];
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/benchmark/case/flutter_popup_menu_test.unit
+++ b/benchmark/case/flutter_popup_menu_test.unit
@@ -1,0 +1,53 @@
+void main() {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: PopupMenuButton<String>(
+            key: popupMenuButtonKey,
+            child: const Text('button'),
+            onSelected: (String result) { },
+            itemBuilder: (BuildContext context) {
+              return <PopupMenuEntry<String>>[
+                // This menu item's height will be 48 because the default minimum height
+                // is 48 and the height of the text is less than 48.
+                const PopupMenuItem<String>(
+                  value: '0',
+                  child: Text('Item 0'),
+                ),
+                // This menu item's height parameter specifies its minimum height. The
+                // overall height of the menu item will be 50 because the child's
+                // height 40, is less than 50.
+                const PopupMenuItem<String>(
+                  height: 50,
+                  value: '1',
+                  child: SizedBox(
+                    height: 40,
+                    child: Text('Item 1'),
+                  ),
+                ),
+                // This menu item's height parameter specifies its minimum height, so the
+                // overall height of the menu item will be 75.
+                const PopupMenuItem<String>(
+                  height: 75,
+                  value: '2',
+                  child: SizedBox(
+                    child: Text('Item 2'),
+                  ),
+                ),
+                // This menu item's height will be 100.
+                const PopupMenuItem<String>(
+                  value: '3',
+                  child: SizedBox(
+                    height: 100,
+                    child: Text('Item 3'),
+                  ),
+                ),
+              ];
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/benchmark/case/flutter_scrollbar_test.expect
+++ b/benchmark/case/flutter_scrollbar_test.expect
@@ -5,42 +5,44 @@ void main() {
   testWidgets(
     "Scrollbar doesn't show when scroll the inner scrollable widget",
     (WidgetTester tester) async {
-      await tester.pumpWidget(Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: const MediaQueryData(),
-          child: ScrollConfiguration(
-            behavior: const NoScrollbarBehavior(),
-            child: Scrollbar(
-              key: key2,
-              child: SingleChildScrollView(
-                key: outerKey,
-                child: SizedBox(
-                  height: 1000.0,
-                  width: double.infinity,
-                  child: Column(children: <Widget>[
-                    Scrollbar(
-                      key: key1,
-                      child: SizedBox(
-                        height: 300.0,
-                        width: double.infinity,
-                        child: SingleChildScrollView(
-                          key: innerKey,
-                          child: const SizedBox(
-                            key: Key('Inner scrollable'),
-                            height: 1000.0,
-                            width: double.infinity,
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: ScrollConfiguration(
+              behavior: const NoScrollbarBehavior(),
+              child: Scrollbar(
+                key: key2,
+                child: SingleChildScrollView(
+                  key: outerKey,
+                  child: SizedBox(
+                    height: 1000.0,
+                    width: double.infinity,
+                    child: Column(children: <Widget>[
+                      Scrollbar(
+                        key: key1,
+                        child: SizedBox(
+                          height: 300.0,
+                          width: double.infinity,
+                          child: SingleChildScrollView(
+                            key: innerKey,
+                            child: const SizedBox(
+                              key: Key('Inner scrollable'),
+                              height: 1000.0,
+                              width: double.infinity,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                  ]),
+                    ]),
+                  ),
                 ),
               ),
             ),
           ),
         ),
-      ));
+      );
     },
     variant: TargetPlatformVariant.all(),
   );

--- a/benchmark/case/large.expect
+++ b/benchmark/case/large.expect
@@ -960,28 +960,28 @@ class Traverser {
     /// Ensure we only add the barback dependency once.
     if (_getDependencies("barback").length != 1) return new Future.value();
 
-    return Future.wait(barback.pubConstraints.keys.map((depName) {
-      var constraint = barback.pubConstraints[depName];
-      _solver.logSolve(
-        'add implicit $constraint pub dependency on '
-        '$depName',
-      );
+    return Future.wait(
+      barback.pubConstraints.keys.map((depName) {
+        var constraint = barback.pubConstraints[depName];
+        _solver.logSolve(
+          'add implicit $constraint pub dependency on '
+          '$depName',
+        );
 
-      var override = _solver._overrides[depName];
+        var override = _solver._overrides[depName];
 
-      // Use the same source and description as the dependency override if one
-      // exists. This is mainly used by the pkgbuild tests, which use dependency
-      // overrides for all repo packages.
-      var pubDep =
-          override == null
-              ? new PackageDep(depName, "hosted", constraint, depName)
-              : override.withConstraint(constraint);
-      return _registerDependency(new Dependency(
-        "pub itself",
-        Version.none,
-        pubDep,
-      ));
-    }));
+        // Use the same source and description as the dependency override if one
+        // exists. This is mainly used by the pkgbuild tests, which use dependency
+        // overrides for all repo packages.
+        var pubDep =
+            override == null
+                ? new PackageDep(depName, "hosted", constraint, depName)
+                : override.withConstraint(constraint);
+        return _registerDependency(
+          new Dependency("pub itself", Version.none, pubDep),
+        );
+      }),
+    );
   }
 
   /// Gets the list of dependencies for package [name].

--- a/test/tall/invocation/block_argument_kind.stmt
+++ b/test/tall/invocation/block_argument_kind.stmt
@@ -59,75 +59,87 @@ function_______________________(() => null);
 function_______________________(
   () => null,
 );
->>> Function call.
+>>> Function call is not a block argument.
 function(innerFunction(veryLongArgumentExpression));
 <<<
-function(innerFunction(
-  veryLongArgumentExpression,
-));
->>> Zero-argument function call with block comment.
+function(
+  innerFunction(
+    veryLongArgumentExpression,
+  ),
+);
+>>> A zero-argument function call with block comment is not a block argument.
 function(innerFunction(/* long comment */));
 <<<
-function(innerFunction(
-  /* long comment */
-));
->>> Zero-argument function call with line comment.
+function(
+  innerFunction(/* long comment */),
+);
+>>> Zero-argument function call with line comment is not a block argument.
 function(innerFunction(// comment
 ));
 <<<
-function(innerFunction(
-  // comment
-));
+function(
+  innerFunction(
+    // comment
+  ),
+);
 >>> A zero-argument function call is not a block argument.
 function_______________________(inner());
 <<<
 function_______________________(
   inner(),
 );
->>> Method call.
+>>> A method call is not a block argument.
 function(target.inner(veryLongArgumentExpression));
 <<<
-function(target.inner(
-  veryLongArgumentExpression,
-));
->>> Zero-argument method call with block comment.
+function(
+  target.inner(
+    veryLongArgumentExpression,
+  ),
+);
+>>> A zero-argument method call with block comment is not a block argument.
 function(target.inner(/* long comment */));
 <<<
-function(target.inner(
-  /* long comment */
-));
->>> Zero-argument method call with line comment.
+function(
+  target.inner(/* long comment */),
+);
+>>> A zero-argument method call with line comment is not a block argument.
 function(target.inner(// comment
 ));
 <<<
-function(target.inner(
-  // comment
-));
+function(
+  target.inner(
+    // comment
+  ),
+);
 >>> A zero-argument method call is not a block argument.
 function________________(target.inner());
 <<<
 function________________(
   target.inner(),
 );
->>> Instance creation expression.
+>>> An instance creation expression is not a block argument.
 function(new SomeClass(veryLongArgumentExpression));
 <<<
-function(new SomeClass(
-  veryLongArgumentExpression,
-));
->>> Zero-argument instance creation expression with block comment.
+function(
+  new SomeClass(
+    veryLongArgumentExpression,
+  ),
+);
+>>> A zero-argument instance creation expression with block comment is not a block argument.
 function(new SomeClass(/* long comment */));
 <<<
-function(new SomeClass(
-  /* long comment */
-));
->>> Zero-argument instance creation expression with line comment.
+function(
+  new SomeClass(/* long comment */),
+);
+>>> A zero-argument instance creation expression with line comment is not a block argument.
 function(new SomeClass(// comment
 ));
 <<<
-function(new SomeClass(
-  // comment
-));
+function(
+  new SomeClass(
+    // comment
+  ),
+);
 >>> A zero-argument instance creation expression is not a block argument.
 function________________(new SomeClass());
 <<<
@@ -171,37 +183,43 @@ function_________________________(() {}());
 function_________________________(
   () {}(),
 );
->>> Function expression call.
+>>> A function expression call is not a block argument.
 function((expression)(veryLongArgumentExpression));
 <<<
-function((expression)(
-  veryLongArgumentExpression,
-));
->>> Zero-argument function expression call with block comment.
+function(
+  (expression)(
+    veryLongArgumentExpression,
+  ),
+);
+>>> A zero-argument function expression call with block comment is not a block argument.
 function((expression)(/* long comment */));
 <<<
-function((expression)(
-  /* long comment */
-));
->>> Zero-argument function expression call with line comment.
+function(
+  (expression)(/* long comment */),
+);
+>>> A zero-argument function expression call with line comment is not a block argument.
 function((expression)(// comment
 ));
 <<<
-function((expression)(
-  // comment
-));
+function(
+  (expression)(
+    // comment
+  ),
+);
 >>> A zero-argument function expression call is not a block argument.
 function_______________________((expr)());
 <<<
 function_______________________(
   (expr)(),
 );
->>> Parenthesized expression where inner expression is a block argument.
-function((innerFunction(veryLongArgumentExpression)));
+>>> A parenthesized expression where inner expression is a block argument.
+function(([element1, element2, element3]));
 <<<
-function((innerFunction(
-  veryLongArgumentExpression,
-)));
+function(([
+  element1,
+  element2,
+  element3,
+]));
 >>> List literal.
 function([veryLongElement, anotherLongElement]);
 <<<

--- a/test/tall/invocation/other.stmt
+++ b/test/tall/invocation/other.stmt
@@ -10,17 +10,17 @@ foo(
   c,
 );
 >>> Multiple nested collections inside a block argument.
-method(function([veryLongElement, veryLongElement],
-[veryLongElement, veryLongElement, veryLongElement]));
+method({[veryLongElement, veryLongElement],
+[veryLongElement, veryLongElement, veryLongElement]});
 <<<
-method(function(
+method({
   [veryLongElement, veryLongElement],
   [
     veryLongElement,
     veryLongElement,
     veryLongElement,
   ],
-));
+});
 >>> Mixed named/positional arguments with collection arguments.
 function(argument, a: argument, argument, b: argument,
 [element, element, element, element],

--- a/test/tall/statement/assert.stmt
+++ b/test/tall/statement/assert.stmt
@@ -57,13 +57,14 @@ assert(
   veryLongArgument2,
 );
 >>> Allow block formatting of condition.
-assert(inner(argument, argument, argument));
+assert([element1, element2, element3, element4]);
 <<<
-assert(inner(
-  argument,
-  argument,
-  argument,
-));
+assert([
+  element1,
+  element2,
+  element3,
+  element4,
+]);
 >>> Allow block formatting of message.
 assert(true, () {
   return someSlowMessageComputation();


### PR DESCRIPTION
I've been running the new formatter on the Flutter repo looking for ugly output and performance problems. (Mostly the latter.) One source of pathologically bad performance is nested function call block arguments. It's not a problem with block arguments in general because when a collection is a block argument, the collection itself doesn't support block arguments. But consider:

```
f1(f2(f3(f4(f5(f6(f7(f8(f9(f10(arg))))))))))
```

There are 2^10 ways that can be formatted, and no current optimizations kick in to avoid that rathole.

The slowest file to format in the Flutter repo is popup_menu_test.dart and the main culprit is pathological performance from this. I added a new benchmark for the slowest statement in that file.

With the old formatter, it finishes in 0.088ms. With the new formatter before this change, it's about 211ms, so over 2,000 times slower. This PR gets it down to 4.827ms, about 43 times faster.

My machine can format the entire Flutter repo packages directory in 35.17s. This change gets it down to 31.872. Not bad for essentially a one line change.

I also generally think code looks better when we don't allow function calls to be block arguments. In simple cases, it can look nice, but it gets weird quickly. I scanned a diff of this PR on the Flutter repo and in almost every case, I think it leads to easier to read code.
