### PR TITLE
Don't apply the page width optimization to already pinned pieces.

### DIFF
--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -125,6 +125,10 @@ class Solution implements Comparable<Solution> {
     void traverse(Piece piece) {
       piece.forEachChild(traverse);
 
+      // If the piece is already pinned (for example, by being inside a string
+      // interpolation), then there's nothing else to do.
+      if (piece.pinnedState != null) return;
+
       if (piece.fixedStateForPageWidth(pageWidth - leadingIndent)
           case var state?) {
         var additionalCost = _tryBind(pieceStates, piece, state);


### PR DESCRIPTION
The last two commits clash and somehow the tests didn't fail on GitHub before merging. Maybe because I didn't merge the second commit with main on the PR branch before merging?

The string interpolation optimization pins pieces inside interpolation expressions. The page width optimization tries to bind pieces if it can tell they will always split. Those two optimizations collide if you have a very long expression inside a string interpolation.

The interpolation optimization pins it to *not* split, but then the later optimization tries to constrain it to always split, which fails.

This fixes that by skipping the page width optimization if the piece is already pinned.
