### PR TITLE
Fix firstNonCommentToken in anticipation of analyzer fix.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -18,6 +18,9 @@ extension AstNodeExtensions on AstNode {
     return switch (this) {
       AnnotatedNode(metadata: [var annotation, ...]) => annotation.beginToken,
       AnnotatedNode(firstTokenAfterCommentAndMetadata: var token) => token,
+      // DefaultFormalParameter is not an AnnotatedNode, but its first child
+      // (parameter) *is* an AnnotatedNode, so we can't just use beginToken.
+      DefaultFormalParameter(:var parameter) => parameter.firstNonCommentToken,
       _ => beginToken
     };
   }


### PR DESCRIPTION
This commit fixes a subtle bug in the formatter which is currently covered up by an analyzer bug. The formatter bug is this: `AstNodeExtensions.firstNonCommentToken` assumes that if an AST node doesn't implement `AnnotatedNode`, then it can't possibly begin with a documentation comment, so it is safe to simply defer to `beginToken`. But that isn't true `DefaultFormalParameter` doesn't implement `AnnotatedNode`, but its first child is a `NormalFormalParameter`, which *can* begin with a documentation comment.

Currently, analyzer bug https://github.com/dart-lang/sdk/issues/56313 prevents `NormalFormalParameter.beginToken` from properly accounting for the presence of the documentation comment, so as a result, `AstNodeExtensions.firstNonCommentToken` works correctly on `DefaultFormalParameter`. In order to avoid breaking the formatter when I fix the analyzer bug, I need to first fix the formatter.

The formatter fix is for `AstNodeExtensions.firstNonCommentToken` to recognize that `DefaultFormalParameter` is unusual, and to compute its first non-comment token directly (by looking at the first non-cmoment token of its first child, `parameter`). The formatter fix works regardless of whether the analyzer bug is fixed, so it is safe to land the formatter fix first.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
