### PR TITLE
Add a couple of regression tests for examples from Jake.

### DIFF
--- a/test/tall/regression/other/dart.unit
+++ b/test/tall/regression/other/dart.unit
@@ -1,0 +1,42 @@
+>>> Large argument list with block formatting.
+class C {
+  Future<void> startServer({bool? ensureCleanBuild, List<String>? buildArgs}) =>
+      _startServer(
+        'dart',
+        [
+          '--packages=.dart_tool/package_config.json',
+          p.join('..', 'build_runner', 'bin', 'build_runner.dart'),
+          'serve',
+          '--verbose',
+          if (buildArgs != null) ...buildArgs,
+        ],
+        ensureCleanBuild: ensureCleanBuild,
+      );
+}
+<<<
+class C {
+  Future<void> startServer({bool? ensureCleanBuild, List<String>? buildArgs}) =>
+      _startServer('dart', [
+        '--packages=.dart_tool/package_config.json',
+        p.join('..', 'build_runner', 'bin', 'build_runner.dart'),
+        'serve',
+        '--verbose',
+        if (buildArgs != null) ...buildArgs,
+      ], ensureCleanBuild: ensureCleanBuild);
+}
+>>> Long method chain.
+main() {
+  var stdErrLines = proc.stderr.transform(utf8.decoder).transform(
+    const LineSplitter(),
+  ).asBroadcastStream();
+}
+<<<
+### TODO(rnystrom): It would be nice if we could put the target of a split
+### method chain on the same line as the assignment.
+main() {
+  var stdErrLines =
+      proc.stderr
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .asBroadcastStream();
+}


### PR DESCRIPTION
These are things he noticed when trying the old prototype formatter. The real implementation does somewhat better than the prototype, but these may not still have the ideal formatting.

For the first one, there is still a TODO to consider tweaking the heuristics for block arguments, so I'm going to just land this test the way it's currently behaving and then we can revisit it when more of the regression tests are migrated.

cc @jakemac53 