### PR TITLE
Invalidate eagerly by newline constraint

### DIFF
--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -312,6 +312,13 @@ class CodeWriter {
     // If the child contained a newline then invalidate the solution if any of
     // the containing pieces don't allow one at this point in the tree.
     if (childHadNewline) {
+      // TODO(rnystrom): We already do much of the newline constraint validation
+      // when the Solution is first created before we format. For performance,
+      // it would be good to do *all* of it before formatting. The missing part
+      // is that pieces containing hard newlines (comments, multiline strings,
+      // sequences, etc.) do not constrain their parents when the solution is
+      // first created. If we can get that working, then this check can be
+      // removed.
       if (_currentPiece case var parent?
           when !parent.allowNewlineInChild(
               _solution.pieceState(parent), piece)) {

--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -209,7 +209,7 @@ class CodeWriter {
   /// and multi-line strings.
   void whitespace(Whitespace whitespace, {bool flushLeft = false}) {
     if (whitespace case Whitespace.newline || Whitespace.blankLine) {
-      _handleNewline(allowNewlines: true);
+      _hadNewline = true;
       _pendingIndent = flushLeft ? 0 : _indentStack.last.indent;
     }
 
@@ -231,7 +231,7 @@ class CodeWriter {
   /// be `false`. It's up to the parent piece to only call this when it's safe
   /// to do so. In practice, this usually means when the parent piece knows that
   /// [piece] will have a newline before and after it.
-  void format(Piece piece, {bool separate = false, bool allowNewlines = true}) {
+  void format(Piece piece, {bool separate = false}) {
     if (separate) {
       Profile.count('CodeWriter.format() piece separate');
 
@@ -239,7 +239,7 @@ class CodeWriter {
     } else {
       Profile.count('CodeWriter.format() piece inline');
 
-      _formatInline(piece, allowNewlines: allowNewlines);
+      _formatInline(piece);
     }
   }
 
@@ -270,7 +270,7 @@ class CodeWriter {
   }
 
   /// Format [piece] writing directly into this [CodeWriter].
-  void _formatInline(Piece piece, {required bool allowNewlines}) {
+  void _formatInline(Piece piece) {
     // Begin a new formatting context for this child.
     var previousPiece = _currentPiece;
     _currentPiece = piece;
@@ -309,9 +309,18 @@ class CodeWriter {
 
     _currentPiece = previousPiece;
 
-    // If the child contained a newline then the parent transitively does.
-    if (childHadNewline && _currentPiece != null) {
-      _handleNewline(allowNewlines: allowNewlines);
+    // If the child contained a newline then invalidate the solution if any of
+    // the containing pieces don't allow one at this point in the tree.
+    if (childHadNewline) {
+      if (_currentPiece case var parent?
+          when !parent.allowNewlineInChild(
+              _solution.pieceState(parent), piece)) {
+        _solution.invalidate(_currentPiece!);
+      }
+
+      // Note that this piece contains a newline so that we can propagate that
+      // up to containing pieces too.
+      _hadNewline = true;
     }
   }
 
@@ -325,18 +334,6 @@ class CodeWriter {
   void endSelection(int end) {
     _flushWhitespace();
     _solution.endSelection(_buffer.length + end);
-  }
-
-  /// Notes that a newline has been written.
-  ///
-  /// If this occurs in a place where newlines are prohibited, then invalidates
-  /// the solution.
-  void _handleNewline({required bool allowNewlines}) {
-    if (!allowNewlines) _solution.invalidate(_currentPiece!);
-
-    // Note that this piece contains a newline so that we can propagate that
-    // up to containing pieces too.
-    _hadNewline = true;
   }
 
   /// Write any pending whitespace.

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -12,6 +12,7 @@ import '../debug.dart' as debug;
 import '../piece/adjacent.dart';
 import '../piece/list.dart';
 import '../piece/piece.dart';
+import '../piece/text.dart';
 import '../profile.dart';
 import '../source_code.dart';
 import 'comment_writer.dart';

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -229,7 +229,7 @@ class AssignPiece extends Piece {
     // can split because there are no block operands.
     var totalLength = 0;
     if (_left case var left? when !_canBlockSplitLeft) {
-      if (left.containsNewline) return _atOperator;
+      if (left.containsHardNewline) return _atOperator;
 
       totalLength += left.totalCharacters;
     }
@@ -237,7 +237,7 @@ class AssignPiece extends Piece {
     totalLength += _operator.totalCharacters;
 
     if (!_canBlockSplitRight) {
-      if (_right.containsNewline) return _atOperator;
+      if (_right.containsHardNewline) return _atOperator;
       totalLength += _right.totalCharacters;
     }
 

--- a/lib/src/piece/assign.dart
+++ b/lib/src/piece/assign.dart
@@ -140,6 +140,18 @@ class AssignPiece extends Piece {
   }
 
   @override
+  bool allowNewlineInChild(State state, Piece child) {
+    if (state == State.unsplit) {
+      if (child == _left) return false;
+
+      // Always allow block-splitting the right side if it supports it.
+      if (child == _right) return _canBlockSplitRight;
+    }
+
+    return true;
+  }
+
+  @override
   void format(CodeWriter writer, State state) {
     switch (state) {
       case State.unsplit:
@@ -170,7 +182,7 @@ class AssignPiece extends Piece {
   }
 
   void _writeLeft(CodeWriter writer, {bool allowNewlines = true}) {
-    if (_left case var left?) writer.format(left, allowNewlines: allowNewlines);
+    if (_left case var left?) writer.format(left);
   }
 
   void _writeOperator(CodeWriter writer, {bool split = false}) {
@@ -183,7 +195,7 @@ class AssignPiece extends Piece {
   void _writeRight(CodeWriter writer,
       {bool indent = false, bool allowNewlines = true}) {
     if (indent) writer.pushIndent(Indent.expression);
-    writer.format(_right, allowNewlines: allowNewlines);
+    writer.format(_right);
     if (indent) writer.popIndent();
   }
 

--- a/lib/src/piece/clause.dart
+++ b/lib/src/piece/clause.dart
@@ -81,7 +81,7 @@ class ClausePiece extends Piece {
   final bool _allowLeadingClause;
 
   ClausePiece(this._clauses, {bool allowLeadingClause = false})
-      : _allowLeadingClause = allowLeadingClause;
+      : _allowLeadingClause = allowLeadingClause && _clauses.length > 1;
 
   @override
   List<State> get additionalStates =>

--- a/lib/src/piece/clause.dart
+++ b/lib/src/piece/clause.dart
@@ -88,6 +88,18 @@ class ClausePiece extends Piece {
       [if (_allowLeadingClause) _betweenClauses, State.split];
 
   @override
+  bool allowNewlineInChild(State state, Piece child) {
+    if (_allowLeadingClause && child == _clauses.first) {
+      // A split inside the first clause forces a split before the keyword.
+      return state == State.split;
+    } else {
+      // For the other clauses (or if there is no leading one), any split
+      // inside a clause forces all of them to split.
+      return state != State.unsplit;
+    }
+  }
+
+  @override
   void format(CodeWriter writer, State state) {
     writer.pushIndent(Indent.expression);
 
@@ -96,13 +108,13 @@ class ClausePiece extends Piece {
         // Before the leading clause, only split when in the fully split state.
         // A split inside the first clause forces a split before the keyword.
         writer.splitIf(state == State.split);
-        writer.format(clause, allowNewlines: state == State.split);
+        writer.format(clause);
       } else {
         // For the other clauses (or if there is no leading one), split in the
         // fully split state and any split inside and clause forces all of them
         // to split.
         writer.splitIf(state != State.unsplit);
-        writer.format(clause, allowNewlines: state != State.unsplit);
+        writer.format(clause);
       }
     }
 

--- a/lib/src/piece/constructor.dart
+++ b/lib/src/piece/constructor.dart
@@ -127,24 +127,31 @@ class ConstructorPiece extends Piece {
   }
 
   @override
+  bool allowNewlineInChild(State state, Piece child) {
+    if (child == _body) return true;
+
+    // If there's a newline in the header or parameters (like a line comment
+    // after the `)`), then don't allow the initializers to remain unsplit.
+    return _initializers == null || state != State.unsplit;
+  }
+
+  @override
   void format(CodeWriter writer, State state) {
     // If there's a newline in the header or parameters (like a line comment
     // after the `)`), then don't allow the initializers to remain unsplit.
-    var allowNewlines = _initializers == null || state != State.unsplit;
-
-    writer.format(_header, allowNewlines: allowNewlines);
-    writer.format(_parameters, allowNewlines: allowNewlines);
+    writer.format(_header);
+    writer.format(_parameters);
 
     if (_redirect case var redirect?) {
       writer.space();
-      writer.format(redirect, allowNewlines: allowNewlines);
+      writer.format(redirect);
     }
 
     if (_initializers case var initializers?) {
       writer.pushIndent(Indent.block);
       writer.splitIf(state == _splitBeforeInitializers);
 
-      writer.format(_initializerSeparator!, allowNewlines: allowNewlines);
+      writer.format(_initializerSeparator!);
       writer.space();
 
       // Indent subsequent initializers past the `:`.
@@ -154,7 +161,7 @@ class ConstructorPiece extends Piece {
         writer.pushIndent(Indent.initializer);
       }
 
-      writer.format(initializers, allowNewlines: allowNewlines);
+      writer.format(initializers);
       writer.popIndent();
       writer.popIndent();
     }

--- a/lib/src/piece/constructor.dart
+++ b/lib/src/piece/constructor.dart
@@ -136,9 +136,11 @@ class ConstructorPiece extends Piece {
   }
 
   @override
+  bool containsNewline(State state) =>
+      state == _splitBeforeInitializers || super.containsNewline(state);
+
+  @override
   void format(CodeWriter writer, State state) {
-    // If there's a newline in the header or parameters (like a line comment
-    // after the `)`), then don't allow the initializers to remain unsplit.
     writer.format(_header);
     writer.format(_parameters);
 

--- a/lib/src/piece/control_flow.dart
+++ b/lib/src/piece/control_flow.dart
@@ -40,12 +40,7 @@ class ControlFlowPiece extends Piece {
   }
 
   @override
-  void forEachChild(void Function(Piece piece) callback) {
-    for (var section in _sections) {
-      callback(section.header);
-      callback(section.statement);
-    }
-  }
+  bool allowNewlineInChild(State state, Piece child) => state == State.split;
 
   @override
   void format(CodeWriter writer, State state) {
@@ -53,7 +48,7 @@ class ControlFlowPiece extends Piece {
       var section = _sections[i];
 
       // A split in the condition forces the branches to split.
-      writer.format(section.header, allowNewlines: state == State.split);
+      writer.format(section.header);
 
       if (!section.isBlock) {
         writer.pushIndent(Indent.block);
@@ -61,7 +56,7 @@ class ControlFlowPiece extends Piece {
       }
 
       // TODO(perf): Investigate whether it's worth using `separate:` here.
-      writer.format(section.statement, allowNewlines: state == State.split);
+      writer.format(section.statement);
 
       // Reset the indentation for the subsequent `else` or `} else` line.
       if (!section.isBlock) writer.popIndent();
@@ -69,6 +64,14 @@ class ControlFlowPiece extends Piece {
       if (i < _sections.length - 1) {
         writer.splitIf(state == State.split && !section.isBlock);
       }
+    }
+  }
+
+  @override
+  void forEachChild(void Function(Piece piece) callback) {
+    for (var section in _sections) {
+      callback(section.header);
+      callback(section.statement);
     }
   }
 

--- a/lib/src/piece/control_flow.dart
+++ b/lib/src/piece/control_flow.dart
@@ -43,6 +43,17 @@ class ControlFlowPiece extends Piece {
   bool allowNewlineInChild(State state, Piece child) => state == State.split;
 
   @override
+  bool containsNewline(State state) {
+    if (state == State.split) {
+      for (var section in _sections) {
+        if (!section.isBlock) return true;
+      }
+    }
+
+    return super.containsNewline(state);
+  }
+
+  @override
   void format(CodeWriter writer, State state) {
     for (var i = 0; i < _sections.length; i++) {
       var section = _sections[i];

--- a/lib/src/piece/for.dart
+++ b/lib/src/piece/for.dart
@@ -99,18 +99,22 @@ class ForInPiece extends Piece {
   List<State> get additionalStates => const [State.split];
 
   @override
+  bool allowNewlineInChild(State state, Piece child) {
+    if (state == State.split) return true;
+
+    // Always allow block-splitting the sequence if it supports it.
+    return child == _sequence && _canBlockSplitSequence;
+  }
+
+  @override
   void format(CodeWriter writer, State state) {
     // When splitting at `in`, both operands may split or not and will be
     // indented if they do.
     if (state == State.split) writer.pushIndent(Indent.expression);
 
-    writer.format(_variable, allowNewlines: state == State.split);
-
+    writer.format(_variable);
     writer.splitIf(state == State.split);
-
-    // Always allow block-splitting the sequence if it supports it.
-    writer.format(_sequence,
-        allowNewlines: _canBlockSplitSequence || state == State.split);
+    writer.format(_sequence);
 
     if (state == State.split) writer.popIndent();
   }

--- a/lib/src/piece/infix.dart
+++ b/lib/src/piece/infix.dart
@@ -88,7 +88,7 @@ class InfixPiece extends Piece {
 
     for (var operand in _operands) {
       // If any operand contains a newline, then we have to split.
-      if (operand.containsNewline) return State.split;
+      if (operand.containsHardNewline) return State.split;
 
       totalLength += operand.totalCharacters;
       if (totalLength > pageWidth) break;

--- a/lib/src/piece/infix.dart
+++ b/lib/src/piece/infix.dart
@@ -48,10 +48,17 @@ class InfixPiece extends Piece {
   List<State> get additionalStates => const [State.split];
 
   @override
-  void format(CodeWriter writer, State state) {
+  bool allowNewlineInChild(State state, Piece child) {
+    if (state == State.split) return true;
+
     // Comments before the operands don't force the operator to split.
+    return _leadingComments.contains(child);
+  }
+
+  @override
+  void format(CodeWriter writer, State state) {
     for (var comment in _leadingComments) {
-      writer.format(comment, allowNewlines: true);
+      writer.format(comment);
     }
 
     if (_indent) writer.pushIndent(Indent.expression);
@@ -62,8 +69,7 @@ class InfixPiece extends Piece {
       // or last operand.
       var separate = state == State.split && i > 0 && i < _operands.length - 1;
 
-      writer.format(_operands[i],
-          separate: separate, allowNewlines: state == State.split);
+      writer.format(_operands[i], separate: separate);
       if (i < _operands.length - 1) writer.splitIf(state == State.split);
     }
 

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -116,6 +116,17 @@ class ListPiece extends Piece {
   }
 
   @override
+  bool allowNewlineInChild(State state, Piece child) {
+    if (state == State.split) return true;
+    if (child == _before) return true;
+    if (child == _after) return true;
+
+    // Only some elements (usually a single block element) allow newlines
+    // when the list itself isn't split.
+    return child is ListElementPiece && child.allowNewlinesWhenUnsplit;
+  }
+
+  @override
   void format(CodeWriter writer, State state) {
     // Format the opening bracket, if there is one.
     if (_before case var before?) {
@@ -144,13 +155,7 @@ class ListPiece extends Piece {
       var separate = state == State.split &&
           (i > 0 || _before != null) &&
           (i < _elements.length - 1 || _after != null);
-
-      // Only some elements (usually a single block element) allow newlines
-      // when the list itself isn't split.
-      var allowNewlines =
-          element.allowNewlinesWhenUnsplit || state == State.split;
-
-      writer.format(element, separate: separate, allowNewlines: allowNewlines);
+      writer.format(element, separate: separate);
 
       if (state == State.unsplit && element.indentWhenBlockFormatted) {
         writer.popIndent();
@@ -173,7 +178,7 @@ class ListPiece extends Piece {
       writer.splitIf(state == State.split,
           space: _style.spaceWhenUnsplit && _elements.isNotEmpty);
 
-      writer.format(after, allowNewlines: true);
+      writer.format(after);
     }
   }
 

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -199,7 +199,7 @@ class ListPiece extends Piece {
     if (_before case var before?) {
       // A newline in the opening bracket (like a line comment after the
       // bracket) forces the list to split.
-      if (before.containsNewline) return State.split;
+      if (before.containsHardNewline) return State.split;
       totalLength += before.totalCharacters;
     }
 
@@ -208,7 +208,7 @@ class ListPiece extends Piece {
       // to split.
       if (element.allowNewlinesWhenUnsplit) continue;
 
-      if (element.containsNewline) return State.split;
+      if (element.containsHardNewline) return State.split;
       totalLength += element.totalCharacters;
       if (totalLength > pageWidth) break;
     }

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -43,13 +43,13 @@ abstract class Piece {
   ///
   /// This is lazily computed and cached for performance, so should only be
   /// accessed after all of the piece's children are known.
-  late final bool containsNewline = calculateContainsNewline();
+  late final bool containsHardNewline = calculateContainsHardNewline();
 
-  bool calculateContainsNewline() {
+  bool calculateContainsHardNewline() {
     var anyHasNewline = false;
 
     forEachChild((child) {
-      anyHasNewline |= child.containsNewline;
+      anyHasNewline |= child.containsHardNewline;
     });
 
     return anyHasNewline;
@@ -96,8 +96,9 @@ abstract class Piece {
   void forEachChild(void Function(Piece piece) callback);
 
   /// If the piece can determine that it will always end up in a certain state
-  /// given [pageWidth] and size metrics returned by calling [containsNewline]
-  /// and [totalCharacters] on its children, then returns that [State].
+  /// given [pageWidth] and size metrics returned by calling
+  /// [containsHardNewline] and [totalCharacters] on its children, then returns
+  /// that [State].
   ///
   /// For example, a series of infix operators wider than a page will always
   /// split one per operator. If we can determine this eagerly just based on

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -84,6 +84,10 @@ abstract class Piece {
   /// child piece and the state that child should be constrained to.
   void applyConstraints(State state, Constrain constrain) {}
 
+  /// Whether the [child] of this piece should be allowed to contain newlines
+  /// (directly or transitively) when this piece is in [state].
+  bool allowNewlineInChild(State state, Piece child) => true;
+
   /// Given that this piece is in [state], use [writer] to produce its formatted
   /// output.
   void format(CodeWriter writer, State state);

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -108,8 +108,9 @@ abstract class Piece {
   void forEachChild(void Function(Piece piece) callback);
 
   /// If the piece can determine that it will always end up in a certain state
-  /// given [pageWidth] and size metrics returned by calling [containsHardNewline]
-  /// and [totalCharacters] on its children, then returns that [State].
+  /// given [pageWidth] and size metrics returned by calling
+  /// [containsHardNewline] and [totalCharacters] on its children, then returns
+  /// that [State].
   ///
   /// For example, a series of infix operators wider than a page will always
   /// split one per operator. If we can determine this eagerly just based on

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -43,9 +43,9 @@ abstract class Piece {
   ///
   /// This is lazily computed and cached for performance, so should only be
   /// accessed after all of the piece's children are known.
-  late final bool containsNewline = _calculateContainsNewline();
+  late final bool containsNewline = calculateContainsNewline();
 
-  bool _calculateContainsNewline() {
+  bool calculateContainsNewline() {
     var anyHasNewline = false;
 
     forEachChild((child) {
@@ -60,9 +60,9 @@ abstract class Piece {
   ///
   /// This is lazily computed and cached for performance, so should only be
   /// accessed after all of the piece's children are known.
-  late final int totalCharacters = _calculateTotalCharacters();
+  late final int totalCharacters = calculateTotalCharacters();
 
-  int _calculateTotalCharacters() {
+  int calculateTotalCharacters() {
     var total = 0;
 
     forEachChild((child) {
@@ -153,198 +153,6 @@ abstract class Piece {
 
   @override
   String toString() => '$debugName${_pinnedState ?? ''}';
-}
-
-/// A simple atomic piece of code.
-///
-/// This may represent a series of tokens where no split can occur between them.
-/// It may also contain one or more comments.
-sealed class TextPiece extends Piece {
-  /// RegExp that matches any valid Dart line terminator.
-  static final _lineTerminatorPattern = RegExp(r'\r\n?|\n');
-
-  /// The lines of text in this piece.
-  ///
-  /// Most [TextPieces] will contain only a single line, but a piece for a
-  /// multi-line string or comment will have multiple lines. These are stored
-  /// as separate lines instead of a single multi-line Dart String so that
-  /// line endings are normalized and so that column calculation during line
-  /// splitting calculates each line in the piece separately.
-  final List<String> _lines = [''];
-
-  /// The offset from the beginning of [text] where the selection starts, or
-  /// `null` if the selection does not start within this chunk.
-  int? _selectionStart;
-
-  /// The offset from the beginning of [text] where the selection ends, or
-  /// `null` if the selection does not start within this chunk.
-  int? _selectionEnd;
-
-  /// Append [text] to the end of this piece.
-  ///
-  /// If [text] may contain any newline characters, then [multiline] must be
-  /// `true`.
-  ///
-  /// If [selectionStart] and/or [selectionEnd] are given, then notes that the
-  /// corresponding selection markers appear that many code units from where
-  /// [text] will be appended.
-  void append(String text,
-      {bool multiline = false, int? selectionStart, int? selectionEnd}) {
-    if (selectionStart != null) {
-      _selectionStart = _adjustSelection(selectionStart);
-    }
-
-    if (selectionEnd != null) {
-      _selectionEnd = _adjustSelection(selectionEnd);
-    }
-
-    if (multiline) {
-      var lines = text.split(_lineTerminatorPattern);
-      for (var i = 0; i < lines.length; i++) {
-        if (i > 0) _lines.add('');
-        _lines.last += lines[i];
-      }
-    } else {
-      _lines.last += text;
-    }
-  }
-
-  /// Sets [selectionStart] to be [start] code units after the end of the
-  /// current text in this piece.
-  void startSelection(int start) {
-    _selectionStart = _adjustSelection(start);
-  }
-
-  /// Sets [selectionEnd] to be [end] code units after the end of the
-  /// current text in this piece.
-  void endSelection(int end) {
-    _selectionEnd = _adjustSelection(end);
-  }
-
-  /// Adjust [offset] by the current length of this [TextPiece].
-  int _adjustSelection(int offset) {
-    for (var line in _lines) {
-      offset += line.length;
-    }
-
-    return offset;
-  }
-
-  void _formatSelection(CodeWriter writer) {
-    if (_selectionStart case var start?) {
-      writer.startSelection(start);
-    }
-
-    if (_selectionEnd case var end?) {
-      writer.endSelection(end);
-    }
-  }
-
-  void _formatLines(CodeWriter writer) {
-    for (var i = 0; i < _lines.length; i++) {
-      if (i > 0) writer.newline(flushLeft: i > 0);
-      writer.write(_lines[i]);
-    }
-  }
-
-  @override
-  bool _calculateContainsNewline() => _lines.length > 1;
-
-  @override
-  int _calculateTotalCharacters() {
-    var total = 0;
-
-    for (var line in _lines) {
-      total += line.length;
-    }
-
-    return total;
-  }
-
-  @override
-  String toString() => '`${_lines.join('¬')}`';
-}
-
-/// [TextPiece] for non-comment source code that may have comments attached to
-/// it.
-class CodePiece extends TextPiece {
-  /// Pieces for any comments that appear immediately before this code.
-  final List<Piece> _leadingComments;
-
-  /// Pieces for any comments that hang off the same line as this code.
-  final List<Piece> _hangingComments = [];
-
-  CodePiece([this._leadingComments = const []]);
-
-  void addHangingComment(Piece comment) {
-    _hangingComments.add(comment);
-  }
-
-  @override
-  void format(CodeWriter writer, State state) {
-    _formatSelection(writer);
-
-    if (_leadingComments.isNotEmpty) {
-      // Always put leading comments on a new line.
-      writer.newline();
-
-      for (var comment in _leadingComments) {
-        writer.format(comment);
-      }
-    }
-
-    _formatLines(writer);
-
-    for (var comment in _hangingComments) {
-      writer.space();
-      writer.format(comment);
-    }
-  }
-
-  @override
-  void forEachChild(void Function(Piece piece) callback) {
-    _leadingComments.forEach(callback);
-    _hangingComments.forEach(callback);
-  }
-}
-
-/// A [TextPiece] for a source code comment and the whitespace after it, if any.
-class CommentPiece extends TextPiece {
-  /// Whitespace at the end of the comment.
-  final Whitespace _trailingWhitespace;
-
-  CommentPiece([this._trailingWhitespace = Whitespace.none]);
-
-  @override
-  void format(CodeWriter writer, State state) {
-    _formatSelection(writer);
-    _formatLines(writer);
-    writer.whitespace(_trailingWhitespace);
-  }
-
-  @override
-  bool _calculateContainsNewline() =>
-      _trailingWhitespace.hasNewline || super._calculateContainsNewline();
-
-  @override
-  void forEachChild(void Function(Piece piece) callback) {}
-}
-
-/// A piece that writes a single space.
-class SpacePiece extends Piece {
-  @override
-  void forEachChild(void Function(Piece piece) callback) {}
-
-  @override
-  void format(CodeWriter writer, State state) {
-    writer.space();
-  }
-
-  @override
-  bool _calculateContainsNewline() => false;
-
-  @override
-  int _calculateTotalCharacters() => 1;
 }
 
 /// A state that a piece can be in.

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -42,6 +42,10 @@ class SequencePiece extends Piece {
     }
   }
 
+  /// If there are multiple elements, there are newlines between them.
+  @override
+  bool calculateContainsHardNewline() => _elements.length > 1;
+
   @override
   String get debugName => 'Seq';
 }
@@ -84,7 +88,7 @@ class BlockPiece extends Piece {
 
   /// A [BlockPiece] is never empty and always splits between the delimiters.
   @override
-  bool calculateContainsNewline() => true;
+  bool calculateContainsHardNewline() => true;
 
   @override
   String get debugName => 'Block';

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -3,78 +3,93 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../back_end/code_writer.dart';
+import '../constants.dart';
 import 'piece.dart';
 
 /// A piece for a series of statements or members inside a block or declaration
-/// body.
+/// body or at the top level of a program.
 ///
-/// Usually constructed using a [SequenceBuilder].
+/// Constructed using a [SequenceBuilder].
 class SequencePiece extends Piece {
-  /// The opening delimiter, if any.
-  final Piece? _leftBracket;
-
   /// The series of members or statements.
   final List<SequenceElementPiece> _elements;
 
-  SequencePiece(this._elements, {Piece? leftBracket, Piece? rightBracket})
-      : _leftBracket = leftBracket,
-        _rightBracket = rightBracket;
-
-  /// The closing delimiter, if any.
-  final Piece? _rightBracket;
-
-  @override
-  List<State> get additionalStates => [if (_elements.isNotEmpty) State.split];
+  SequencePiece(this._elements);
 
   @override
   void format(CodeWriter writer, State state) {
-    if (_leftBracket case var leftBracket?) {
-      writer.format(leftBracket, allowNewlines: state == State.split);
-      writer.pushIndent(_elements.firstOrNull?._indent ?? 0);
-      writer.splitIf(state == State.split, space: false);
-    }
+    writer.pushIndent(Indent.none);
 
     for (var i = 0; i < _elements.length; i++) {
       var element = _elements[i];
 
-      // We can format an element separately if the element is on its own line.
-      // This happens when the sequence is split and there is something before
-      // and after the element, either brackets or other items.
-      var separate = state == State.split &&
-          (i > 0 || _leftBracket != null) &&
-          (i < _elements.length - 1 || _rightBracket != null);
-
-      writer.format(element,
-          separate: separate, allowNewlines: state == State.split);
+      writer.format(element, separate: true, allowNewlines: true);
 
       if (i < _elements.length - 1) {
-        if (_leftBracket != null || i > 0) writer.popIndent();
+        writer.popIndent();
         writer.pushIndent(_elements[i + 1]._indent);
         writer.newline(blank: element.blankAfter);
       }
     }
 
-    if (_leftBracket != null || _elements.length > 1) writer.popIndent();
-
-    if (_rightBracket case var rightBracket?) {
-      writer.splitIf(state == State.split, space: false);
-      writer.format(rightBracket, allowNewlines: state == State.split);
-    }
+    writer.popIndent();
   }
 
   @override
   void forEachChild(void Function(Piece piece) callback) {
-    if (_leftBracket case var leftBracket?) callback(leftBracket);
-
     for (var element in _elements) {
       callback(element);
     }
-
-    if (_rightBracket case var rightBracket?) callback(rightBracket);
   }
 
   @override
   String get debugName => 'Seq';
+}
+
+/// A piece for a non-empty brace-delimited series of statements or members
+/// inside a block or declaration body.
+///
+/// Unlike [ListPiece], always splits between the elements.
+///
+/// Constructed using a [SequenceBuilder].
+class BlockPiece extends Piece {
+  /// The opening delimiter.
+  final Piece _leftBracket;
+
+  /// The series of members or statements.
+  final SequencePiece _elements;
+
+  /// The closing delimiter.
+  final Piece _rightBracket;
+
+  BlockPiece(this._leftBracket, this._elements, this._rightBracket);
+
+  @override
+  void format(CodeWriter writer, State state) {
+    writer.format(_leftBracket, allowNewlines: true);
+    writer.pushIndent(Indent.block);
+    writer.newline();
+
+    writer.format(_elements);
+
+    writer.popIndent();
+    writer.newline();
+    writer.format(_rightBracket, allowNewlines: true);
+  }
+
+  @override
+  void forEachChild(void Function(Piece piece) callback) {
+    callback(_leftBracket);
+    callback(_elements);
+    callback(_rightBracket);
+  }
+
+  /// A [BlockPiece] is never empty and always splits between the delimiters.
+  @override
+  bool calculateContainsNewline() => true;
+
+  @override
+  String get debugName => 'Block';
 }
 
 /// An element inside a [SequencePiece].

--- a/lib/src/piece/sequence.dart
+++ b/lib/src/piece/sequence.dart
@@ -23,7 +23,7 @@ class SequencePiece extends Piece {
     for (var i = 0; i < _elements.length; i++) {
       var element = _elements[i];
 
-      writer.format(element, separate: true, allowNewlines: true);
+      writer.format(element, separate: true);
 
       if (i < _elements.length - 1) {
         writer.popIndent();
@@ -66,15 +66,13 @@ class BlockPiece extends Piece {
 
   @override
   void format(CodeWriter writer, State state) {
-    writer.format(_leftBracket, allowNewlines: true);
+    writer.format(_leftBracket);
     writer.pushIndent(Indent.block);
     writer.newline();
-
     writer.format(_elements);
-
     writer.popIndent();
     writer.newline();
-    writer.format(_rightBracket, allowNewlines: true);
+    writer.format(_rightBracket);
   }
 
   @override

--- a/lib/src/piece/text.dart
+++ b/lib/src/piece/text.dart
@@ -1,0 +1,198 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../back_end/code_writer.dart';
+import 'piece.dart';
+
+/// A simple atomic piece of code.
+///
+/// This may represent a series of tokens where no split can occur between them.
+/// It may also contain one or more comments.
+sealed class TextPiece extends Piece {
+  /// RegExp that matches any valid Dart line terminator.
+  static final _lineTerminatorPattern = RegExp(r'\r\n?|\n');
+
+  /// The lines of text in this piece.
+  ///
+  /// Most [TextPieces] will contain only a single line, but a piece for a
+  /// multi-line string or comment will have multiple lines. These are stored
+  /// as separate lines instead of a single multi-line Dart String so that
+  /// line endings are normalized and so that column calculation during line
+  /// splitting calculates each line in the piece separately.
+  final List<String> _lines = [''];
+
+  /// The offset from the beginning of [text] where the selection starts, or
+  /// `null` if the selection does not start within this chunk.
+  int? _selectionStart;
+
+  /// The offset from the beginning of [text] where the selection ends, or
+  /// `null` if the selection does not start within this chunk.
+  int? _selectionEnd;
+
+  /// Append [text] to the end of this piece.
+  ///
+  /// If [text] may contain any newline characters, then [multiline] must be
+  /// `true`.
+  ///
+  /// If [selectionStart] and/or [selectionEnd] are given, then notes that the
+  /// corresponding selection markers appear that many code units from where
+  /// [text] will be appended.
+  void append(String text,
+      {bool multiline = false, int? selectionStart, int? selectionEnd}) {
+    if (selectionStart != null) {
+      _selectionStart = _adjustSelection(selectionStart);
+    }
+
+    if (selectionEnd != null) {
+      _selectionEnd = _adjustSelection(selectionEnd);
+    }
+
+    if (multiline) {
+      var lines = text.split(_lineTerminatorPattern);
+      for (var i = 0; i < lines.length; i++) {
+        if (i > 0) _lines.add('');
+        _lines.last += lines[i];
+      }
+    } else {
+      _lines.last += text;
+    }
+  }
+
+  /// Sets [selectionStart] to be [start] code units after the end of the
+  /// current text in this piece.
+  void startSelection(int start) {
+    _selectionStart = _adjustSelection(start);
+  }
+
+  /// Sets [selectionEnd] to be [end] code units after the end of the
+  /// current text in this piece.
+  void endSelection(int end) {
+    _selectionEnd = _adjustSelection(end);
+  }
+
+  /// Adjust [offset] by the current length of this [TextPiece].
+  int _adjustSelection(int offset) {
+    for (var line in _lines) {
+      offset += line.length;
+    }
+
+    return offset;
+  }
+
+  void _formatSelection(CodeWriter writer) {
+    if (_selectionStart case var start?) {
+      writer.startSelection(start);
+    }
+
+    if (_selectionEnd case var end?) {
+      writer.endSelection(end);
+    }
+  }
+
+  void _formatLines(CodeWriter writer) {
+    for (var i = 0; i < _lines.length; i++) {
+      if (i > 0) writer.newline(flushLeft: i > 0);
+      writer.write(_lines[i]);
+    }
+  }
+
+  @override
+  bool calculateContainsNewline() => _lines.length > 1;
+
+  @override
+  int calculateTotalCharacters() {
+    var total = 0;
+
+    for (var line in _lines) {
+      total += line.length;
+    }
+
+    return total;
+  }
+
+  @override
+  String toString() => '`${_lines.join('¬')}`';
+}
+
+/// [TextPiece] for non-comment source code that may have comments attached to
+/// it.
+class CodePiece extends TextPiece {
+  /// Pieces for any comments that appear immediately before this code.
+  final List<Piece> _leadingComments;
+
+  /// Pieces for any comments that hang off the same line as this code.
+  final List<Piece> _hangingComments = [];
+
+  CodePiece([this._leadingComments = const []]);
+
+  void addHangingComment(Piece comment) {
+    _hangingComments.add(comment);
+  }
+
+  @override
+  void format(CodeWriter writer, State state) {
+    _formatSelection(writer);
+
+    if (_leadingComments.isNotEmpty) {
+      // Always put leading comments on a new line.
+      writer.newline();
+
+      for (var comment in _leadingComments) {
+        writer.format(comment);
+      }
+    }
+
+    _formatLines(writer);
+
+    for (var comment in _hangingComments) {
+      writer.space();
+      writer.format(comment);
+    }
+  }
+
+  @override
+  void forEachChild(void Function(Piece piece) callback) {
+    _leadingComments.forEach(callback);
+    _hangingComments.forEach(callback);
+  }
+}
+
+/// A [TextPiece] for a source code comment and the whitespace after it, if any.
+class CommentPiece extends TextPiece {
+  /// Whitespace at the end of the comment.
+  final Whitespace _trailingWhitespace;
+
+  CommentPiece([this._trailingWhitespace = Whitespace.none]);
+
+  @override
+  void format(CodeWriter writer, State state) {
+    _formatSelection(writer);
+    _formatLines(writer);
+    writer.whitespace(_trailingWhitespace);
+  }
+
+  @override
+  bool calculateContainsNewline() =>
+      _trailingWhitespace.hasNewline || super.calculateContainsNewline();
+
+  @override
+  void forEachChild(void Function(Piece piece) callback) {}
+}
+
+/// A piece that writes a single space.
+class SpacePiece extends Piece {
+  @override
+  void forEachChild(void Function(Piece piece) callback) {}
+
+  @override
+  void format(CodeWriter writer, State state) {
+    writer.space();
+  }
+
+  @override
+  bool calculateContainsNewline() => false;
+
+  @override
+  int calculateTotalCharacters() => 1;
+}

--- a/lib/src/piece/text.dart
+++ b/lib/src/piece/text.dart
@@ -196,3 +196,20 @@ class SpacePiece extends Piece {
   @override
   int calculateTotalCharacters() => 1;
 }
+
+/// A piece that writes a single newline.
+class NewlinePiece extends Piece {
+  @override
+  void forEachChild(void Function(Piece piece) callback) {}
+
+  @override
+  void format(CodeWriter writer, State state) {
+    writer.newline();
+  }
+
+  @override
+  bool calculateContainsNewline() => true;
+
+  @override
+  int calculateTotalCharacters() => 0;
+}

--- a/lib/src/piece/text.dart
+++ b/lib/src/piece/text.dart
@@ -98,7 +98,7 @@ sealed class TextPiece extends Piece {
   }
 
   @override
-  bool calculateContainsNewline() => _lines.length > 1;
+  bool calculateContainsHardNewline() => _lines.length > 1;
 
   @override
   int calculateTotalCharacters() {
@@ -173,8 +173,8 @@ class CommentPiece extends TextPiece {
   }
 
   @override
-  bool calculateContainsNewline() =>
-      _trailingWhitespace.hasNewline || super.calculateContainsNewline();
+  bool calculateContainsHardNewline() =>
+      _trailingWhitespace.hasNewline || super.calculateContainsHardNewline();
 
   @override
   void forEachChild(void Function(Piece piece) callback) {}
@@ -191,7 +191,7 @@ class SpacePiece extends Piece {
   }
 
   @override
-  bool calculateContainsNewline() => false;
+  bool calculateContainsHardNewline() => false;
 
   @override
   int calculateTotalCharacters() => 1;
@@ -208,7 +208,7 @@ class NewlinePiece extends Piece {
   }
 
   @override
-  bool calculateContainsNewline() => true;
+  bool calculateContainsHardNewline() => true;
 
   @override
   int calculateTotalCharacters() => 0;

--- a/lib/src/piece/type.dart
+++ b/lib/src/piece/type.dart
@@ -36,15 +36,19 @@ class TypePiece extends Piece {
   }
 
   @override
-  void format(CodeWriter writer, State state) {
+  bool allowNewlineInChild(State state, Piece child) {
+    if (child == _body) return true;
+
     // If the body may or may not split, then a newline in the header or
     // clauses forces the body to split.
-    var allowSplitInHeader =
-        _bodyType != TypeBodyType.list || state == State.split;
+    return _bodyType != TypeBodyType.list || state == State.split;
+  }
 
-    writer.format(_header, allowNewlines: allowSplitInHeader);
+  @override
+  void format(CodeWriter writer, State state) {
+    writer.format(_header);
     if (_clauses case var clauses?) {
-      writer.format(clauses, allowNewlines: allowSplitInHeader);
+      writer.format(clauses);
     }
 
     if (_bodyType != TypeBodyType.semicolon) writer.space();

--- a/lib/src/piece/variable.dart
+++ b/lib/src/piece/variable.dart
@@ -60,8 +60,17 @@ class VariablePiece extends Piece {
       ];
 
   @override
+  bool allowNewlineInChild(State state, Piece child) {
+    if (child == _header) {
+      return state != State.unsplit;
+    } else {
+      return _variables.length == 1 || state != State.unsplit;
+    }
+  }
+
+  @override
   void format(CodeWriter writer, State state) {
-    writer.format(_header, allowNewlines: state != State.unsplit);
+    writer.format(_header);
 
     // If we split at the variables (but not the type), then indent the
     // variables and their initializers.
@@ -75,9 +84,7 @@ class VariablePiece extends Piece {
       if (i > 0) writer.splitIf(state != State.unsplit);
 
       // TODO(perf): Investigate whether it's worth using `separate:` here.
-      // Force multiple variables to split if an initializer does.
-      writer.format(_variables[i],
-          allowNewlines: _variables.length == 1 || state != State.unsplit);
+      writer.format(_variables[i]);
     }
 
     if (state == _betweenVariables) writer.popIndent();

--- a/test/tall/declaration/class_comment.unit
+++ b/test/tall/declaration/class_comment.unit
@@ -20,7 +20,9 @@ class C {
 >>> Empty class containing inline block comment.
 class C {   /* comment */  }
 <<<
-class C {/* comment */}
+class C {
+  /* comment */
+}
 >>> Empty class containing non-inline block comment.
 class C {
 

--- a/test/tall/declaration/extension_type_comment.unit
+++ b/test/tall/declaration/extension_type_comment.unit
@@ -12,7 +12,9 @@ extension /*b*/ type /*c*/ A
 ) /*j*/
     implements /*k*/
         I1 /*l*/, /*m*/
-        I2 /*n*/ {/*o*/} /*p*/
+        I2 /*n*/ {
+  /*o*/
+} /*p*/
 >>> Line comments everywhere.
 // 0
 @patch // a

--- a/test/tall/statement/block_comment.stmt
+++ b/test/tall/statement/block_comment.stmt
@@ -9,7 +9,9 @@
 >>> Empty block containing inline block comment.
 {   /* comment */  }
 <<<
-{/* comment */}
+{
+  /* comment */
+}
 >>> Empty block containing non-inline block comment.
 {
 

--- a/test/tall/statement/switch_comment.stmt
+++ b/test/tall/statement/switch_comment.stmt
@@ -135,13 +135,19 @@ switch (e) {
 switch (e) {/* comment */
 }
 <<<
-switch (e) {/* comment */}
+switch (e) {
+  /* comment */
+}
 >>> Block comment with leading newline.
 switch (e) {
   /* comment */}
 <<<
-switch (e) {/* comment */}
+switch (e) {
+  /* comment */
+}
 >>> Inline block comment.
 switch (e) {  /* comment */  }
 <<<
-switch (e) {/* comment */}
+switch (e) {
+  /* comment */
+}


### PR DESCRIPTION
Propagate newline constrains eagerly when binding states in a Solution.

One of the main ways the formatter defines its formatting style is by having constraints that prohibit newlines in some child pieces when a parent is in a given state.

The two simplest examples (which cover a large amount of code) is that when an InfixPiece or a ListPiece is in State.unsplit, they don't allow any newlines in any of their children. That constraint effectively creates the desired style which is that a split inside an infix operand or list element forces the surrounding expression to split.

Whenever we bind a parent piece to some state, we can now ask it if it allows any of its children to contain newlines. For any given child, if the answer is "no" then:

-   If the child is already bound to a state that contains newlines, then we know this solution is a dead end. It and every solution you can ever derive from it will contain an invalid newline.

-   If the child isn't bound to a state yet, we can still look at all of its states and see which of them contain newlines. Any state that does can be eliminated because we'll never successfully bind the child to that state without violating this constraint.

    It may turn out that no states are left, in which case again we have a dead end solution.

    Or there may be just one valid state (usually State.unsplit), and we can immediately the child to that state and do this whole process recursively for this child.

    Or there may be just a couple of states left and we can at least winnow this child's states down to that list when we go to expand it later.

The end result is that even before actually formatting a solution, we can often tell if it's a dead end and discard it. If not, we can often bind a whole bunch of the bound piece's children in one go instead of having to do them one at a time and slowly formatting the interim solutions at each step.

The end result is a pretty decent improvement. Here's the micro benchmarks:

```
Benchmark (tall)                fastest   median  slowest  average  baseline
-----------------------------  --------  -------  -------  -------  --------
block                             0.070    0.071    0.122    0.075     92.7%
chain                             0.640    0.654    0.681    0.655    254.5%
collection                        0.175    0.180    0.193    0.181     96.3%
collection_large                  0.930    0.955    0.988    0.955     97.2%
conditional                       0.067    0.068    0.086    0.071    132.4%
curry                             0.596    0.608    1.478    0.631    278.9%
flutter_popup_menu_test           0.293    0.302    0.326    0.303    141.4%
flutter_scrollbar_test            0.160    0.166    0.184    0.166     96.1%
function_call                     1.460    1.483    1.680    1.490     97.5%
infix_large                       0.709    0.733    0.761    0.733     97.4%
infix_small                       0.175    0.181    0.198    0.181     93.0%
interpolation                     0.091    0.096    0.118    0.096     98.7%
large                             3.514    3.574    3.767    3.596    129.5%
top_level                         0.146    0.150    0.182    0.152    106.7%
```

There's a slight regression on some of the tiny microbenchmarks (probably because there's some overhead traversing and binding children to State.unsplit when that solution ends up winning anyway). But the improvement to the larger ones is significant.

More interesting is the overall performance. Here's formatting the Flutter repo:

```
Current formatter     10.964 ========================================
This PR                8.826 ================================
Short style formatter  4.558 ================
```

The current formatter is 58.43% slower than the old short style formatter.

This PR is 24.22% faster than the current formatter. It's 48.36% slower than the old formatter, but it gets the formatter 33.37% of the way to the old short style one.
