### PR TITLE
Preserve one blank line between elements in delimited lists.

### DIFF
--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -207,7 +207,11 @@ class DelimitedListBuilder {
   /// before the closing delimiter.
   void _addComments(CommentSequence comments, {required bool hasElementAfter}) {
     // Early out if there's nothing to do.
-    if (_commentsBeforeComma.isEmpty && comments.isEmpty) return;
+    if (_commentsBeforeComma.isEmpty &&
+        comments.isEmpty &&
+        comments.linesBeforeNextToken <= 1) {
+      return;
+    }
 
     if (_commentsBeforeComma.requiresNewline || comments.requiresNewline) {
       _mustSplit = true;
@@ -236,6 +240,11 @@ class DelimitedListBuilder {
         var commentPiece = _visitor.pieces.commentPiece(comment);
         _elements.last.addComment(commentPiece);
       }
+    }
+
+    // Preserve one blank line between successive elements.
+    if (_elements.isNotEmpty && comments.linesBeforeNextToken > 1) {
+      _blanksAfter.add(_elements.last);
     }
 
     // Comments that are neither hanging nor leading are treated like their own

--- a/test/tall/declaration/enum.unit
+++ b/test/tall/declaration/enum.unit
@@ -131,3 +131,45 @@ enum SomeEnumType<
   b,
   c,
 }
+>>> Remove blank lines before first and last value. Preserve one between.
+enum E {
+
+
+  firstConstant,
+
+
+
+  secondConstant,
+
+
+
+  thirdConstant
+
+
+}
+<<<
+enum E {
+  firstConstant,
+
+  secondConstant,
+
+  thirdConstant,
+}
+>>> Discard blank lines if doesn't need to split.
+enum E {
+
+
+  a,
+
+
+
+  b,
+
+
+
+  c,
+
+
+}
+<<<
+enum E { a, b, c }

--- a/test/tall/declaration/enum_comment.unit
+++ b/test/tall/declaration/enum_comment.unit
@@ -63,6 +63,7 @@ enum A {
 <<<
 enum A {
   B,
+
   // comment
 }
 >>> Ensure blank line above doc comments.

--- a/test/tall/declaration/enum_metadata.unit
+++ b/test/tall/declaration/enum_metadata.unit
@@ -26,6 +26,7 @@ enum Foo { a,
 <<<
 enum Foo {
   a,
+
   @meta
   b,
 }

--- a/test/tall/expression/list.stmt
+++ b/test/tall/expression/list.stmt
@@ -47,7 +47,7 @@ const [1, 2, 3];
       fourth +
       fifth,
 ];
->>> Remove blank lines around elements.
+>>> Remove blank lines before first and last elements. Preserve one between.
 [
 
 
@@ -66,9 +66,29 @@ const [1, 2, 3];
 <<<
 [
   firstElement,
+
   secondElement,
+
   thirdElement,
 ];
+>>> Discard blank lines if doesn't need to split.
+[
+
+
+  1,
+
+
+
+  2,
+
+
+
+  3,
+
+
+];
+<<<
+[1, 2, 3];
 >>> With type argument.
 <  int  >  [  1  ,  2  ,  3  ];
 <<<

--- a/test/tall/expression/list_comment.stmt
+++ b/test/tall/expression/list_comment.stmt
@@ -106,6 +106,7 @@ var list = [
 [
   // comment
   element,
+
   noComment,
 
   // comment

--- a/test/tall/expression/list_preserve_newlines.stmt
+++ b/test/tall/expression/list_preserve_newlines.stmt
@@ -73,6 +73,7 @@ var list = [
   element3,
   element4,
   element5,
+
   element6, element7,
 
   // comment

--- a/test/tall/expression/map.stmt
+++ b/test/tall/expression/map.stmt
@@ -77,7 +77,7 @@ const {first: 1, second: 2};
       fifth +
       sixth,
 });
->>> Remove blank lines around entries.
+>>> Remove blank lines before first and last entries. Preserve one between.
 ({
 
 
@@ -96,9 +96,29 @@ const {first: 1, second: 2};
 <<<
 ({
   firstElement: 1,
+
   secondElement: 2,
+
   thirdElement: 3,
 });
+>>> Discard blank lines if doesn't need to split.
+({
+
+
+  1,
+
+
+
+  2,
+
+
+
+  3,
+
+
+});
+<<<
+({1, 2, 3});
 >>> With type arguments.
 <  int  ,  String  >  {  1  :  'one'  ,  2  :  'two'  };
 <<<

--- a/test/tall/expression/map_comment.stmt
+++ b/test/tall/expression/map_comment.stmt
@@ -52,6 +52,7 @@ var map = {
 ({
   // comment
   element: 1,
+
   noComment: 2,
 
   // comment

--- a/test/tall/expression/map_preserve_newlines.stmt
+++ b/test/tall/expression/map_preserve_newlines.stmt
@@ -42,6 +42,7 @@ var map = {
   element3: 3,
   element4: 4,
   element5: 5,
+
   element6: 6, element7: 7,
 
   // comment

--- a/test/tall/expression/record.stmt
+++ b/test/tall/expression/record.stmt
@@ -128,3 +128,45 @@ var record = (
   third,
   fourth,
 );
+>>> Remove blank lines before first and last entries. Preserve one between.
+var record = (
+
+
+  firstField: 1,
+
+
+
+  secondField: 2,
+
+
+
+  thirdField: 3
+
+
+);
+<<<
+var record = (
+  firstField: 1,
+
+  secondField: 2,
+
+  thirdField: 3,
+);
+>>> Discard blank lines if doesn't need to split.
+var record = (
+
+
+  a: 1,
+
+
+
+  b: 2,
+
+
+
+  c: 3
+
+
+);
+<<<
+var record = (a: 1, b: 2, c: 3);

--- a/test/tall/expression/record_comment.stmt
+++ b/test/tall/expression/record_comment.stmt
@@ -100,5 +100,6 @@ var record = (
 
   // comment
   element,
+
   element,
 );

--- a/test/tall/expression/record_preserve_newlines.stmt
+++ b/test/tall/expression/record_preserve_newlines.stmt
@@ -44,6 +44,7 @@ record = (
   element3,
   element4,
   element5,
+
   element6, element7,
 
   // comment

--- a/test/tall/expression/set_preserve_newlines.stmt
+++ b/test/tall/expression/set_preserve_newlines.stmt
@@ -44,6 +44,7 @@ var set = {
   element3,
   element4,
   element5,
+
   element6, element7,
 
   // comment

--- a/test/tall/expression/switch.stmt
+++ b/test/tall/expression/switch.stmt
@@ -31,7 +31,7 @@ e = switch (c) {
     veryLongExpression + thatSplits,
   third => c,
 };
->>> Discard newlines between cases.
+>>> Remove blank lines before first and last case. Preserve one between.
 e = switch (obj) {
 
 
@@ -49,7 +49,9 @@ e = switch (obj) {
 <<<
 e = switch (obj) {
   0 => a,
+
   1 => b,
+
   2 => c,
 };
 >>> Don't split at parentheses.

--- a/test/tall/expression/switch_comment.stmt
+++ b/test/tall/expression/switch_comment.stmt
@@ -19,6 +19,7 @@ e = switch (n) {
 e = switch (n) {
   // comment
   0 => a,
+
   // comment
   1 => b,
 

--- a/test/tall/invocation/function.stmt
+++ b/test/tall/invocation/function.stmt
@@ -81,3 +81,45 @@ someFunctionOne(
   someArgument,
   someArgument,
 );
+>>> Remove blank lines before first and last arguments. Preserve one between.
+function(
+
+
+  firstElement,
+
+
+
+  secondElement,
+
+
+
+  thirdElement
+
+
+);
+<<<
+function(
+  firstElement,
+
+  secondElement,
+
+  thirdElement,
+);
+>>> Discard blank lines if doesn't need to split.
+f(
+
+
+  1,
+
+
+
+  2,
+
+
+
+  3,
+
+
+);
+<<<
+f(1, 2, 3);

--- a/test/tall/pattern/list.stmt
+++ b/test/tall/pattern/list.stmt
@@ -120,3 +120,49 @@ var [{k: v}] = value;
 var [(v,)] = value;
 <<<
 var [(v,)] = value;
+>>> Remove blank lines before first and last entries. Preserve one between.
+if (obj case [
+
+
+  firstElement,
+
+
+
+  secondElement,
+
+
+
+  thirdElement
+
+
+]) {;}
+<<<
+if (obj case [
+  firstElement,
+
+  secondElement,
+
+  thirdElement,
+]) {
+  ;
+}
+>>> Discard blank lines if doesn't need to split.
+if (obj case [
+
+
+  1,
+
+
+
+  2,
+
+
+
+  3
+
+
+]) {;}
+<<<
+if (obj case [1, 2, 3]) {
+  ;
+}

--- a/test/tall/pattern/map.stmt
+++ b/test/tall/pattern/map.stmt
@@ -101,3 +101,49 @@ var {k: {k: v}} = value;
 var {k: (v,)} = value;
 <<<
 var {k: (v,)} = value;
+>>> Remove blank lines before first and last entries. Preserve one between.
+if (obj case {
+
+
+  firstField: 1,
+
+
+
+  secondField: 2,
+
+
+
+  thirdField: 3
+
+
+}) {;}
+<<<
+if (obj case {
+  firstField: 1,
+
+  secondField: 2,
+
+  thirdField: 3,
+}) {
+  ;
+}
+>>> Discard blank lines if doesn't need to split.
+if (obj case {
+
+
+  a: 1,
+
+
+
+  b: 2,
+
+
+
+  c: 3
+
+
+}) {;}
+<<<
+if (obj case {a: 1, b: 2, c: 3}) {
+  ;
+}

--- a/test/tall/pattern/object.stmt
+++ b/test/tall/pattern/object.stmt
@@ -212,3 +212,49 @@ if (obj case LongClassName<
 )) {
   ;
 }
+>>> Remove blank lines before first and last entries. Preserve one between.
+if (obj case C(
+
+
+  firstField: 1,
+
+
+
+  secondField: 2,
+
+
+
+  thirdField: 3
+
+
+)) {;}
+<<<
+if (obj case C(
+  firstField: 1,
+
+  secondField: 2,
+
+  thirdField: 3,
+)) {
+  ;
+}
+>>> Discard blank lines if doesn't need to split.
+if (obj case C(
+
+
+  a: 1,
+
+
+
+  b: 2,
+
+
+
+  c: 3
+
+
+)) {;}
+<<<
+if (obj case C(a: 1, b: 2, c: 3)) {
+  ;
+}

--- a/test/tall/pattern/record.stmt
+++ b/test/tall/pattern/record.stmt
@@ -176,3 +176,49 @@ var ({k: v},) = value;
 var ((v,),) = value;
 <<<
 var ((v,),) = value;
+>>> Remove blank lines before first and last entries. Preserve one between.
+if (obj case (
+
+
+  firstField: 1,
+
+
+
+  secondField: 2,
+
+
+
+  thirdField: 3
+
+
+)) {;}
+<<<
+if (obj case (
+  firstField: 1,
+
+  secondField: 2,
+
+  thirdField: 3,
+)) {
+  ;
+}
+>>> Discard blank lines if doesn't need to split.
+if (obj case (
+
+
+  a: 1,
+
+
+
+  b: 2,
+
+
+
+  c: 3
+
+
+)) {;}
+<<<
+if (obj case (a: 1, b: 2, c: 3)) {
+  ;
+}

--- a/test/tall/regression/0300/0394.stmt
+++ b/test/tall/regression/0300/0394.stmt
@@ -22,5 +22,6 @@ return $.Div(inner: [
     ]),
     $.Img(src: "math.png", width: "350px", height: "42px", clazz: "center"),
   ]),
+
   $.Footer(inner: [$.P(id: "notes", inner: "${seeds} seeds")]),
 ]);

--- a/test/tall/regression/0600/0606.unit
+++ b/test/tall/regression/0600/0606.unit
@@ -80,6 +80,7 @@ enum ErrorKind {
   /// Dart Language Specification) Dart VM native clauses. See
   /// [dart_vm_native.dart].
   ExpectedClassBodyToSkip,
+
   ExpectedDeclaration,
   ExpectedExpression,
   ExpectedFunctionBody,
@@ -113,5 +114,6 @@ enum ErrorKind {
   UnterminatedToken,
   YieldAsIdentifier,
   YieldNotGenerator,
+
   Unspecified,
 }

--- a/test/tall/regression/1400/1469.stmt
+++ b/test/tall/regression/1400/1469.stmt
@@ -1,0 +1,20 @@
+>>>
+stuff = [
+  element,
+
+  element,
+];
+<<<
+stuff = [element, element];
+>>>
+stuff = [
+  extremelyGratuitouslyLongElementThatDoesNotFit,
+
+  extremelyGratuitouslyLongElementThatDoesNotFit,
+];
+<<<
+stuff = [
+  extremelyGratuitouslyLongElementThatDoesNotFit,
+
+  extremelyGratuitouslyLongElementThatDoesNotFit,
+];


### PR DESCRIPTION
This is consistent with the old formatter and lets users break groups of elements into "sections" inside basically all delimited constructs: lists, maps, objects, argument lists, enums, etc.

Fix #1469.