### PR TITLE
When the RHS of `=>` is a function call, prefer to split at the `=>`.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -605,7 +605,9 @@ class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
         nodePiece(node.expression, context: NodeContext.assignment);
 
     pieces.add(AssignPiece(operatorPiece, expression,
-        canBlockSplitRight: node.expression.canBlockSplit));
+        canBlockSplitRight: node.expression.canBlockSplit,
+        avoidBlockSplitRight:
+            node.expression.blockFormatType == BlockFormat.invocation));
     pieces.token(node.semicolon);
   }
 

--- a/test/tall/function/default_value.unit
+++ b/test/tall/function/default_value.unit
@@ -66,9 +66,10 @@ f([
 f([callback(SomeType parameter) = const CallableClass(someLongConstantArgument, anotherConstantArgument)]) {}
 <<<
 f([
-  callback(SomeType parameter) =
-      const CallableClass(
-        someLongConstantArgument,
-        anotherConstantArgument,
-      ),
+  callback(
+    SomeType parameter,
+  ) = const CallableClass(
+    someLongConstantArgument,
+    anotherConstantArgument,
+  ),
 ]) {}

--- a/test/tall/function/expression_body.unit
+++ b/test/tall/function/expression_body.unit
@@ -52,13 +52,11 @@ function() => (
   longElement,
   longElement,
 );
->>> Prefer block-like splitting for function calls.
+>>> Avoid block-like splitting for function calls.
 function() => another(argument, argument);
 <<<
-function() => another(
-  argument,
-  argument,
-);
+function() =>
+    another(argument, argument);
 >>> Use block-like splitting for switch expressions.
 function() => switch (value) { 1 => 'one', 2 => 'two' };
 <<<

--- a/test/tall/regression/0100/0108.unit
+++ b/test/tall/regression/0100/0108.unit
@@ -276,10 +276,8 @@ class ElementBinder {
           eventName,
           (_) => zone.run(
             () => bindAssignableProps.forEach(
-              (propAndExp) => propAndExp[1].assign(
-                scope.context,
-                jsNode[propAndExp[0]],
-              ),
+              (propAndExp) =>
+                  propAndExp[1].assign(scope.context, jsNode[propAndExp[0]]),
             ),
           ),
         ),

--- a/test/tall/regression/0200/0217.stmt
+++ b/test/tall/regression/0200/0217.stmt
@@ -3,8 +3,8 @@ Annotation _getAnnotation(AnnotatedNode node, String name) => nodeMetadata
     .firstWhere((annotation) => _isAnnotationType(annotation, name),
         orElse: () => null);
 <<<
-Annotation _getAnnotation(AnnotatedNode node, String name) => nodeMetadata
-    .firstWhere(
+Annotation _getAnnotation(AnnotatedNode node, String name) =>
+    nodeMetadata.firstWhere(
       (annotation) => _isAnnotationType(annotation, name),
       orElse: () => null,
     );
@@ -13,8 +13,8 @@ Annotation _getAnnotation(AnnotatedNode node, String name) => nodeMetadata
       .firstWhere((annotation) => _isAnnotationType(annotation, name),
           orElse: () => null);
 <<<
-  Annotation _getAnnotation(AnnotatedNode node, String name) => nodeMetadata
-      .firstWhere(
+  Annotation _getAnnotation(AnnotatedNode node, String name) =>
+      nodeMetadata.firstWhere(
         (annotation) => _isAnnotationType(annotation, name),
         orElse: () => null,
       );

--- a/test/tall/regression/0400/0474.unit
+++ b/test/tall/regression/0400/0474.unit
@@ -382,21 +382,13 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   'advance_0': new MethodTrampoline(0, (Parser target) => target._advance()),
   'appendScalarValue_5': new MethodTrampoline(
     5,
-    (Parser target, arg0, arg1, arg2, arg3, arg4) => target._appendScalarValue(
-      arg0,
-      arg1,
-      arg2,
-      arg3,
-      arg4,
-    ),
+    (Parser target, arg0, arg1, arg2, arg3, arg4) =>
+        target._appendScalarValue(arg0, arg1, arg2, arg3, arg4),
   ),
   'computeStringValue_3': new MethodTrampoline(
     3,
-    (Parser target, arg0, arg1, arg2) => target._computeStringValue(
-      arg0,
-      arg1,
-      arg2,
-    ),
+    (Parser target, arg0, arg1, arg2) =>
+        target._computeStringValue(arg0, arg1, arg2),
   ),
   'convertToFunctionDeclaration_1': new MethodTrampoline(
     1,
@@ -561,11 +553,8 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'parseClassTypeAlias_3': new MethodTrampoline(
     3,
-    (Parser target, arg0, arg1, arg2) => target._parseClassTypeAlias(
-      arg0,
-      arg1,
-      arg2,
-    ),
+    (Parser target, arg0, arg1, arg2) =>
+        target._parseClassTypeAlias(arg0, arg1, arg2),
   ),
   'parseCombinator_0': new MethodTrampoline(
     0,
@@ -662,19 +651,13 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'parseFunctionBody_3': new MethodTrampoline(
     3,
-    (Parser target, arg0, arg1, arg2) => target._parseFunctionBody(
-      arg0,
-      arg1,
-      arg2,
-    ),
+    (Parser target, arg0, arg1, arg2) =>
+        target._parseFunctionBody(arg0, arg1, arg2),
   ),
   'parseFunctionDeclaration_3': new MethodTrampoline(
     3,
-    (Parser target, arg0, arg1, arg2) => target._parseFunctionDeclaration(
-      arg0,
-      arg1,
-      arg2,
-    ),
+    (Parser target, arg0, arg1, arg2) =>
+        target._parseFunctionDeclaration(arg0, arg1, arg2),
   ),
   'parseFunctionDeclarationStatement_0': new MethodTrampoline(
     0,
@@ -682,8 +665,8 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'parseFunctionDeclarationStatementAfterReturnType_2': new MethodTrampoline(
     2,
-    (Parser target, arg0, arg1) => target
-        ._parseFunctionDeclarationStatementAfterReturnType(arg0, arg1),
+    (Parser target, arg0, arg1) =>
+        target._parseFunctionDeclarationStatementAfterReturnType(arg0, arg1),
   ),
   'parseFunctionTypeAlias_2': new MethodTrampoline(
     2,
@@ -691,12 +674,8 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'parseGetter_4': new MethodTrampoline(
     4,
-    (Parser target, arg0, arg1, arg2, arg3) => target._parseGetter(
-      arg0,
-      arg1,
-      arg2,
-      arg3,
-    ),
+    (Parser target, arg0, arg1, arg2, arg3) =>
+        target._parseGetter(arg0, arg1, arg2, arg3),
   ),
   'parseIdentifierList_0': new MethodTrampoline(
     0,
@@ -712,8 +691,8 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'parseInitializedIdentifierList_4': new MethodTrampoline(
     4,
-    (Parser target, arg0, arg1, arg2, arg3) => target
-        ._parseInitializedIdentifierList(arg0, arg1, arg2, arg3),
+    (Parser target, arg0, arg1, arg2, arg3) =>
+        target._parseInitializedIdentifierList(arg0, arg1, arg2, arg3),
   ),
   'parseInstanceCreationExpression_1': new MethodTrampoline(
     1,
@@ -745,8 +724,8 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'parseMethodDeclarationAfterParameters_7': new MethodTrampoline(
     7,
-    (Parser target, arg0, arg1, arg2, arg3, arg4, arg5, arg6) => target
-        ._parseMethodDeclarationAfterParameters(
+    (Parser target, arg0, arg1, arg2, arg3, arg4, arg5, arg6) =>
+        target._parseMethodDeclarationAfterParameters(
           arg0,
           arg1,
           arg2,
@@ -758,8 +737,8 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'parseMethodDeclarationAfterReturnType_4': new MethodTrampoline(
     4,
-    (Parser target, arg0, arg1, arg2, arg3) => target
-        ._parseMethodDeclarationAfterReturnType(arg0, arg1, arg2, arg3),
+    (Parser target, arg0, arg1, arg2, arg3) =>
+        target._parseMethodDeclarationAfterReturnType(arg0, arg1, arg2, arg3),
   ),
   'parseModifiers_0': new MethodTrampoline(
     0,
@@ -783,11 +762,8 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'parseOperator_3': new MethodTrampoline(
     3,
-    (Parser target, arg0, arg1, arg2) => target._parseOperator(
-      arg0,
-      arg1,
-      arg2,
-    ),
+    (Parser target, arg0, arg1, arg2) =>
+        target._parseOperator(arg0, arg1, arg2),
   ),
   'parseOptionalReturnType_0': new MethodTrampoline(
     0,
@@ -823,12 +799,8 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'parseSetter_4': new MethodTrampoline(
     4,
-    (Parser target, arg0, arg1, arg2, arg3) => target._parseSetter(
-      arg0,
-      arg1,
-      arg2,
-      arg3,
-    ),
+    (Parser target, arg0, arg1, arg2, arg3) =>
+        target._parseSetter(arg0, arg1, arg2, arg3),
   ),
   'parseShiftExpression_0': new MethodTrampoline(
     0,
@@ -880,24 +852,23 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'parseVariableDeclarationListAfterMetadata_1': new MethodTrampoline(
     1,
-    (Parser target, arg0) => target._parseVariableDeclarationListAfterMetadata(
-      arg0,
-    ),
+    (Parser target, arg0) =>
+        target._parseVariableDeclarationListAfterMetadata(arg0),
   ),
   'parseVariableDeclarationListAfterType_3': new MethodTrampoline(
     3,
-    (Parser target, arg0, arg1, arg2) => target
-        ._parseVariableDeclarationListAfterType(arg0, arg1, arg2),
+    (Parser target, arg0, arg1, arg2) =>
+        target._parseVariableDeclarationListAfterType(arg0, arg1, arg2),
   ),
   'parseVariableDeclarationStatementAfterMetadata_1': new MethodTrampoline(
     1,
-    (Parser target, arg0) => target
-        ._parseVariableDeclarationStatementAfterMetadata(arg0),
+    (Parser target, arg0) =>
+        target._parseVariableDeclarationStatementAfterMetadata(arg0),
   ),
   'parseVariableDeclarationStatementAfterType_3': new MethodTrampoline(
     3,
-    (Parser target, arg0, arg1, arg2) => target
-        ._parseVariableDeclarationStatementAfterType(arg0, arg1, arg2),
+    (Parser target, arg0, arg1, arg2) =>
+        target._parseVariableDeclarationStatementAfterType(arg0, arg1, arg2),
   ),
   'parseWhileStatement_0': new MethodTrampoline(
     0,
@@ -918,26 +889,18 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'reportErrorForCurrentToken_2': new MethodTrampoline(
     2,
-    (Parser target, arg0, arg1) => target._reportErrorForCurrentToken(
-      arg0,
-      arg1,
-    ),
+    (Parser target, arg0, arg1) =>
+        target._reportErrorForCurrentToken(arg0, arg1),
   ),
   'reportErrorForNode_3': new MethodTrampoline(
     3,
-    (Parser target, arg0, arg1, arg2) => target._reportErrorForNode(
-      arg0,
-      arg1,
-      arg2,
-    ),
+    (Parser target, arg0, arg1, arg2) =>
+        target._reportErrorForNode(arg0, arg1, arg2),
   ),
   'reportErrorForToken_3': new MethodTrampoline(
     3,
-    (Parser target, arg0, arg1, arg2) => target._reportErrorForToken(
-      arg0,
-      arg1,
-      arg2,
-    ),
+    (Parser target, arg0, arg1, arg2) =>
+        target._reportErrorForToken(arg0, arg1, arg2),
   ),
   'skipBlock_0': new MethodTrampoline(
     0,
@@ -1005,11 +968,8 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'translateCharacter_3': new MethodTrampoline(
     3,
-    (Parser target, arg0, arg1, arg2) => target._translateCharacter(
-      arg0,
-      arg1,
-      arg2,
-    ),
+    (Parser target, arg0, arg1, arg2) =>
+        target._translateCharacter(arg0, arg1, arg2),
   ),
   'unlockErrorListener_0': new MethodTrampoline(
     0,
@@ -1037,14 +997,13 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'validateModifiersForFunctionDeclarationStatement_1': new MethodTrampoline(
     1,
-    (Parser target, arg0) => target
-        ._validateModifiersForFunctionDeclarationStatement(arg0),
+    (Parser target, arg0) =>
+        target._validateModifiersForFunctionDeclarationStatement(arg0),
   ),
   'validateModifiersForGetterOrSetterOrMethod_1': new MethodTrampoline(
     1,
-    (Parser target, arg0) => target._validateModifiersForGetterOrSetterOrMethod(
-      arg0,
-    ),
+    (Parser target, arg0) =>
+        target._validateModifiersForGetterOrSetterOrMethod(arg0),
   ),
   'validateModifiersForOperator_1': new MethodTrampoline(
     1,
@@ -1052,9 +1011,8 @@ Map<String, MethodTrampoline> methodTable_Parser = <String, MethodTrampoline>{
   ),
   'validateModifiersForTopLevelDeclaration_1': new MethodTrampoline(
     1,
-    (Parser target, arg0) => target._validateModifiersForTopLevelDeclaration(
-      arg0,
-    ),
+    (Parser target, arg0) =>
+        target._validateModifiersForTopLevelDeclaration(arg0),
   ),
   'validateModifiersForTopLevelFunction_1': new MethodTrampoline(
     1,

--- a/test/tall/regression/0500/0500.unit
+++ b/test/tall/regression/0500/0500.unit
@@ -39,9 +39,8 @@
           });
         },
         setter:
-            (value, ExprCont ek, ExprCont k) => ek(
-              "NoSuchMethodError: method not found: '${names[i]}='",
-            ),
+            (value, ExprCont ek, ExprCont k) =>
+                ek("NoSuchMethodError: method not found: '${names[i]}='"),
       );
     }
   };

--- a/test/tall/regression/0500/0557.unit
+++ b/test/tall/regression/0500/0557.unit
@@ -15,10 +15,8 @@ class PublicType {
 class PublicType {
   const factory PublicType.constructor(String a, Type b) = PublicTypeImpl._;
 
-  factory PublicType.constructor(String a, Type b) => new PublicTypeImpl._(
-    a,
-    b,
-  );
+  factory PublicType.constructor(String a, Type b) =>
+      new PublicTypeImpl._(a, b);
 }
 >>>
 class PublicType {

--- a/test/tall/regression/0500/0584.unit
+++ b/test/tall/regression/0500/0584.unit
@@ -2,7 +2,5 @@
 bool
     listEquals<T>(List<T> a, List<T> b) => const ListEquality<T>().equals(a, b);
 <<<
-bool listEquals<T>(List<T> a, List<T> b) => const ListEquality<T>().equals(
-  a,
-  b,
-);
+bool listEquals<T>(List<T> a, List<T> b) =>
+    const ListEquality<T>().equals(a, b);

--- a/test/tall/regression/0700/0721.unit
+++ b/test/tall/regression/0700/0721.unit
@@ -28,7 +28,6 @@ class C {
 class C {
   static token() => FirebaseMessaging().getToken();
 
-  static unsubscribe(String topic) => FirebaseMessaging().unsubscribeFromTopic(
-    topic,
-  );
+  static unsubscribe(String topic) =>
+      FirebaseMessaging().unsubscribeFromTopic(topic);
 }

--- a/test/tall/regression/1100/1190.unit
+++ b/test/tall/regression/1100/1190.unit
@@ -55,66 +55,66 @@ AaaaaaaAaaaaaaaaAaaaaaaaAaaaa _aaaAaaaaaaaaAaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
 ) {
   switch (aaaaaaAaaa) {
     case aaaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaa(aaaaaaa?.aaaaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaa);
     case aaaaaaaaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaa(aaaaaaa?.aaaaaaaaaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaaaaaaa);
     case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(
             aaaaaaa?.aaaaaaaaaaAaaaa,
             aaaaaaaaAaaa,
             aaaaaaaAaaaaaaaAaaaaa: aaaaa,
           );
     case aaaAaaaaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaa(aaaaaaa?.aaaAaaaaaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaAaaaaaaa);
     case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
             aaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa() == true
                 ? aaaaaaa!.aaaaaaaaaaAaaaaAaaaaa
                 : null,
           );
     case aaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
             aaaaaaa?.aaaAaaAaaaaaaaaaAaaaaAaaaaa() == true
                 ? aaaaaaa!.aaaAaaaaaaaaaAaaaaAaaaaa
                 : null,
           );
     case aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
             aaaaaaa?.aaaAaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa() == true
                 ? aaaaaaa!.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa
                 : null,
           );
     case aaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
     case aaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
     case aaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaa(aaaaaaa?.aaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaa);
     case aaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
     case aaaaaAaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaa(aaaaaaa?.aaaaaAaaaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaAaaaaa);
     case aaaaAaaAaaaaAaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(aaaaaaa?.aaaa, aaaaaaaaAaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaa, aaaaaaaaAaaa);
     case aaaaaAaaaaAaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(aaaaaaa?.aaaaaAaaaaAaaaa, aaaaaaaaAaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaaaAaaaaAaaaa, aaaaaaaaAaaa);
     case aaaaaAaaaaAaaaaAaaAaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaa(aaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa);
     default:
       throw AaaaaaaaaaaaaAaaaa(aaaaaaAaaa);
   }
@@ -176,66 +176,66 @@ AaaaaaaAaaaaaaaaAaaaaaaaAaaaa _aaaAaaaaaaaaAaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
 ) {
   switch (aaaaaaAaaa) {
     case aaaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaa(aaaaaaa?.aaaaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaa);
     case aaaaaaaaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaa(aaaaaaa?.aaaaaaaaaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaaaaaaa);
     case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(
             aaaaaaa?.aaaaaaaaaaAaaaa,
             aaaaaaaaAaaa,
             aaaaaaaAaaaaaaaAaaaaa: false,
           );
     case aaaAaaaaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaa(aaaaaaa?.aaaAaaaaaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaAaaaaaaa);
     case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
             aaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa() == true
                 ? aaaaaaa!.aaaaaaaaaaAaaaaAaaaaa
                 : null,
           );
     case aaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
             aaaaaaa?.aaaAaaAaaaaaaaaaAaaaaAaaaaa() == true
                 ? aaaaaaa!.aaaAaaaaaaaaaAaaaaAaaaaa
                 : null,
           );
     case aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaaaaaAaaaaAaaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaaaaAaaaaAaaaaa(
             aaaaaaa?.aaaAaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa() == true
                 ? aaaaaaa!.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa
                 : null,
           );
     case aaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
     case aaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
     case aaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaa(aaaaaaa?.aaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaa);
     case aaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaa, aaaaaaaaAaaa);
     case aaaaaAaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaa(aaaaaaa?.aaaaaAaaaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaa(aaaaaaa?.aaaaaAaaaaa);
     case aaaaAaaAaaaaAaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(aaaaaaa?.aaaa, aaaaaaaaAaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaa, aaaaaaaaAaaa);
     case aaaaaAaaaaAaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaa(aaaaaaa?.aaaaaAaaaaAaaaa, aaaaaaaaAaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaa(aaaaaaa?.aaaaaAaaaaAaaaa, aaaaaaaaAaaa);
     case aaaaaAaaaaAaaaaAaaAaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaa(aaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa);
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaa(aaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa);
     default:
       throw AaaaaaaaaaaaaAaaaa(aaaaaaAaaa);
   }
@@ -312,8 +312,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
 }) {
   switch (aaaaaaAaaa) {
     case aaaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaaaa,
             aaaaaaa?.aaaaaa,
             aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
@@ -321,8 +321,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaaaaaaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaaaaaaaaa,
             aaaaaaa?.aaaaaaaaaaa,
             aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
@@ -330,8 +330,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaaaaaaaaAaaaa,
             aaaaaaa?.aaaaaaaaaaAaaaa,
             aaaaaaaaAaaa!,
@@ -341,8 +341,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaAaaaaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaAaaaaaaa,
             aaaaaaa?.aaaAaaaaaaa,
             aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
@@ -350,8 +350,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaaaaaaaaAaaaaAaaaaa,
             aaaaaaa?.aaaaaaaaaaAaaaaAaaaaa,
             aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
@@ -359,8 +359,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa,
             aaaaaaa?.aaaAaaaaaaaaaAaaaaAaaaaa,
             aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
@@ -368,8 +368,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaaaaaAaaaaAaaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa,
             aaaaaaa?.aaaaaaaaAaaAaaaaaaaaaAaaaaAaaaaa,
             aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
@@ -377,8 +377,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(
             aaaaaaaa?.aaa,
             aaaaaaa?.aaa,
             aaaaaaaaAaaa!,
@@ -388,8 +388,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(
             aaaaaaaa?.aaa,
             aaaaaaa?.aaa,
             aaaaaaaaAaaa!,
@@ -399,8 +399,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaaaaAaaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaa,
             aaaaaaa?.aaaa,
             aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
@@ -408,8 +408,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaAaaaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(
             aaaaaaaa?.aaa,
             aaaaaaa?.aaa,
             aaaaaaaaAaaa!,
@@ -419,8 +419,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaaaAaaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaaaAaaaaa,
             aaaaaaa?.aaaaaAaaaaa,
             aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,
@@ -428,8 +428,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaaAaaAaaaaAaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaa,
             aaaaaaa?.aaaa,
             aaaaaaaaAaaa!,
@@ -438,8 +438,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaaaAaaaaAaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaAaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaAaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaaaAaaaaAaaaa,
             aaaaaaa?.aaaaaAaaaaAaaaa,
             aaaaaaaaAaaa!,
@@ -448,8 +448,8 @@ _aaaAaaaaaaaaAaaaaAaaaaaaaaaAaaaaaaaAaaaaaAaaaaaaaa(
             aaaaAaaa: true,
           );
     case aaaaaAaaaaAaaaaAaaAaaaaAaaaaaAaaa:
-      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) => aaaaaaAaaaaaaaa
-          .aaaaaaaaaAaaaaaAaaaaAaaaa(
+      return (Aaaaaaaa? aaaaaaa, Aaaaaaaa? aaaaaaaa) =>
+          aaaaaaAaaaaaaaa.aaaaaaaaaAaaaaaAaaaaAaaaa(
             aaaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa,
             aaaaaaa?.aaaaaAaaaaAaaaaAaaAaaaa,
             aaaaaaaAaaaaaaaaaa: aaaaaaaAaaaaaaaaaa,

--- a/test/tall/regression/1200/1253.unit
+++ b/test/tall/regression/1200/1253.unit
@@ -1,0 +1,41 @@
+>>>
+class C {
+  T visitVariableDeclarationList(
+    VariableDeclarationList node,
+  ) => visitExpression(node);
+
+  T visitAssignment(Assignment node) => visitExpression(node);
+
+  T visitVariableInitialization(VariableInitialization node) => visitExpression(
+    node,
+  );
+}
+<<<
+class C {
+  T visitVariableDeclarationList(VariableDeclarationList node) =>
+      visitExpression(node);
+
+  T visitAssignment(Assignment node) => visitExpression(node);
+
+  T visitVariableInitialization(VariableInitialization node) =>
+      visitExpression(node);
+}
+>>>
+class C {
+  Instantiator visitLiteralStatement(LiteralStatement node) => TODO(
+    'visitLiteralStatement',
+  );
+}
+<<<
+class C {
+  Instantiator visitLiteralStatement(LiteralStatement node) =>
+      TODO('visitLiteralStatement');
+}
+>>>
+ModifiableCssSupportsRule copyWithoutChildren() => ModifiableCssSupportsRule(
+  condition,
+  span,
+);
+<<<
+ModifiableCssSupportsRule copyWithoutChildren() =>
+    ModifiableCssSupportsRule(condition, span);

--- a/test/tall/regression/1400/1463.unit
+++ b/test/tall/regression/1400/1463.unit
@@ -79,9 +79,8 @@ class C {
             );
           } else if (apiError.message?.contains('Permission denied') ?? false) {
             di<InteractionManager>().pushToastWithBuilder(
-              (context) => ToastConfig(
-                context.l10n.defaultMessagingRestriction,
-              ),
+              (context) =>
+                  ToastConfig(context.l10n.defaultMessagingRestriction),
             );
           }
         });
@@ -140,9 +139,8 @@ class C {
             );
           } else if (apiError.message?.contains('Permission denied') ?? false) {
             di<InteractionManager>().pushToastWithBuilder(
-              (context) => ToastConfig(
-                context.l10n.defaultMessagingRestriction,
-              ),
+              (context) =>
+                  ToastConfig(context.l10n.defaultMessagingRestriction),
             );
           }
         });

--- a/test/tall/regression/other/misc.unit
+++ b/test/tall/regression/other/misc.unit
@@ -30,5 +30,5 @@ ItemRenderer<Project> get projectRenderer =>
 Future<String> executeShellCommand(String command) async =>
     _api.executeShellCommand(command);
 <<<
-Future<String> executeShellCommand(String command) async => _api
-    .executeShellCommand(command);
+Future<String> executeShellCommand(String command) async =>
+    _api.executeShellCommand(command);


### PR DESCRIPTION
We use the same AssignPiece rule for `=`, `=>`, and `:`. And that rule uniformly handles all kinds of block-formattable right hand sides: collection literals, switch expressions, and function calls. For the most part, that works well and provides nice consistent formatting. Users generally like:

```dart
// Better:
variable = [
  long,
  list,
  literal,
];

// Worse:
variable =
    [long, list, literal];
```

And:

```dart
// Better:
SomeWidget(
  children: [
    long,
    list,
    literal,
  ],
);

// Worse:
SomeWidget(
  children:
      [long, list, literal],
);
```

And (with somewhat less consensus):

```dart
// Better:
variable = function(
  long,
  argument,
  list,
);

// Worse:
variable =
    function(long, argument, list);
```

Also, users have long requested and seem to like:

```dart
// Better:
class C {
  List<String> makeStuff() => [
    long,
    list,
    literal,
  ];
}

// Worse:
class C {
  List<String> makeStuff() =>
      [long, list, literal];
}
```

So based on all that, I just used uniform rules for all combinations of assignment constructs and delimited constructs. That means that this behavior falls out implicitly:

```dart
// Better:
class C {
  String doThing() => function(
    long,
    argument,
    list,
  );
}

// Worse:
class C {
  String doThing() =>
      function(long, argument, list);
}
```

But it turns out that that particular combination of `=>` with a function call on the right doesn't get the same user sentiment. Instead, most (including me) prefer:

```dart
class C {
  String doThing() =>
      function(long, argument, list);
}
```

I think it's because this keeps the function name next to its arguments. With the other block-like forms: list literals, etc. there isn't really anything particularly interesting going on in the opening delimiter, so it makes sense to keep it on the same line as the `=>` since it's pretty much just punctuation. But a function call is a single coherent operation including the function and its arguments.

So this PR tweaks the cost rule for AssignPiece. When the operator is `=>` and the RHS is a function call, we prefer to split at the `=>` if that lets the RHS stay unsplit.
