### PR TITLE
Preserve a blank line after a leading top-level comment.

### DIFF
--- a/benchmark/case/large.expect
+++ b/benchmark/case/large.expect
@@ -1,6 +1,7 @@
 // Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 library pub.solver.backtracking_solver;
 
 import 'dart:async';

--- a/lib/src/front_end/sequence_builder.dart
+++ b/lib/src/front_end/sequence_builder.dart
@@ -107,6 +107,9 @@ class SequenceBuilder {
 
   /// Writes any comments appearing before [token] to the sequence.
   ///
+  /// Also handles blank lines between preceding comments and elements and the
+  /// subsequent element.
+  ///
   /// Comments between sequence elements get special handling where comments
   /// on their own line become standalone sequence elements.
   void addCommentsBefore(Token token, {int? indent}) {
@@ -152,7 +155,13 @@ class SequenceBuilder {
     if (comments.requiresNewline) _mustSplit = true;
 
     // Write a blank before the token if there should be one.
-    if (comments.linesBeforeNextToken > 1) addBlank();
+    if (comments.linesBeforeNextToken > 1) {
+      // If we just wrote a comment, then allow a blank line between it and the
+      // element.
+      if (comments.isNotEmpty) _allowBlank = true;
+
+      addBlank();
+    }
   }
 
   void _add(int indent, Piece piece) {

--- a/test/tall/regression/1400/1415.unit
+++ b/test/tall/regression/1400/1415.unit
@@ -1,0 +1,20 @@
+>>>
+// Comment.
+
+main() {}
+<<<
+// Comment.
+
+main() {}
+>>>
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+<<<
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';

--- a/test/tall/statement/block_comment.stmt
+++ b/test/tall/statement/block_comment.stmt
@@ -97,3 +97,20 @@ line */
   b:
   c;
 }
+>>> Preserve one blank line between a leading comment and statement.
+{
+
+
+
+// comment
+
+
+
+a;
+}
+<<<
+{
+  // comment
+
+  a;
+}

--- a/test/tall/top_level/comment.unit
+++ b/test/tall/top_level/comment.unit
@@ -101,3 +101,49 @@ void b() => body;
 void c() {
   ;
 }
+>>> Preserve one blank line between a leading comment and declaration.
+// comment
+
+
+
+var a = 1;
+<<<
+// comment
+
+var a = 1;
+>>> Preserve one blank line between a leading comment and directive.
+// comment
+
+
+
+import 'x.dart';
+<<<
+// comment
+
+import 'x.dart';
+>>> Preserve one blank line between comments and declarations.
+// comment
+var a = 1;
+
+// comment
+
+var b = 2;
+
+
+
+// comment
+
+
+
+var c = 3;
+<<<
+// comment
+var a = 1;
+
+// comment
+
+var b = 2;
+
+// comment
+
+var c = 3;


### PR DESCRIPTION
Preserving blank lines between comments and code was mostly working correctly except for one edge case: A blank line between the *first* comment at the top level of a file and the subsequent code would get discarded. This fixes that.

Fix #1415.
