### PR TITLE
If a class's type parameters split, force the clauses to split too.

### DIFF
--- a/lib/src/piece/type.dart
+++ b/lib/src/piece/type.dart
@@ -2,18 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../back_end/code_writer.dart';
-import 'clause.dart';
 import 'piece.dart';
 
 /// Piece for a type declaration with a body containing members.
 ///
 /// Used for class, enum, and extension declarations.
 class TypePiece extends Piece {
-  /// The leading keywords and modifiers, type name, and type parameters.
+  /// The leading keywords and modifiers, type name, type parameters, and any
+  /// other `extends`, `with`, etc. clauses.
   final Piece _header;
-
-  /// The `extends`, `with`, and/or `implements` clauses, if there are any.
-  final ClausePiece? _clauses;
 
   /// The `native` clause, if any, and the type body.
   final Piece _body;
@@ -21,8 +18,7 @@ class TypePiece extends Piece {
   /// What kind of body the type has.
   final TypeBodyType _bodyType;
 
-  TypePiece(this._header, this._clauses, this._body,
-      {required TypeBodyType bodyType})
+  TypePiece(this._header, this._body, {required TypeBodyType bodyType})
       : _bodyType = bodyType;
 
   @override
@@ -47,10 +43,6 @@ class TypePiece extends Piece {
   @override
   void format(CodeWriter writer, State state) {
     writer.format(_header);
-    if (_clauses case var clauses?) {
-      writer.format(clauses);
-    }
-
     if (_bodyType != TypeBodyType.semicolon) writer.space();
     writer.format(_body);
   }
@@ -58,7 +50,6 @@ class TypePiece extends Piece {
   @override
   void forEachChild(void Function(Piece piece) callback) {
     callback(_header);
-    if (_clauses case var clauses?) callback(clauses);
     callback(_body);
   }
 }

--- a/test/tall/declaration/class_clause.unit
+++ b/test/tall/declaration/class_clause.unit
@@ -252,3 +252,20 @@ class C extends A
           LongTypeArgument,
           AnotherLongType
         > {}
+>>> Split in class type parameters forces clause to split.
+class C<LongTypeParameter, AnotherLongType> extends Other {}
+<<<
+class C<
+  LongTypeParameter,
+  AnotherLongType
+>
+    extends Other {}
+>>> Split in class type parameters forces clauses to split.
+class C<LongTypeParameter, AnotherLongType> extends Other with Mixin {}
+<<<
+class C<
+  LongTypeParameter,
+  AnotherLongType
+>
+    extends Other
+    with Mixin {}

--- a/test/tall/declaration/extension.unit
+++ b/test/tall/declaration/extension.unit
@@ -35,7 +35,8 @@ extension Extension<LongTypeParameter, Another> on BaseClass {}
 extension Extension<
   LongTypeParameter,
   Another
-> on BaseClass {}
+>
+    on BaseClass {}
 >>> Unnamed.
 extension on String {}
 <<<

--- a/test/tall/declaration/extension_type.unit
+++ b/test/tall/declaration/extension_type.unit
@@ -48,7 +48,8 @@ extension type LongExtensionType(LongTypeName a) implements Something {
 <<<
 extension type LongExtensionType(
   LongTypeName a,
-) implements Something {
+)
+    implements Something {
   method() {
     ;
   }

--- a/test/tall/regression/other/misc.unit
+++ b/test/tall/regression/other/misc.unit
@@ -20,3 +20,20 @@ SomeVeryLongReturnType someFunctionName(
         .then(________traverseDeps_depender__deps_);
   }
 }
+>>> Split in long type parameter clause.
+abstract class StreamNotifierProviderBase<
+  NotifierT extends AsyncNotifierBase<T>,
+  T
+> extends ProviderWithNotifier<AsyncValue<T>, NotifierT>
+    with FutureModifier<T> {
+  // ...
+}
+<<<
+abstract class StreamNotifierProviderBase<
+  NotifierT extends AsyncNotifierBase<T>,
+  T
+>
+    extends ProviderWithNotifier<AsyncValue<T>, NotifierT>
+    with FutureModifier<T> {
+  // ...
+}


### PR DESCRIPTION
I think it looks weird if the `extends`, etc. clauses hang immediately after the `>` when the type parameters split.

Since import/export directives use the same piece, this nominally affects them too but in practice it's extremely rare for there to be a newline in an import before any other clauses.

While I was at it, I cleaned up the way we build a piece tree for directives. That's some of the oldest code in the new formatter and was more complex than it needed to be. There was no need to use both an InfixPiece and a ClausesPiece since they do basically the same thing.
