### PR TITLE
Make testBenchmarks() synchronous.

### DIFF
--- a/benchmark/run.dart
+++ b/benchmark/run.dart
@@ -16,6 +16,7 @@ import 'package:dart_style/src/front_end/ast_node_visitor.dart';
 import 'package:dart_style/src/profile.dart';
 import 'package:dart_style/src/short/source_visitor.dart';
 import 'package:dart_style/src/testing/benchmark.dart';
+import 'package:dart_style/src/testing/test_file.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 
@@ -71,9 +72,7 @@ Future<void> main(List<String> arguments) async {
     }
   }
 
-  if (_runWarmupTrials) {
-    await _warmUp();
-  }
+  if (_runWarmupTrials) _warmUp();
 
   var results = <(Benchmark, List<double>)>[];
   for (var benchmark in benchmarks) {
@@ -110,8 +109,8 @@ Future<void> main(List<String> arguments) async {
 /// Since the benchmarks are run on the VM, JIT warm-up has a large impact on
 /// performance. Warming up the VM gives it time for the optimized compiler to
 /// kick in.
-Future<void> _warmUp() async {
-  var benchmark = await Benchmark.read('benchmark/case/large.unit');
+void _warmUp() {
+  var benchmark = Benchmark.read('benchmark/case/large.unit');
   _runTrials('Warming up', benchmark, _warmUpTrials);
 }
 
@@ -209,16 +208,14 @@ Future<List<Benchmark>> _parseArguments(List<String> arguments) async {
 
   var benchmarks = switch (argResults.rest) {
     // Find all the benchmarks.
-    ['all'] => await Benchmark.findAll(),
+    ['all'] => Benchmark.findAll(await findPackageDirectory()),
 
     // Default to the large benchmark.
-    [] => [
-        await Benchmark.read(p.join(_benchmarkDirectory, 'case/large.unit'))
-      ],
+    [] => [Benchmark.read(p.join(_benchmarkDirectory, 'case/large.unit'))],
 
     // The user-specified list of paths.
     [...var paths] when paths.isNotEmpty => [
-        for (var path in paths) await Benchmark.read(path)
+        for (var path in paths) Benchmark.read(path)
       ],
     _ => _usage(argParser, exitCode: 64),
   };

--- a/lib/src/testing/benchmark.dart
+++ b/lib/src/testing/benchmark.dart
@@ -6,18 +6,15 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-import 'test_file.dart';
-
 class Benchmark {
-  /// Finds all of the benchmarks in the `benchmark/cases` directory.
-  static Future<List<Benchmark>> findAll() async {
-    var casesDirectory =
-        Directory(p.join(await findPackageDirectory(), 'benchmark/case'));
+  /// Finds all of the benchmarks in the `benchmark/cases` directory, relative
+  /// to [packageDirectory].
+  static List<Benchmark> findAll(String packageDirectory) {
+    var casesDirectory = Directory(p.join(packageDirectory, 'benchmark/case'));
 
     var benchmarks = [
       for (var entry in casesDirectory.listSync())
-        if (p.extension(entry.path) case '.unit' || '.stmt')
-          await read(entry.path)
+        if (p.extension(entry.path) case '.unit' || '.stmt') read(entry.path)
     ];
 
     benchmarks.sort((a, b) => a.name.compareTo(b.name));
@@ -30,8 +27,8 @@ class Benchmark {
   /// This should point to a `.unit` or `.stmt` file that has a corresponding
   /// `.expect` and `expect_short` file in the same directory with those
   /// expectations.
-  static Future<Benchmark> read(String path) async {
-    var inputLines = await File(path).readAsLines();
+  static Benchmark read(String path) {
+    var inputLines = File(path).readAsLinesSync();
 
     // The first line may have a "|" to indicate the page width.
     var pageWidth = 80;
@@ -43,8 +40,8 @@ class Benchmark {
     var input = inputLines.join('\n');
 
     var shortOutput =
-        await File(p.setExtension(path, '.expect_short')).readAsString();
-    var tallOutput = await File(p.setExtension(path, '.expect')).readAsString();
+        File(p.setExtension(path, '.expect_short')).readAsStringSync();
+    var tallOutput = File(p.setExtension(path, '.expect')).readAsStringSync();
 
     return Benchmark(
         name: p.basenameWithoutExtension(path),

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -142,7 +142,7 @@ Future<void> testFile(String path, {Iterable<StyleFix>? fixes}) async {
 
 /// Format all of the benchmarks and ensure they produce their expected outputs.
 Future<void> testBenchmarks({required bool useTallStyle}) async {
-  var benchmarks = await Benchmark.findAll();
+  var benchmarks = Benchmark.findAll(await findPackageDirectory());
 
   group('Benchmarks', () {
     for (var benchmark in benchmarks) {


### PR DESCRIPTION
This avoids calling group() after an async pause, which breaks running short_format_test.dart and tall_format_test.dart outside of the test runner.

cc @scheglov 