### PR TITLE
Add some profiling instrumentation to the old formatter.

### DIFF
--- a/benchmark/directory.dart
+++ b/benchmark/directory.dart
@@ -11,6 +11,9 @@ import 'package:dart_style/src/constants.dart';
 import 'package:dart_style/src/profile.dart';
 import 'package:dart_style/src/testing/benchmark.dart';
 
+/// Whether to use the short or tall style formatter.
+bool _isShort = false;
+
 /// Reads a given directory of Dart files and repeatedly formats their contents.
 ///
 /// This allows getting profile information on a large real-world codebase
@@ -60,7 +63,8 @@ void main(List<String> arguments) async {
 
 void _runFormatter(String source) {
   try {
-    var formatter = DartFormatter(experimentFlags: [tallStyleExperimentFlag]);
+    var formatter = DartFormatter(
+        experimentFlags: [if (!_isShort) tallStyleExperimentFlag]);
 
     var result = formatter.format(source);
 
@@ -77,6 +81,10 @@ void _runFormatter(String source) {
 Future<String> _parseArguments(List<String> arguments) async {
   var argParser = ArgParser();
   argParser.addFlag('help', negatable: false, help: 'Show usage information.');
+  argParser.addFlag('short',
+      abbr: 's',
+      negatable: false,
+      help: 'Whether the formatter should use short or tall style.');
   argParser.addFlag('aot',
       negatable: false,
       help: 'Whether the benchmark should run in AOT mode versus JIT.');
@@ -93,8 +101,13 @@ Future<String> _parseArguments(List<String> arguments) async {
   }
 
   if (argResults['aot'] as bool) {
-    await rerunAsAot([argResults.rest.single]);
+    await rerunAsAot([
+      for (var argument in arguments)
+        if (argument != '--aot') argument,
+    ]);
   }
+
+  _isShort = argResults['short'] as bool;
 
   return argResults.rest.single;
 }

--- a/lib/src/back_end/solver.dart
+++ b/lib/src/back_end/solver.dart
@@ -86,6 +86,7 @@ class Solver {
         rootState: rootState);
 
     Profile.begin('Solver enqueue');
+    Profile.count('Solver enqueue');
     _queue.add(solution);
     Profile.end('Solver enqueue');
 
@@ -95,9 +96,8 @@ class Solver {
     var attempts = 0;
 
     while (_queue.isNotEmpty && attempts < _maxAttempts) {
-      Profile.begin('Solver dequeue');
+      Profile.count('Solver dequeue');
       var solution = _queue.removeFirst();
-      Profile.end('Solver dequeue');
 
       attempts++;
 
@@ -125,9 +125,8 @@ class Solver {
       // options.
       for (var expanded in solution.expand(_cache, root,
           pageWidth: _pageWidth, leadingIndent: _leadingIndent)) {
-        Profile.begin('Solver enqueue');
+        Profile.count('Solver enqueue');
         _queue.add(expanded);
-        Profile.end('Solver enqueue');
       }
     }
 

--- a/lib/src/short/chunk.dart
+++ b/lib/src/short/chunk.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import '../profile.dart';
 import 'fast_hash.dart';
 import 'marking_scheme.dart';
 import 'nesting_level.dart';
@@ -100,7 +101,9 @@ class Chunk extends Selection {
       : _text = '',
         _flushLeft = flushLeft,
         _isDouble = isDouble,
-        _spaceWhenUnsplit = space;
+        _spaceWhenUnsplit = space {
+    Profile.count('Create Chunk');
+  }
 
   /// Creates a dummy chunk.
   ///
@@ -113,7 +116,9 @@ class Chunk extends Selection {
         nesting = NestingLevel(),
         _spaceWhenUnsplit = false,
         _flushLeft = false,
-        _isDouble = false;
+        _isDouble = false {
+    Profile.count('Create Chunk');
+  }
 
   /// Append [text] to the end of the chunk's text.
   void appendText(String text) {

--- a/lib/src/short/chunk_builder.dart
+++ b/lib/src/short/chunk_builder.dart
@@ -7,6 +7,7 @@ import '../comment_type.dart';
 import '../constants.dart';
 import '../dart_formatter.dart';
 import '../debug.dart' as debug;
+import '../profile.dart';
 import '../source_code.dart';
 import 'chunk.dart';
 import 'line_writer.dart';
@@ -653,9 +654,13 @@ class ChunkBuilder {
       debug.log();
     }
 
+    Profile.begin('ChunkBuilder run line splitter');
+
     var writer = LineWriter(_formatter, _chunks);
     var result =
         writer.writeLines(isCompilationUnit: _source.isCompilationUnit);
+
+    Profile.end('ChunkBuilder run line splitter');
 
     int? selectionStart;
     int? selectionLength;

--- a/lib/src/short/line_splitting/solve_state.dart
+++ b/lib/src/short/line_splitting/solve_state.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 import '../../constants.dart';
 import '../../debug.dart' as debug;
+import '../../profile.dart';
 import '../chunk.dart';
 import '../nesting_level.dart';
 import '../rule/rule.dart';
@@ -108,6 +109,8 @@ class SolveState {
       _initBoundRulesInUnboundLines();
 
   SolveState(this._splitter, this._ruleValues) {
+    Profile.count('Create SolveState');
+
     _calculateSplits();
     _calculateCost();
   }

--- a/lib/src/short/line_splitting/solve_state_queue.dart
+++ b/lib/src/short/line_splitting/solve_state_queue.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import '../../profile.dart';
 import 'line_splitter.dart';
 import 'solve_state.dart';
 
@@ -39,6 +40,8 @@ class SolveStateQueue {
   ///
   /// Grows the capacity if the backing list is full.
   void add(SolveState state) {
+    Profile.count('SolveStateQueue.add()');
+
     if (_tryOverlap(state)) return;
 
     if (_length == _queue.length) {
@@ -55,6 +58,8 @@ class SolveStateQueue {
 
   SolveState removeFirst() {
     assert(_length > 0);
+
+    Profile.count('SolveStateQueue.removeFirst()');
 
     // Remove the highest priority state.
     var result = _queue[0]!;

--- a/lib/src/short/rule/rule.dart
+++ b/lib/src/short/rule/rule.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../constants.dart';
+import '../../profile.dart';
 import '../chunk.dart';
 import '../fast_hash.dart';
 
@@ -80,10 +81,14 @@ class Rule extends FastHash {
   /// rules.
   bool get splitsOnInnerRules => true;
 
-  Rule([this._cost = Cost.normal]);
+  Rule([this._cost = Cost.normal]) {
+    Profile.count('Create Rule');
+  }
 
   /// Creates a new rule that is already fully split.
   Rule.hard() : _cost = 0 {
+    Profile.count('Create Rule');
+
     // Set the cost to zero since it will always be applied, so there's no
     // point in penalizing it.
     //

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -14,6 +14,7 @@ import '../ast_extensions.dart';
 import '../comment_type.dart';
 import '../constants.dart';
 import '../dart_formatter.dart';
+import '../profile.dart';
 import '../source_code.dart';
 import 'argument_list_visitor.dart';
 import 'call_chain_visitor.dart';
@@ -119,12 +120,16 @@ class SourceVisitor extends ThrowingAstVisitor {
   /// This is the only method that should be called externally. Everything else
   /// is effectively private.
   SourceCode run(AstNode node) {
+    Profile.begin('SourceVisitor create Chunks');
+
     visit(node);
 
     // Output trailing comments.
     writePrecedingCommentsAndNewlines(node.endToken.next!);
 
     assert(_constNesting == 0, 'Should have exited all const contexts.');
+
+    Profile.end('SourceVisitor create Chunks');
 
     // Finish writing and return the complete result.
     return builder.end();


### PR DESCRIPTION
This helps comparing the different phases in the two implementations against each other.

Also, I added support to benchmark/directory.dart to run in tall or short style.
