### PR TITLE
Take leading indentation into account when constraining by page width.

### DIFF
--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -115,6 +115,24 @@ class Solution implements Comparable<Solution> {
       cost += additionalCost!;
     }
 
+    // Given the page width (minus any leading indentation), we may be able to
+    // eagerly tell that some pieces must bind to a certain state. If so, do
+    // that now. We do that here instead of pinning the pieces because when
+    // this is called while separately formatting a piece subtree, the greater
+    // leading indentation gives a narrower remaining page width and makes it
+    // more likely we can tell that a piece will be forced to split.
+    void traverse(Piece piece) {
+      piece.forEachChild(traverse);
+
+      if (piece.fixedStateForPageWidth(pageWidth - leadingIndent)
+          case var state?) {
+        var additionalCost = _tryBind(pieceStates, piece, state);
+        cost += additionalCost!;
+      }
+    }
+
+    traverse(root);
+
     return Solution._(cache, root, pageWidth, leadingIndent, cost, pieceStates);
   }
 

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -180,21 +180,6 @@ class PieceWriter {
       debug.log(debug.pieceTree(rootPiece));
     }
 
-    // See if it's possible to eagerly pin any of the pieces based just on the
-    // length and newlines in their children. This is faster, especially for
-    // larger outermost pieces, then relying on the solver to determine their
-    // state.
-    void traverse(Piece piece) {
-      piece.forEachChild(traverse);
-
-      if (piece.fixedStateForPageWidth(_formatter.pageWidth - _formatter.indent)
-          case var state?) {
-        piece.pin(state);
-      }
-    }
-
-    traverse(rootPiece);
-
     var cache = SolutionCache();
     var formatter = Solver(cache,
         pageWidth: _formatter.pageWidth, leadingIndent: _formatter.indent);

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -211,8 +211,9 @@ class ListPiece extends Piece {
     if (_after case var after?) {
       totalLength += after.totalCharacters;
 
-      // Note that in `_after` does *not* force the list to split, so we ignore
-      // it here. This is typically a line comment after the closing bracket.
+      // Note that a newline in `_after` does *not* force the list to split, so
+      // we ignore it here. This is typically a line comment after the closing
+      // bracket.
     }
 
     // If the entire list doesn't fit on one line, it will split.


### PR DESCRIPTION
There's an important optimization where if a piece can tell that it's contents will never fit the given page with without splitting, it can eagerly bind to a specific state. This optimization is really important for forcing large outermost function calls and collections to split so the solver doesn't waste tons of time pointlessly trying to not split them.

Before this change, that optimization only looked at the total page width when determining how much "room" a piece has. That's nice because it means the answer is context free. Thus we can directly pin the piece because no matter the indentation, it's never going to fit.

But it means that when a piece is separately formatted and deeply nested, we don't take that leading indentation into account. Doing so can let us tell that the piece isn't going to fit more often because the remaining space is narrower.

This change does that. Instead of pinning, it binds the piece in the solution when it doesn't fit and takes the leading indentation into account. Binding instead of pinning is slightly slower (though I have some ideas how to optimize that), so this has a constant time performance regression. But being able to eagerly split pieces more often on deeply nested code has a huge performance improvement on large code when it kicks in:

```
Benchmark (tall)                fastest  baseline
-----------------------------  --------  --------
block                             0.091    132.5%
chain                             2.489     99.6%
collection                        0.187    159.3%
collection_large                  1.203     73.8%
flutter_popup_menu_test           0.552    869.2%
flutter_scrollbar_test            0.235     91.1%
function_call                     2.018     68.7%
infix_large                       1.723     86.9%
infix_small                       0.370     83.1%
large                             5.702     90.7%
top_level                         0.271     97.0%
```

Most benchmarks get a little slower but a few get way faster. On real world code, I think this optimization overall pays its way. (And, again, I think we can improve the cost of binding too.)
