### PR TITLE
Preserve type parameters in function-typed "this." and "super." params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Allow passing a language version to `DartFomatter()`. Formatted code will be
   parsed at that version. If omitted, defaults to the latest version. In a
   future release, this parameter will become required.
+* Preserve type parameters on old-style function-typed formals that also use
+  `this.` or `super.` (#1321).
 * Remove temporary work around for analyzer 6.2.0 from dart_style 2.3.6.
 * Require `package:analyzer` `>=6.5.0 <7.0.0`.
 

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -1339,6 +1339,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       token(node.thisKeyword);
       token(node.period);
       token(node.name);
+      visit(node.typeParameters);
       visit(node.parameters);
       token(node.question);
       _endFormalParameter(node);
@@ -2801,6 +2802,7 @@ class SourceVisitor extends ThrowingAstVisitor {
       token(node.superKeyword);
       token(node.period);
       token(node.name);
+      visit(node.typeParameters);
       visit(node.parameters);
       token(node.question);
       _endFormalParameter(node);

--- a/test/short/regression/1300/1321.unit
+++ b/test/short/regression/1300/1321.unit
@@ -1,0 +1,38 @@
+>>> `super.` parameter.
+class A {
+  A(int foo<T>(int a));
+}
+class B extends A {
+  B.sub1(int super.bar1<T1>(int a1),);
+  B.sub2(int super.bar2<T2>(int a2),);
+}
+main() {}
+<<<
+class A {
+  A(int foo<T>(int a));
+}
+
+class B extends A {
+  B.sub1(
+    int super.bar1<T1>(int a1),
+  );
+  B.sub2(
+    int super.bar2<T2>(int a2),
+  );
+}
+
+main() {}
+>>> `this.` parameter.
+class A {
+  A.sub1(int this.bar1<T1>(int a1),);
+  A.sub2(int this.bar2<T2>(int a2),);
+}
+<<<
+class A {
+  A.sub1(
+    int this.bar1<T1>(int a1),
+  );
+  A.sub2(
+    int this.bar2<T2>(int a2),
+  );
+}

--- a/test/tall/regression/1300/1321.unit
+++ b/test/tall/regression/1300/1321.unit
@@ -1,0 +1,30 @@
+>>> `super.` parameter.
+class A {
+  A(int foo<T>(int a));
+}
+class B extends A {
+  B.sub1(int super.bar1<T1>(int a1),);
+  B.sub2(int super.bar2<T2>(int a2),);
+}
+main() {}
+<<<
+class A {
+  A(int foo<T>(int a));
+}
+
+class B extends A {
+  B.sub1(int super.bar1<T1>(int a1));
+  B.sub2(int super.bar2<T2>(int a2));
+}
+
+main() {}
+>>> `this.` parameter.
+class A {
+  A.sub1(int this.bar1<T1>(int a1),);
+  A.sub2(int this.bar2<T2>(int a2),);
+}
+<<<
+class A {
+  A.sub1(int this.bar1<T1>(int a1));
+  A.sub2(int this.bar2<T2>(int a2));
+}


### PR DESCRIPTION
If you have a parameter that:

- uses "this." or "super.",
- and also uses the old function-typed formal parameter syntax,
- and also is a generic function...

then the short style formatter would drop the type parameters on the floor. The tall style already does the right thing.

Fix the short style and add regression tests for both.

Fix #1321.
