### PR TITLE
Don't use AssignPiece for for-in loop "in" clauses.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1204,8 +1204,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitMapLiteralEntry(MapLiteralEntry node) {
-    writeAssignment(node.key, node.separator, node.value,
-        spaceBeforeOperator: false);
+    writeAssignment(node.key, node.separator, node.value);
   }
 
   @override
@@ -1220,8 +1219,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitMapPatternEntry(MapPatternEntry node) {
-    writeAssignment(node.key, node.separator, node.value,
-        spaceBeforeOperator: false);
+    writeAssignment(node.key, node.separator, node.value);
   }
 
   @override
@@ -1271,8 +1269,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitNamedExpression(NamedExpression node) {
-    writeAssignment(node.name.label, node.name.colon, node.expression,
-        spaceBeforeOperator: false);
+    writeAssignment(node.name.label, node.name.colon, node.expression);
   }
 
   @override

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -81,7 +81,7 @@ class AssignPiece extends Piece {
   /// The left-hand side of the operation.
   final Piece? _left;
 
-  // TODO(rnystrom): If it wasn't for the need to constraint [_left] to split
+  // TODO(rnystrom): If it wasn't for the need to constrain [_left] to split
   // in [applyConstraints()], we could write the operator into the same piece
   // as [_left]. In the common case where the AssignPiece is for a named
   // argument, the name and `:` would then end up in a single atomic

--- a/test/tall/statement/for_in.stmt
+++ b/test/tall/statement/for_in.stmt
@@ -113,9 +113,10 @@ for (var (longIdentifier &&
 for (var [longIdentifier, anotherLongOne] in obj) {;}
 <<<
 for (var [
-  longIdentifier,
-  anotherLongOne,
-] in obj) {
+      longIdentifier,
+      anotherLongOne,
+    ]
+    in obj) {
   ;
 }
 >>> With pattern, split in value.


### PR DESCRIPTION
One of the reasons that AssignPiece is so hairy is because it handles both splitting after the operator ("=", ":", etc.) and before "in".

Splitting out for-in loops to their own Piece class lets us get rid of a little of that complexity.

Also, I thought that was the only reason that the operator is a separate Piece. That's actually not true because we also need the LHS to be its own piece for applyConstraints().

Even so, I still think it's a little easier to understand with for-in loops being their own piece.

I also slightly tweaked the formatting of for-in loops. In the rare case where the left side block splits, we now indent it and split at "in". This is consistent with the old style. I don't have a strong preference, but I think it looks a little neater this way.
