### PR TITLE
Ignore warnings from deprecated analyzer APIs for now.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -625,6 +625,8 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   Piece visitExtensionDeclaration(ExtensionDeclaration node) {
     return createType(node.metadata, [node.extensionKeyword], node.name,
         typeParameters: node.typeParameters,
+        // TODO(rnystrom): Move to the new analyzer API after Dart 3.4 ships.
+        // ignore: deprecated_member_use
         onType: (node.onKeyword, node.extendedType),
         body: () =>
             createBody(node.leftBracket, node.members, node.rightBracket));
@@ -1356,6 +1358,8 @@ class AstNodeVisitor extends ThrowingAstVisitor<Piece> with PieceFactory {
   }
 
   @override
+  // TODO(rnystrom): Move to the new analyzer API after Dart 3.4 ships.
+  // ignore: deprecated_member_use
   Piece visitOnClause(OnClause node) {
     throw UnsupportedError(
         'This node is handled by PieceFactory.createType().');

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -1096,6 +1096,8 @@ mixin PieceFactory {
       NamedType? superclass,
       RepresentationDeclaration? representation,
       ExtendsClause? extendsClause,
+      // TODO(rnystrom): Move to the new analyzer API after Dart 3.4 ships.
+      // ignore: deprecated_member_use
       OnClause? onClause,
       WithClause? withClause,
       ImplementsClause? implementsClause,

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -1275,8 +1275,11 @@ class SourceVisitor extends ThrowingAstVisitor {
 
     visit(node.typeParameters);
     soloSplit();
+    // TODO(rnystrom): Move to the new analyzer API after Dart 3.4 ships.
+    // ignore: deprecated_member_use
     token(node.onKeyword);
     space();
+    // ignore: deprecated_member_use
     visit(node.extendedType);
     space();
     builder.unnest();
@@ -2366,6 +2369,8 @@ class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
+  // TODO(rnystrom): Move to the new analyzer API after Dart 3.4 ships.
+  // ignore: deprecated_member_use
   void visitOnClause(OnClause node) {
     _visitCombinator(node.onKeyword, node.superclassConstraints);
   }


### PR DESCRIPTION
In order to fix these, I need to move to the new API, but that API requires package macros which doesn't currently support any stable versions of the Dart SDK.

Analyzer will continue to support the old API until analyzer 7.0.0 ships, so it's safe to continue using the old API with the current constraint that dart_style has on analyzer.

So, for now, just ignore the warnings and leave a TODO to fix them after Dart 3.4.0 ships and we can move to the new analyzer.
