### PR TITLE
Use surrounding packages to infer language version in the CLI.

### DIFF
--- a/bin/format.dart
+++ b/bin/format.dart
@@ -138,7 +138,7 @@ void main(List<String> args) async {
   if (argResults.rest.isEmpty) {
     await formatStdin(options, selection, argResults['stdin-name'] as String);
   } else {
-    formatPaths(options, argResults.rest);
+    await formatPaths(options, argResults.rest);
   }
 
   options.summary.show();

--- a/lib/src/cli/format_command.dart
+++ b/lib/src/cli/format_command.dart
@@ -170,7 +170,7 @@ class FormatCommand extends Command<int> {
     if (argResults.rest.isEmpty) {
       await formatStdin(options, selection, stdinName);
     } else {
-      formatPaths(options, argResults.rest);
+      await formatPaths(options, argResults.rest);
       options.summary.show();
     }
 

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -72,7 +72,7 @@ void defineOptions(ArgParser parser,
         help: 'Language version of formatted code.\n'
             'Use "latest" to parse as the latest supported version.\n'
             'Omit to look for a surrounding package config.',
-        // TODO(rnystrom): Show this when package config support is implemented.
+        // TODO(rnystrom): Show this when the tall-style experiment ships.
         hide: true);
   }
 

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -244,10 +244,9 @@ class DartFormatter {
         sdkLanguageVersion: version, flags: experiments);
 
     return parseString(
-      content: source,
-      featureSet: featureSet,
-      path: uri,
-      throwIfDiagnostics: false,
-    );
+        content: source,
+        featureSet: featureSet,
+        path: uri,
+        throwIfDiagnostics: false);
   }
 }

--- a/lib/src/language_version_cache.dart
+++ b/lib/src/language_version_cache.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+import 'dart:io';
+
+import 'package:package_config/package_config.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import 'profile.dart';
+
+/// Caches the default language version that should be used for files within
+/// directories.
+///
+/// The default language version for a Dart file is found by walking the parent
+/// directories of the file being formatted to look for a
+/// `.dart_tool/package_config.json` file. When found, we cache the result for
+/// the formatted file's parent directory. This way, when formatting multiple
+/// files in the same directory, we don't have to look for and read the package
+/// config multiple times, which is slow.
+///
+/// (When formatting dart_style on a Mac laptop, it would spend as much time
+/// looking for package configs for each file as it did formatting if we don't
+/// cache. Caching makes it ~10x faster to find the language version for each
+/// file.)
+class LanguageVersionCache {
+  /// The previously cached default language version for all files immediately
+  /// within a given directory.
+  ///
+  /// The version may be `null` if we formatted a file in that directory and
+  /// discovered that there is no surrounding package.
+  final Map<String, Version?> _directoryVersions = {};
+
+  /// Looks for a package surrounding [file] and, if found, returns the default
+  /// language version specified by that package.
+  Future<Version?> find(File file) async {
+    Profile.begin('look up package config');
+    try {
+      // Use the cached version (which may be `null`) if present.
+      var directory = file.parent.path;
+      if (_directoryVersions.containsKey(directory)) {
+        return _directoryVersions[directory];
+      }
+
+      // Otherwise, walk the file system and look for it.
+      var config = await findPackageConfig(file.parent);
+      if (config?.packageOf(file.absolute.uri)?.languageVersion
+          case var languageVersion?) {
+        // Store the version as pub_semver's [Version] type because that's
+        // what the analyzer parser uses, which is where the version
+        // ultimately gets used.
+        var version = Version(languageVersion.major, languageVersion.minor, 0);
+        return _directoryVersions[directory] = version;
+      }
+
+      // We weren't able to resolve this file's directory, so don't try again.
+      return _directoryVersions[directory] = null;
+    } finally {
+      Profile.end('look up package config');
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   analyzer: '^6.5.0'
   args: ">=1.0.0 <3.0.0"
   collection: "^1.17.0"
+  package_config: ^2.1.0
   path: ^1.0.0
   pub_semver: ">=1.4.4 <3.0.0"
   source_span: ^1.4.0

--- a/test/command_test.dart
+++ b/test/command_test.dart
@@ -576,5 +576,116 @@ main() {
       await process.stderr.cancel();
       await process.shouldExit(65);
     });
+
+    group('package config', () {
+      // TODO(rnystrom): Remove this test when the experiment ships.
+      test('no package search if experiment is off', () async {
+        // Put the file in a directory with a malformed package config. If we
+        // search for it, we should get an error.
+        await d.dir('foo', [
+          d.dir('.dart_tool', [
+            d.file('package_config.json', 'this no good json is bad json'),
+          ]),
+          d.file('main.dart', 'main(){    }'),
+        ]).create();
+
+        var process = await runCommandOnDir();
+        await process.shouldExit(0);
+
+        // Should format the file without any error reading the package config.
+        await d.dir('foo', [d.file('main.dart', 'main() {}\n')]).validate();
+      });
+
+      test('no package search if language version is specified', () async {
+        // Put the file in a directory with a malformed package config. If we
+        // search for it, we should get an error.
+        await d.dir('foo', [
+          d.dir('.dart_tool', [
+            d.file('package_config.json', 'this no good json is bad json'),
+          ]),
+          d.file('main.dart', 'main(){    }'),
+        ]).create();
+
+        var process = await runCommandOnDir(
+            ['--language-version=latest', '--enable-experiment=tall-style']);
+        await process.shouldExit(0);
+
+        // Should format the file without any error reading the package config.
+        await d.dir('foo', [d.file('main.dart', 'main() {}\n')]).validate();
+      });
+
+      test('default to language version of surrounding package', () async {
+        // The package config sets the language version to 3.1, but the switch
+        // case uses a syntax which is valid in earlier versions of Dart but an
+        // error in 3.0 and later. Verify that the error is reported (instead of
+        // the formatter falling back to try to parse the file at the older
+        // language version).
+        await d.dir('foo', [
+          packageConfig('foo', 3, 1),
+          d.file('main.dart', 'main() { switch (o) { case 1 + 2: break; } }'),
+        ]).create();
+
+        var path = p.join(d.sandbox, 'foo', 'main.dart');
+        // TODO(rnystrom): Remove experiment flag when it ships.
+        var process =
+            await runCommand([path, '--enable-experiment=tall-style']);
+
+        expect(await process.stderr.next,
+            'Could not format because the source could not be parsed:');
+        expect(await process.stderr.next, '');
+        expect(await process.stderr.next, contains(p.join('foo', 'main.dart')));
+        await process.shouldExit(65);
+      });
+
+      test('language version comment overrides package default', () async {
+        // The package config sets the language version to 3.1, but the switch
+        // case uses a syntax which is valid in earlier versions of Dart but an
+        // error in 3.0 and later. Verify that no error is reported since this
+        // file opts to the older version.
+        await d.dir('foo', [
+          packageConfig('foo', 3, 1),
+          d.file('main.dart', '''
+          // @dart=2.19
+          main() { switch (obj) { case 1 + 2: // Error in 3.1.
+            } }
+          '''),
+        ]).create();
+
+        var process = await runCommandOnDir();
+        await process.shouldExit(0);
+
+        // Formats the file.
+        await d.dir('foo', [
+          d.file('main.dart', '''
+// @dart=2.19
+main() {
+  switch (obj) {
+    case 1 + 2: // Error in 3.1.
+  }
+}
+''')
+        ]).validate();
+      });
+
+      test('malformed', () async {
+        await d.dir('foo', [
+          d.dir('.dart_tool', [
+            d.file('package_config.json', 'this no good json is bad json'),
+          ]),
+          d.file('main.dart', 'main() {}'),
+        ]).create();
+
+        var path = p.join(d.sandbox, 'foo', 'main.dart');
+        // TODO(rnystrom): Remove experiment flag when it ships.
+        var process =
+            await runCommand([path, '--enable-experiment=tall-style']);
+
+        expect(
+            await process.stderr.next,
+            allOf(startsWith('Could not read package configuration for'),
+                contains(p.join('foo', 'main.dart'))));
+        await process.shouldExit(65);
+      });
+    });
   });
 }

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -21,8 +21,7 @@ void main() {
       d.file('a.dart', unformattedSource),
     ]).create();
 
-    var dir = Directory(d.sandbox);
-    processDirectory(overwriteOptions, dir);
+    await formatPaths(overwriteOptions, [d.sandbox]);
 
     await d.dir('code.dart', [
       d.file('a.dart', formattedSource),
@@ -44,8 +43,7 @@ void main() {
     // Wait a bit so the mod time of a formatted file will be different.
     await Future<void>.delayed(const Duration(seconds: 1));
 
-    var dir = Directory(p.join(d.sandbox, 'code'));
-    processDirectory(overwriteOptions, dir);
+    await formatPaths(overwriteOptions, [p.join(d.sandbox, 'code')]);
 
     // Should be touched.
     var badAfter = modTime('bad.dart');
@@ -61,8 +59,7 @@ void main() {
       d.dir('.skip', [d.file('a.dart', unformattedSource)])
     ]).create();
 
-    var dir = Directory(d.sandbox);
-    processDirectory(overwriteOptions, dir);
+    await formatPaths(overwriteOptions, [d.sandbox]);
 
     await d.dir('code', [
       d.dir('.skip', [d.file('a.dart', unformattedSource)])
@@ -73,8 +70,7 @@ void main() {
       () async {
     await d.dir('.code', [d.file('a.dart', unformattedSource)]).create();
 
-    var dir = Directory(p.join(d.sandbox, '.code'));
-    processDirectory(overwriteOptions, dir);
+    await formatPaths(overwriteOptions, [p.join(d.sandbox, '.code')]);
 
     await d.dir('.code', [d.file('a.dart', formattedSource)]).validate();
   });
@@ -92,8 +88,7 @@ void main() {
     Link(p.join(d.sandbox, 'code', 'linked_dir'))
         .createSync(p.join(d.sandbox, 'target_dir'));
 
-    var dir = Directory(p.join(d.sandbox, 'code'));
-    processDirectory(overwriteOptions, dir);
+    await formatPaths(overwriteOptions, [p.join(d.sandbox, 'code')]);
 
     await d.dir('code', [
       d.file('a.dart', formattedSource),
@@ -116,8 +111,7 @@ void main() {
     Link(p.join(d.sandbox, 'code', 'linked_dir'))
         .createSync(p.join(d.sandbox, 'target_dir'));
 
-    var dir = Directory(p.join(d.sandbox, 'code'));
-    processDirectory(followOptions, dir);
+    await formatPaths(followOptions, [p.join(d.sandbox, 'code')]);
 
     await d.dir('code', [
       d.file('a.dart', formattedSource),
@@ -135,8 +129,7 @@ void main() {
 
       Process.runSync('chmod', ['-w', p.join(d.sandbox, 'a.dart')]);
 
-      var file = File(p.join(d.sandbox, 'a.dart'));
-      processFile(overwriteOptions, file);
+      await formatPaths(overwriteOptions, [p.join(d.sandbox, 'a.dart')]);
 
       // Should not have been formatted.
       await d.file('a.dart', unformattedSource).validate();
@@ -150,8 +143,7 @@ void main() {
       Link(p.join(d.sandbox, 'code', 'linked_file.dart'))
           .createSync(p.join(d.sandbox, 'target_file.dart'));
 
-      var dir = Directory(p.join(d.sandbox, 'code'));
-      processDirectory(overwriteOptions, dir);
+      await formatPaths(overwriteOptions, [p.join(d.sandbox, 'code')]);
 
       await d.dir('code', [
         d.file('linked_file.dart', unformattedSource),
@@ -166,8 +158,7 @@ void main() {
       Link(p.join(d.sandbox, 'code', 'linked_file.dart'))
           .createSync(p.join(d.sandbox, 'target_file.dart'));
 
-      var dir = Directory(p.join(d.sandbox, 'code'));
-      processDirectory(followOptions, dir);
+      await formatPaths(followOptions, [p.join(d.sandbox, 'code')]);
 
       await d.dir('code', [
         d.file('linked_file.dart', formattedSource),

--- a/test/language_version_cache_test.dart
+++ b/test/language_version_cache_test.dart
@@ -1,0 +1,140 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:io';
+
+import 'package:dart_style/src/language_version_cache.dart';
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import 'utils.dart';
+
+const _source = 'f() {}';
+
+void main() {
+  test('no surrounding package config', () async {
+    // Note: In theory this test could fail if machine it's run on happens to
+    // have a `.dart_tool` directory containing a package config in one of the
+    // parent directories of the system temporary directory.
+
+    await d.dir('dir', [d.file('main.dart', _source)]).create();
+
+    var cache = LanguageVersionCache();
+    await _expectNullVersion(cache, 'dir/main.dart');
+  });
+
+  test('language version from package config', () async {
+    await d.dir('foo', [
+      packageConfig('foo', 3, 4),
+      d.file('main.dart', _source),
+    ]).create();
+
+    var cache = LanguageVersionCache();
+    await _expectVersion(cache, 'foo/main.dart', 3, 4);
+  });
+
+  test('multiple packages in directory', () async {
+    await d.dir('parent', [
+      _makePackage('foo', 3, 4),
+      _makePackage('bar', 3, 5),
+    ]).create();
+
+    var cache = LanguageVersionCache();
+    await _expectVersion(cache, 'parent/foo/main.dart', 3, 4);
+    await _expectVersion(cache, 'parent/bar/main.dart', 3, 5);
+  });
+
+  test('multiple files in same package', () async {
+    await _makePackage('foo', 3, 4, [
+      d.file('main.dart', _source),
+      d.dir('sub', [
+        d.file('another.dart', _source),
+        d.dir('further', [
+          d.file('third.dart', _source),
+        ]),
+      ]),
+    ]).create();
+
+    var cache = LanguageVersionCache();
+    await _expectVersion(cache, 'foo/main.dart', 3, 4);
+    await _expectVersion(cache, 'foo/sub/another.dart', 3, 4);
+    await _expectVersion(cache, 'foo/sub/further/third.dart', 3, 4);
+  });
+
+  test('some files in package, some not', () async {
+    await d.dir('parent', [
+      _makePackage('foo', 3, 4),
+      d.file('outside.dart', _source),
+      d.dir('sub', [
+        d.file('another.dart', _source),
+      ]),
+    ]).create();
+
+    var cache = LanguageVersionCache();
+    await _expectVersion(cache, 'parent/foo/main.dart', 3, 4);
+    await _expectNullVersion(cache, 'parent/outside.dart');
+    await _expectNullVersion(cache, 'parent/sub/another.dart');
+  });
+
+  test('non-existent file', () async {
+    await d.dir('dir', []).create();
+
+    var cache = LanguageVersionCache();
+    await _expectNullVersion(cache, 'dir/does_not_exist.dart');
+  });
+
+  test('non-existent directory', () async {
+    await d.dir('dir', []).create();
+
+    var cache = LanguageVersionCache();
+    await _expectNullVersion(cache, 'dir/does/not/exist.dart');
+  });
+
+  test('nested package', () async {
+    await _makePackage('outer', 3, 4, [
+      d.file('out_main.dart', _source),
+      _makePackage('inner', 3, 5, [
+        d.file('in_main.dart', _source),
+      ])
+    ]).create();
+
+    var cache = LanguageVersionCache();
+    await _expectVersion(cache, 'outer/out_main.dart', 3, 4);
+    await _expectVersion(cache, 'outer/inner/in_main.dart', 3, 5);
+  });
+}
+
+Future<void> _expectVersion(
+    LanguageVersionCache cache, String path, int major, int minor) async {
+  expect(await cache.find(_expectedFile(path)), Version(major, minor, 0));
+}
+
+Future<void> _expectNullVersion(LanguageVersionCache cache, String path) async {
+  expect(await cache.find(_expectedFile(path)), null);
+}
+
+/// Normalize path separators to the host OS separator since that's what the
+/// cache uses.
+File _expectedFile(String path) => File(
+      p.joinAll([d.sandbox, ...p.posix.split(path)]),
+    );
+
+/// Create a test package with [packageName] containing a package config with
+/// language version [major].[minor].
+///
+/// If [files] is given, then the package contains those files, otherwise it
+/// contains a default `main.dart` file.
+d.DirectoryDescriptor _makePackage(
+  String packageName,
+  int major,
+  int minor, [
+  List<d.Descriptor>? files,
+]) {
+  files ??= [d.file('main.dart', _source)];
+  return d.dir(packageName, [
+    packageConfig(packageName, major, minor),
+    ...files,
+  ]);
+}

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -223,3 +223,22 @@ void _testFile(TestFile testFile, Iterable<StyleFix>? baseFixes) {
     }
   });
 }
+
+/// Create a test `.dart_tool` directory with a package config for a package
+/// with [packageName] and language version [major].[minor].
+d.DirectoryDescriptor packageConfig(String packageName, int major, int minor) {
+  var config = '''
+  {
+    "configVersion": 2,
+    "packages": [
+      {
+        "name": "$packageName",
+        "rootUri": "../",
+        "packageUri": "lib/",
+        "languageVersion": "$major.$minor"
+      }
+    ]
+  }''';
+
+  return d.dir('.dart_tool', [d.file('package_config.json', config)]);
+}


### PR DESCRIPTION
When formatting file paths using the formatter CLI, look for a surrounding package (identified by a package config) to infer the default (i.e. not `// @dart=`) language version for each formatted file.

Currently, this behavior only happens when the tall-style experiment is enabled. When that experiment ships, it will be the default behavior. If the user passes an explicit language version using "--language-version", then no directory searching happens.

This only affects the CLI behavior. The library API never searches the file system. Also, when passing input to the formatter CLI over stdin, it doesn't search the file system.
