### PR TITLE
Add a couple of regression tests.

### DIFF
--- a/test/tall/regression/other/misc.unit
+++ b/test/tall/regression/other/misc.unit
@@ -20,3 +20,15 @@ SomeVeryLongReturnType someFunctionName(
         .then(________traverseDeps_depender__deps_);
   }
 }
+>>> Function expression body in expression body member.
+ItemRenderer<Project> get projectRenderer => (HasUIDisplayName item) =>
+  item.uiDisplayName;
+<<<
+ItemRenderer<Project> get projectRenderer =>
+    (HasUIDisplayName item) => item.uiDisplayName;
+>>> Call chain body after long member header.
+Future<String> executeShellCommand(String command) async =>
+    _api.executeShellCommand(command);
+<<<
+Future<String> executeShellCommand(String command) async => _api
+    .executeShellCommand(command);


### PR DESCRIPTION
These are things I noticed when formatting a corpus using the old prototype version of the new style. Finally got around to adding tests for them. Fortunately, they format as I expect with the new formatter.

Having `_api` hanging on the end of the first line doesn't look *great* in this example, but I think it's mostly because it's unusual that the function has such a long signature followed by a very small target expression. In general, it seems to look good to hang the target of a call chain at the end of the same line as a `=>` member body.
