### PR TITLE
Add some manual profiling instrumentation.

### DIFF
--- a/benchmark/run.dart
+++ b/benchmark/run.dart
@@ -10,6 +10,7 @@ import 'package:args/args.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:dart_style/src/constants.dart';
 import 'package:dart_style/src/front_end/ast_node_visitor.dart';
+import 'package:dart_style/src/profile.dart';
 import 'package:dart_style/src/short/source_visitor.dart';
 import 'package:dart_style/src/testing/benchmark.dart';
 import 'package:path/path.dart' as p;
@@ -94,6 +95,8 @@ void _runBenchmark(Benchmark benchmark, double? baseline,
   }
 
   _printResult('Best    ', baseline, best);
+
+  Profile.report();
 }
 
 Future<({bool isShort, double? baseline, List<Benchmark> benchmarks})>

--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -4,6 +4,7 @@
 import 'dart:math';
 
 import '../piece/piece.dart';
+import '../profile.dart';
 import 'solution.dart';
 import 'solution_cache.dart';
 
@@ -238,8 +239,12 @@ class CodeWriter {
   /// [piece] will have a newline before and after it.
   void format(Piece piece, {bool separate = false, bool allowNewlines = true}) {
     if (separate) {
+      Profile.count('CodeWriter.format() piece separate');
+
       _formatSeparate(piece);
     } else {
+      Profile.count('CodeWriter.format() piece inline');
+
       _formatInline(piece, allowNewlines: allowNewlines);
     }
   }
@@ -265,7 +270,9 @@ class CodeWriter {
       _solution.endSelection(_buffer.length + end);
     }
 
+    Profile.begin('CodeWriter.format() write separate piece text');
     _buffer.write(solution.text);
+    Profile.end('CodeWriter.format() write separate piece text');
   }
 
   /// Format [piece] writing directly into this [CodeWriter].

--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../piece/piece.dart';
+import '../profile.dart';
 import 'code_writer.dart';
 import 'solution_cache.dart';
 
@@ -120,10 +121,12 @@ class Solution implements Comparable<Solution> {
 
   Solution._(SolutionCache cache, Piece root, int pageWidth, int leadingIndent,
       this._cost, this._pieceStates) {
+    Profile.count('create Solution');
+
     var writer = CodeWriter(pageWidth, leadingIndent, cache, this);
     writer.format(root);
-
     var (text, nextPieceToExpand) = writer.finish();
+
     _text = text;
     _nextPieceToExpand = nextPieceToExpand;
   }
@@ -156,6 +159,8 @@ class Solution implements Comparable<Solution> {
   /// This is called when a subtree of a Piece tree is solved separately and
   /// the resulting solution is being merged with this one.
   void mergeSubtree(Solution subtreeSolution) {
+    Profile.begin('Solution.mergeSubtree()');
+
     _overflow += subtreeSolution._overflow;
 
     // Add the subtree's bound pieces to this one. Make sure to not double
@@ -166,6 +171,8 @@ class Solution implements Comparable<Solution> {
         return state;
       });
     });
+
+    Profile.end('Solution.mergeSubtree()');
   }
 
   /// Sets [selectionStart] to be [start] code units into the output.

--- a/lib/src/back_end/solver.dart
+++ b/lib/src/back_end/solver.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 
 import '../debug.dart' as debug;
 import '../piece/piece.dart';
+import '../profile.dart';
 import 'solution.dart';
 import 'solution_cache.dart';
 
@@ -77,7 +78,9 @@ class Solver {
         leadingIndent: _leadingIndent,
         rootState: rootState);
 
+    Profile.begin('Solver enqueue');
     _queue.add(solution);
+    Profile.end('Solver enqueue');
 
     // The lowest cost solution found so far that does overflow.
     var best = solution;
@@ -87,10 +90,12 @@ class Solver {
     // TODO(perf): Consider bailing out after a certain maximum number of tries,
     // so that it outputs suboptimal formatting instead of hanging entirely.
     while (_queue.isNotEmpty) {
+      Profile.begin('Solver dequeue');
       var solution = _queue.removeFirst();
-      tries++;
+      Profile.end('Solver dequeue');
 
       if (debug.traceSolver) {
+        tries++;
         debug.log(debug.bold('Try #$tries $solution'));
         debug.log(solution.text);
         debug.log('');
@@ -114,7 +119,9 @@ class Solver {
       // options.
       for (var expanded in solution.expand(_cache, root,
           pageWidth: _pageWidth, leadingIndent: _leadingIndent)) {
+        Profile.begin('Solver enqueue');
         _queue.add(expanded);
+        Profile.end('Solver enqueue');
       }
     }
 

--- a/lib/src/cli/summary.dart
+++ b/lib/src/cli/summary.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:io';
 
+import '../profile.dart';
 import '../source_code.dart';
 import 'formatter_options.dart';
 
@@ -110,6 +111,8 @@ class _ProfileSummary implements Summary {
       var s = _elided > 1 ? 's' : '';
       print('...$_elided more file$s each took less than 10ms.');
     }
+
+    Profile.report();
   }
 
   /// Called when [file] is about to be formatted.

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -20,6 +20,7 @@ import '../piece/list.dart';
 import '../piece/piece.dart';
 import '../piece/type.dart';
 import '../piece/variable.dart';
+import '../profile.dart';
 import '../source_code.dart';
 import 'adjacent_builder.dart';
 import 'chain_builder.dart';
@@ -67,6 +68,10 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   /// This is the only method that should be called externally. Everything else
   /// is effectively private.
   SourceCode run(AstNode node) {
+    Profile.begin('AstNodeVisitor.run()');
+
+    Profile.begin('AstNodeVisitor build Piece tree');
+
     // Always treat the code being formatted as contained in a sequence, even
     // if we aren't formatting an entire compilation unit. That way, comments
     // before and after the node are handled properly.
@@ -111,8 +116,16 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
     // Write any comments at the end of the code.
     sequence.addCommentsBefore(node.endToken.next!);
 
+    var unitPiece = sequence.build();
+
+    Profile.end('AstNodeVisitor build Piece tree');
+
     // Finish writing and return the complete result.
-    return pieces.finish(sequence.build());
+    var result = pieces.finish(unitPiece);
+
+    Profile.end('AstNodeVisitor.run()');
+
+    return result;
   }
 
   @override

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -10,6 +10,7 @@ import '../dart_formatter.dart';
 import '../debug.dart' as debug;
 import '../piece/adjacent.dart';
 import '../piece/piece.dart';
+import '../profile.dart';
 import '../source_code.dart';
 import 'comment_writer.dart';
 
@@ -180,6 +181,8 @@ class PieceWriter {
       debug.log(debug.pieceTree(rootPiece));
     }
 
+    Profile.begin('PieceWriter.finish() traverse and pin');
+
     // See if it's possible to eagerly pin any of the pieces based just on the
     // length and newlines in their children. This is faster, especially for
     // larger outermost pieces, then relying on the solver to determine their
@@ -195,11 +198,17 @@ class PieceWriter {
 
     traverse(rootPiece);
 
+    Profile.end('PieceWriter.finish() traverse and pin');
+
+    Profile.begin('PieceWriter.finish() format piece tree');
+
     var cache = SolutionCache();
     var formatter = Solver(cache,
         pageWidth: _formatter.pageWidth, leadingIndent: _formatter.indent);
     var result = formatter.format(rootPiece);
     var outputCode = result.text;
+
+    Profile.end('PieceWriter.finish() format piece tree');
 
     // Be a good citizen, end with a newline.
     if (_source.isCompilationUnit) outputCode += _formatter.lineEnding!;

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../back_end/code_writer.dart';
+import '../profile.dart';
 
 typedef Constrain = void Function(Piece other, State constrainedState);
 
@@ -78,6 +79,10 @@ abstract class Piece {
     });
 
     return total;
+  }
+
+  Piece() {
+    Profile.count('create Piece');
   }
 
   /// Apply any constraints that this piece places on other pieces when this

--- a/lib/src/profile.dart
+++ b/lib/src/profile.dart
@@ -1,0 +1,124 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:developer';
+import 'dart:math';
+
+/// Manually instrumented profiling.
+///
+/// Using a general-purpose sampling profiler is difficult with the formatter
+/// because so much of its code is recursive. Manual instrumentation can provide
+/// more concise, meaningful data.
+class Profile {
+  /// Whether profiling is enabled.
+  ///
+  /// Enabling profiling has a noticeable effect on overall performance. When
+  /// measuring, make sure to have profiling enabled when gathering baseline
+  /// measurements so that the comparison to the optimized version takes into
+  /// account the profiling overhead.
+  ///
+  /// When this is `false`, hopefully the compiler is able to completely
+  /// tree-shake calls to these methods. This should always be `false` in the
+  /// committed version of this file.
+  static const enabled = false;
+
+  /// Tracks counts of labelled occurrences.
+  static final Map<String, int> _counts = {};
+
+  /// The total accumulated time from completed calls to [begin()]/[end()] for
+  /// each label, in microseconds.
+  static final Map<String, int> _accumulatedTimes = {};
+
+  /// Label and start time (in microseconds) of each call to [begin()] that has
+  /// not had a corresponding call to [end()] yet.
+  static final List<(String, int)> _running = [];
+
+  /// Notes that [label] has occurred one more time.
+  static void count(String label) {
+    if (!enabled) return;
+
+    _counts.update(label, (count) => count + 1, ifAbsent: () => 1);
+  }
+
+  /// Begins measuring the elapsed time between this call and a subsequent
+  /// matching call to [end()].
+  ///
+  /// Works like a stack: A call to [end()] always completes the most recent
+  /// [begin()].
+  ///
+  /// Multiple calls to [begin()]/[end()] with the same label accumulate their
+  /// total time. Time is always inclusive. In other words, the time spent in
+  /// a subsequent call to [begin()]/[end()] before this call's [end()] is not
+  /// subtracted from this one.
+  ///
+  /// Also, no attempt is made to account for re-entrancy, so the accumulated
+  /// time may be greater than the wall clock time if there are recursive calls
+  /// that use the same label.
+  static void begin(String label) {
+    if (!enabled) return;
+
+    _running.add((label, Timeline.now));
+  }
+
+  static void end(String label) {
+    if (!enabled) return;
+
+    var (startLabel, start) = _running.removeLast();
+
+    // Must push and pop in stack order.
+    assert(label == startLabel);
+    var elapsed = Timeline.now - start;
+
+    _accumulatedTimes.update(label, (accumulated) => accumulated + elapsed,
+        ifAbsent: () => elapsed);
+  }
+
+  /// Discards all recorded profiling data.
+  static void reset() {
+    if (!enabled) return;
+
+    // Shouldn't be in the middle of profiling.
+    assert(_running.isEmpty);
+
+    _counts.clear();
+    _running.clear();
+    _accumulatedTimes.clear();
+  }
+
+  /// Prints a report of all recorded profiling information.
+  static void report() {
+    if (!enabled) return;
+
+    // Should have finished everything by now.
+    assert(_running.isEmpty);
+
+    _showTable('Counts', _counts);
+    _showTable('Times (ms)', _accumulatedTimes, milliseconds: true);
+  }
+
+  static void _showTable(String header, Map<String, int> data,
+      {bool milliseconds = false}) {
+    if (data.isEmpty) return;
+
+    print('');
+    print(header);
+
+    var labels = data.keys.toList();
+    labels.sort();
+
+    var longestLabel =
+        labels.fold(0, (length, label) => max(length, label.length));
+
+    for (var label in labels) {
+      String value;
+      if (milliseconds) {
+        value = (data[label]! / 1000).toStringAsFixed(3).padLeft(10);
+      } else {
+        value = data[label]!.toString().padLeft(8);
+      }
+
+      print('${label.padRight(longestLabel)} = $value');
+    }
+  }
+}


### PR DESCRIPTION
I'm not generally a fan of leaving debug-only code in a codebase, but the recursive nature of the formatter makes it really hard to use the DevTools CPU profiler effectively, and I'm tired of temporarily adding this code and deleting it all the time.

When profiling is disabled, it doesn't seem to effect the performance, so I think it's reasonable to just leave it in.
