### PR TITLE
Allow passing a language version to the formatter CLI.

### DIFF
--- a/lib/src/cli/format_command.dart
+++ b/lib/src/cli/format_command.dart
@@ -4,7 +4,9 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:pub_semver/pub_semver.dart';
 
+import '../dart_formatter.dart';
 import '../io.dart';
 import '../short/style_fix.dart';
 import 'formatter_options.dart';
@@ -87,6 +89,20 @@ class FormatCommand extends Command<int> {
       usageException('Cannot print a summary with JSON output.');
     }
 
+    Version? languageVersion;
+    if (argResults['language-version'] case String version) {
+      var versionPattern = RegExp(r'^([0-9]+)\.([0-9]+)$');
+      if (version == 'latest') {
+        languageVersion = DartFormatter.latestLanguageVersion;
+      } else if (versionPattern.firstMatch(version) case var match?) {
+        languageVersion =
+            Version(int.parse(match[1]!), int.parse(match[2]!), 0);
+      } else {
+        usageException('--language-version must be a version like "3.2" or '
+            '"latest", was "$version".');
+      }
+    }
+
     var pageWidth = int.tryParse(argResults['line-length'] as String) ??
         usageException('--line-length must be an integer, was '
             '"${argResults['line-length']}".');
@@ -140,6 +156,7 @@ class FormatCommand extends Command<int> {
     var stdinName = argResults['stdin-name'] as String;
 
     var options = FormatterOptions(
+        languageVersion: languageVersion,
         indent: indent,
         pageWidth: pageWidth,
         followLinks: followLinks,

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -4,6 +4,8 @@
 
 import 'dart:io';
 
+import 'package:pub_semver/pub_semver.dart';
+
 import '../short/style_fix.dart';
 import '../source_code.dart';
 import 'output.dart';
@@ -15,6 +17,10 @@ const dartStyleVersion = '2.3.6';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 class FormatterOptions {
+  /// The language version formatted code should be parsed at or `null` if not
+  /// specified.
+  final Version? languageVersion;
+
   /// The number of spaces of indentation to prefix the output with.
   final int indent;
 
@@ -45,7 +51,8 @@ class FormatterOptions {
   final List<String> experimentFlags;
 
   FormatterOptions(
-      {this.indent = 0,
+      {this.languageVersion,
+      this.indent = 0,
       this.pageWidth = 80,
       this.followLinks = false,
       Iterable<StyleFix>? fixes,

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -67,6 +67,13 @@ void defineOptions(ArgParser parser,
         },
         defaultsTo: 'line',
         hide: !verbose);
+
+    parser.addOption('language-version',
+        help: 'Language version of formatted code.\n'
+            'Use "latest" to parse as the latest supported version.\n'
+            'Omit to look for a surrounding package config.',
+        // TODO(rnystrom): Show this when package config support is implemented.
+        hide: true);
   }
 
   parser.addFlag('set-exit-if-changed',

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -27,6 +27,7 @@ Future<void> formatStdin(
   var input = StringBuffer();
   stdin.transform(const Utf8Decoder()).listen(input.write, onDone: () {
     var formatter = DartFormatter(
+        languageVersion: options.languageVersion,
         indent: options.indent,
         pageWidth: options.pageWidth,
         fixes: options.fixes,
@@ -137,6 +138,7 @@ bool processFile(FormatterOptions options, File file, {String? displayPath}) {
   displayPath ??= file.path;
 
   var formatter = DartFormatter(
+      languageVersion: options.languageVersion,
       indent: options.indent,
       pageWidth: options.pageWidth,
       fixes: options.fixes,

--- a/test/dart_formatter_test.dart
+++ b/test/dart_formatter_test.dart
@@ -33,6 +33,7 @@ void main() async {
       expect(() => formatter.format('main() {switch (o) {case 1+2: break;}}'),
           throwsA(isA<FormatterException>()));
     });
+
     test('@dart comment overrides version', () {
       // Use a language version after patterns were supported and `1 + 2` is an
       // error.


### PR DESCRIPTION
This option is hidden for now because support for traversing the surrounding directories to look for a package config isn't implemented yet. Once that's working too, I'll make the option visible.

This just adds support for explicitly specifying a version through the command line.
