### PR TITLE
Force a cascade to split if an indirect method call section splits.

### DIFF
--- a/lib/src/front_end/chain_builder.dart
+++ b/lib/src/front_end/chain_builder.dart
@@ -78,11 +78,25 @@ class ChainBuilder {
         var piece = _visitor.nodePiece(section);
 
         var callType = switch (section) {
+          // If the section is itself a method chain, then force the cascade to
+          // split if the method does, as in:
+          //
+          //     cascadeTarget
+          //       ..methodTarget.method(
+          //         argument,
+          //       );
+          MethodInvocation(target: _?) => CallType.unsplittableCall,
+
+          // Otherwise, allow a direct method call in the cascade to not split
+          // the cascade if the arguments can split, as in:
+          //
+          //     cascadeTarget..method(
+          //       argument,
+          //     );
           MethodInvocation(argumentList: var args)
               when args.arguments.canSplit(args.rightParenthesis) =>
             CallType.splittableCall,
-          MethodInvocation() => CallType.unsplittableCall,
-          _ => CallType.property,
+          _ => CallType.unsplittableCall,
         };
 
         _calls.add(ChainCall(piece, callType));

--- a/test/tall/regression/0400/0407.unit
+++ b/test/tall/regression/0400/0407.unit
@@ -11,9 +11,10 @@ void main() {
         (new Account()
           ..accountId = new Int64(111)
           ..tags =
-              (new Account_Tags()..accountHotlist.add(
-                new Hotlist()..hotlistId = new Int64(10),
-              )));
+              (new Account_Tags()
+                ..accountHotlist.add(
+                  new Hotlist()..hotlistId = new Int64(10),
+                )));
 }
 >>> (indent 4)
 main() {

--- a/test/tall/regression/0400/0489.stmt
+++ b/test/tall/regression/0400/0489.stmt
@@ -3,8 +3,9 @@ longerNamedFoo..items.add(new Foo()
   ..name = bar.toto
   ..placeUrl = place.toString());
 <<<
-longerNamedFoo..items.add(
-  new Foo()
-    ..name = bar.toto
-    ..placeUrl = place.toString(),
-);
+longerNamedFoo
+  ..items.add(
+    new Foo()
+      ..name = bar.toto
+      ..placeUrl = place.toString(),
+  );

--- a/test/tall/regression/0800/0881.unit
+++ b/test/tall/regression/0800/0881.unit
@@ -24,7 +24,7 @@ void main() async {
   });
 }
 <<<
-### TODO(1466): Should allow the `FakeRequestHandler()` target after the `=>`.
+### TODO(1466): Should allow the `FakeRequestHandler()` target after the `=`.
 void main() async {
   group('my group', () {
     setUp(() async {
@@ -33,13 +33,14 @@ void main() async {
             ..when(
               withServiceName(Ng2ProtoFooBarBazService.serviceName),
             ).thenRespond(
-              FooBarBazListResponse()..entities.add(
-                FooBarBaz()
-                  ..fooBarBazEntityId = entityId
-                  ..name = 'Test entity'
-                  ..baseFooBarBazId = baseFooBarBazId
-                  ..entityFooBarBazId = entityFooBarBazId,
-              ),
+              FooBarBazListResponse()
+                ..entities.add(
+                  FooBarBaz()
+                    ..fooBarBazEntityId = entityId
+                    ..name = 'Test entity'
+                    ..baseFooBarBazId = baseFooBarBazId
+                    ..entityFooBarBazId = entityFooBarBazId,
+                ),
             )
             ..when(
               allOf(

--- a/test/tall/regression/other/misc.stmt
+++ b/test/tall/regression/other/misc.stmt
@@ -1,0 +1,14 @@
+40 columns                              |
+>>>
+someLongExpression..prop.cascade(
+  argument,
+  argument,
+  argument,
+);
+<<<
+someLongExpression
+  ..prop.cascade(
+    argument,
+    argument,
+    argument,
+  );


### PR DESCRIPTION
We always split a cascade if it has multiple sections. We don't require it to split if it has only one:

```dart
cascadeTarget..method(argument);
```

We also don't require it to split if the section is a method call whose argument list splits:

```dart
cascadeTarget..method(
  argument,
);
```

But the section might not be an immediate method call like `method()` here. It could be some longer call chain as in:

```dart
cascadeTarget..some.property.chain.method(argument);
```

In that case, if the ultimate trailing argument list splits, I think it's better to force the cascade section to split too:

```dart
cascadeTarget..some.property.chain.method(
  argument,
);

// Better:
cascadeTarget
  ..some.property.chain.method(
    argument,
  );
```

Otherwise, I think the preceding call chain gets sort of buried in the line with the cascade target.

This makes that change.
