### PR TITLE
Don't allow splitting in interpolation expressions.

### DIFF
--- a/benchmark/case/interpolation.expect
+++ b/benchmark/case/interpolation.expect
@@ -1,0 +1,22 @@
+main() {
+  var a = '''
+      {
+        selected:
+          hovered: $hoverColor, otherwise: ${colorScheme?.primary.withOpacity(0.04)},
+          focused: $focusColor, otherwise: ${colorScheme?.primary.withOpacity(0.12)},
+          pressed: $splashColor, otherwise: ${colorScheme?.primary.withOpacity(0.16)},
+        unselected:
+          hovered: $hoverColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.04)},
+          focused: $focusColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.12)},
+          pressed: $splashColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.16)},
+        otherwise: null,
+      }
+      ''';
+
+  log.writeln(
+    '  (name:"${stats.channel}" type:"${stats.type}" codec:"${stats.codec}" upBytes:${stats.upBytes} upBytes_avg:${stats.averageUpPayload.toStringAsFixed(1)} downBytes:${stats.downBytes} downBytes_avg:${stats.averageDownPayload.toStringAsFixed(1)})',
+  );
+
+  var b =
+      '${objectRuntimeType(this, 'BoundedFrictionSimulation')}(cₓ: ${_drag.toStringAsFixed(1)}, x₀: ${_x.toStringAsFixed(1)}, dx₀: ${_v.toStringAsFixed(1)}, x: ${_minX.toStringAsFixed(1)}..${_maxX.toStringAsFixed(1)})';
+}

--- a/benchmark/case/interpolation.expect_short
+++ b/benchmark/case/interpolation.expect_short
@@ -1,0 +1,21 @@
+main() {
+  var a = '''
+      {
+        selected:
+          hovered: $hoverColor, otherwise: ${colorScheme?.primary.withOpacity(0.04)},
+          focused: $focusColor, otherwise: ${colorScheme?.primary.withOpacity(0.12)},
+          pressed: $splashColor, otherwise: ${colorScheme?.primary.withOpacity(0.16)},
+        unselected:
+          hovered: $hoverColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.04)},
+          focused: $focusColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.12)},
+          pressed: $splashColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.16)},
+        otherwise: null,
+      }
+      ''';
+
+  log.writeln(
+      '  (name:"${stats.channel}" type:"${stats.type}" codec:"${stats.codec}" upBytes:${stats.upBytes} upBytes_avg:${stats.averageUpPayload.toStringAsFixed(1)} downBytes:${stats.downBytes} downBytes_avg:${stats.averageDownPayload.toStringAsFixed(1)})');
+
+  var b =
+      '${objectRuntimeType(this, 'BoundedFrictionSimulation')}(cₓ: ${_drag.toStringAsFixed(1)}, x₀: ${_x.toStringAsFixed(1)}, dx₀: ${_v.toStringAsFixed(1)}, x: ${_minX.toStringAsFixed(1)}..${_maxX.toStringAsFixed(1)})';
+}

--- a/benchmark/case/interpolation.unit
+++ b/benchmark/case/interpolation.unit
@@ -1,0 +1,20 @@
+main() {
+  var a = '''
+      {
+        selected:
+          hovered: $hoverColor, otherwise: ${colorScheme?.primary.withOpacity(0.04)},
+          focused: $focusColor, otherwise: ${colorScheme?.primary.withOpacity(0.12)},
+          pressed: $splashColor, otherwise: ${colorScheme?.primary.withOpacity(0.16)},
+        unselected:
+          hovered: $hoverColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.04)},
+          focused: $focusColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.12)},
+          pressed: $splashColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.16)},
+        otherwise: null,
+      }
+      ''';
+
+  log.writeln(
+      '  (name:"${stats.channel}" type:"${stats.type}" codec:"${stats.codec}" upBytes:${stats.upBytes} upBytes_avg:${stats.averageUpPayload.toStringAsFixed(1)} downBytes:${stats.downBytes} downBytes_avg:${stats.averageDownPayload.toStringAsFixed(1)})');
+
+  var b = '${objectRuntimeType(this, 'BoundedFrictionSimulation')}(cₓ: ${_drag.toStringAsFixed(1)}, x₀: ${_x.toStringAsFixed(1)}, dx₀: ${_v.toStringAsFixed(1)}, x: ${_minX.toStringAsFixed(1)}..${_maxX.toStringAsFixed(1)})';
+}

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1061,11 +1061,28 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
 
   @override
   Piece visitInterpolationExpression(InterpolationExpression node) {
-    return buildPiece((b) {
+    var piece = buildPiece((b) {
       b.token(node.leftBracket);
       b.visit(node.expression);
       b.token(node.rightBracket);
     });
+
+    // Don't allow splitting inside interpolated expressions (except for
+    // mandatory splits from comments and sequences). Splits inside
+    // interpolations almost never look good. It's usually better to just let
+    // the lines overflow. More importantly, a single string literal with many
+    // interpolations can easily lead to combinatorial performance in the
+    // solver.
+    // TODO(rnystrom): Traversing the entire interpolation Piece tree and
+    // pinning it feels sort of inelegant. Is there a cleaner approach?
+    void traverse(Piece piece) {
+      piece.preventSplit();
+      piece.forEachChild(traverse);
+    }
+
+    traverse(piece);
+
+    return piece;
   }
 
   @override

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -365,6 +365,12 @@ final class ListElementPiece extends Piece {
   }
 
   @override
+  void preventSplit() {
+    // Don't pin the ListElementPiece. Its state is only used to determine
+    // whether or not to write a comma.
+  }
+
+  @override
   String get debugName => 'ListElem';
 }
 

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -129,6 +129,12 @@ abstract class Piece {
 
   /// Forces this piece to always use [state].
   void pin(State state) {
+    // Only pin a piece once. This can happen if the contents of an
+    // interpolation expression (which are pinned to prevent splitting) are
+    // large enough for [fixedStateForPageWidth()] to also try to pin it to its
+    // fully split state.
+    if (_pinnedState != null) return;
+
     _pinnedState = state;
 
     // If this piece's pinned state constrains any child pieces, pin those too,
@@ -138,13 +144,19 @@ abstract class Piece {
     });
   }
 
+  /// Pin the piece to whatever state is needed to prevent it from splitting.
+  void preventSplit() {
+    // For most pieces, the initial state does it.
+    pin(State.unsplit);
+  }
+
   /// The name of this piece as it appears in debug output.
   ///
   /// By default, this is the class's name with `Piece` removed.
   String get debugName => runtimeType.toString().replaceAll('Piece', '');
 
   @override
-  String toString() => debugName;
+  String toString() => '$debugName${_pinnedState ?? ''}';
 }
 
 /// A simple atomic piece of code.

--- a/test/tall/expression/interpolation.stmt
+++ b/test/tall/expression/interpolation.stmt
@@ -3,18 +3,16 @@
 " ${   interp+olate } and ${fn  (  1 ) } end";
 <<<
 " ${interp + olate} and ${fn(1)} end";
->>> Allow splitting in interpolation if there is nowhere else.
+>>> Don't split in interpolation, even if the result doesn't fit.
 "some text that is long ${interpolate + a + thing} more";
 <<<
-"some text that is long ${interpolate +
-    a +
-    thing} more";
->>> Prefer not splitting in interpolation.
+"some text that is long ${interpolate + a + thing} more";
+>>> Split elsewhere when possible since interpolation doesn't split.
 "first string ${has + interpolation}" + "another ${inter + polated}";
 <<<
 "first string ${has + interpolation}" +
     "another ${inter + polated}";
->>> Split interpolation in multi-line string.
+>>> Don't split interpolation in multi-line string.
 """
 some text that is pretty long
 some more text that is pretty long ${    interpolate + a + thing   } more text
@@ -22,19 +20,14 @@ some more text that is pretty long ${    interpolate + a + thing   } more text
 <<<
 """
 some text that is pretty long
-some more text that is pretty long ${interpolate +
-    a +
-    thing} more text
+some more text that is pretty long ${interpolate + a + thing} more text
 """;
->>> Split in nested interpolation.
+>>> Don't split in nested interpolation.
 "some text that is ${pretty +  'long ${    interpolate +
 a + thing   } more'} text";
 <<<
-"some text that is ${pretty +
-    'long ${interpolate +
-        a +
-        thing} more'} text";
->>> Mandatory newline in interpolation.
+"some text that is ${pretty + 'long ${interpolate + a + thing} more'} text";
+>>> Allow mandatory newlines in interpolation.
 "before ${(){statement();statement();statement();}} after";
 <<<
 "before ${() {
@@ -58,14 +51,10 @@ j ${k
 l}''';
 <<<
 '''a
-${b +
-    """c
-${d +
-        '''e
-f''' +
-        g}
-h""" +
-    i}
+${b + """c
+${d + '''e
+f''' + g}
+h""" + i}
 j ${k + l}''';
 >>> Line comment at beginning of interpolation.
 "before ${// comment


### PR DESCRIPTION
The old formatter doesn't allow splitting inside interpolation because it almost never looks good. It's better to just let the line overflow, especially if it's a multi-line string. If the user wants it to fit, they're better off splitting the string themselves instead of letting the formatter split inside the interpolation.

Also, a single string can have an unbounded number of arbitrarily large interpolation expressions. Since the expressions can't be separately formatted (because they appear in the middle of a line), this leads to combinatorial performance. It's fairly rare, but it's quite bad when it happens. When I format the Flutter repo, one of the slowest files is packages/flutter/lib/src/material/toggle_buttons.dart. It's spending almost all of its time in:

```
  @override
  String toString() {
    return '''
    {
      selected:
        hovered: $hoverColor, otherwise: ${colorScheme?.primary.withOpacity(0.04)},
        focused: $focusColor, otherwise: ${colorScheme?.primary.withOpacity(0.12)},
        pressed: $splashColor, otherwise: ${colorScheme?.primary.withOpacity(0.16)},
      unselected:
        hovered: $hoverColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.04)},
        focused: $focusColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.12)},
        pressed: $splashColor, otherwise: ${colorScheme?.onSurface.withOpacity(0.16)},
      otherwise: null,
    }
    ''';
  }
```

I added a benchmark containing three of the worst examples I found in the Flutter repo. Before this change:

```
Benchmark (tall)                fastest   median  slowest  average  baseline
-----------------------------  --------  -------  -------  -------  --------
interpolation                  1225.785 1241.865 1242.435  1236.695    (none)
```

With this PR, the benchmark is over 10,000x faster:

```
Benchmark (tall)                fastest   median  slowest  average  baseline
-----------------------------  --------  -------  -------  -------  --------
interpolation                     0.115    0.122    0.303    0.132    (none)
```

Since large string interpolations are rare in practice, this doesn't have a huge impact on overall format times of a large corpus. (On my machine, it takes formatting the Flutter repo from 25.43s to 25.01s.) But it does address a significant hot spot and I also think the resulting output looks better.
