### PR TITLE
Ensure a blank line between the directives and the declarations.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -95,6 +95,9 @@ class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
         sequence.visit(directive);
       }
 
+      // Add a blank line between directives and declarations.
+      sequence.addBlank();
+
       for (var declaration in node.declarations) {
         var hasBody = declaration is ClassDeclaration ||
             declaration is EnumDeclaration ||
@@ -312,7 +315,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
   @override
   void visitCompilationUnit(CompilationUnit node) {
     throw UnsupportedError(
-        'CompilationUnit should be handled directly by format().');
+        'CompilationUnit should be handled directly by run().');
   }
 
   @override

--- a/test/tall/regression/0600/0616.unit
+++ b/test/tall/regression/0600/0616.unit
@@ -7,8 +7,8 @@ main() {
   Expect.equals(42, y(l[1]));
 }
 <<<
-### TODO(1470): Should insert blank line after import.
 import "package:expect/expect.dart";
+
 int Function() x = () => 42;
 int Function(int Function()) y = (int Function() x) => x();
 List<int Function()> l = <int Function()>[() => 42, x];

--- a/test/tall/regression/0700/0782.unit
+++ b/test/tall/regression/0700/0782.unit
@@ -7,6 +7,7 @@ import 'dart:io';
 #!/usr/bin/env dart
 
 import 'dart:io';
+
 // More code...
 >>>
 #!/usr/bin/env dart


### PR DESCRIPTION
Fix #1470.
