### PR TITLE
Block-format await expressions if the inner expression allows it.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -220,6 +220,9 @@ extension ExpressionExtensions on Expression {
 
       // Parenthesized expressions unwrap the inner expression.
       ParenthesizedExpression(:var expression) => expression.blockFormatType,
+
+      // Await expressions unwrap the inner expression.
+      AwaitExpression(:var expression) => expression.blockFormatType,
       _ => BlockFormat.none,
     };
   }

--- a/test/tall/regression/0400/0466.unit
+++ b/test/tall/regression/0400/0466.unit
@@ -10,8 +10,8 @@
     Future get identifier________ async {
       var id = identifier________.identifier__;
 
-      return identifier_____________[id] ??=
-          await identifier_______.identifier____________________(
+      return identifier_____________[id] ??= await identifier_______
+          .identifier____________________(
             identifier___________________________.create()..identifier____ = id,
           );
     }

--- a/test/tall/regression/1400/1463.unit
+++ b/test/tall/regression/1400/1463.unit
@@ -47,11 +47,10 @@ class C {
             final chatApi = ChatsApi(di<ApiClient>());
             if (_target == null) {
               assert(_chatPartner != null);
-              _target =
-                  await chatApi.sendMessageToUserAndCreateChatIfNeeded(
-                    _chatPartner!.id.toString(),
-                    messageUpdateRequest: newMessage,
-                  );
+              _target = await chatApi.sendMessageToUserAndCreateChatIfNeeded(
+                _chatPartner!.id.toString(),
+                messageUpdateRequest: newMessage,
+              );
             } else {
               await chatApi.addMessageToChat(
                 chatId,

--- a/test/tall/regression/1500/1526.stmt
+++ b/test/tall/regression/1500/1526.stmt
@@ -1,0 +1,39 @@
+>>> (indent 2)
+  final character =
+      await repository.fetchCharacter(id, cancelToken: cancelToken);
+<<<
+  final character = await repository.fetchCharacter(
+    id,
+    cancelToken: cancelToken,
+  );
+>>> (indent 6)
+      final charactersResponse =
+          await repository.fetchCharacters(
+            offset: meta.page * kCharactersPageLimit,
+            limit: kCharactersPageLimit,
+            nameStartsWith: meta.name,
+            cancelToken: cancelToken,
+          );
+<<<
+      final charactersResponse = await repository.fetchCharacters(
+        offset: meta.page * kCharactersPageLimit,
+        limit: kCharactersPageLimit,
+        nameStartsWith: meta.name,
+        cancelToken: cancelToken,
+      );
+>>> (indent 4)
+    final response =
+        await _get('characters', queryParameters: <String, Object?>{
+          'offset': offset,
+          if (limit != null) 'limit': limit,
+          if (cleanNameFilter != null && cleanNameFilter.isNotEmpty)
+            'nameStartsWith': cleanNameFilter,
+        }, cancelToken: cancelToken);
+<<<
+    final response = await _get('characters', queryParameters:
+        <String, Object?>{
+          'offset': offset,
+          if (limit != null) 'limit': limit,
+          if (cleanNameFilter != null && cleanNameFilter.isNotEmpty)
+            'nameStartsWith': cleanNameFilter,
+        }, cancelToken: cancelToken);

--- a/test/tall/regression/1500/1531.stmt
+++ b/test/tall/regression/1500/1531.stmt
@@ -1,0 +1,42 @@
+>>>
+variable =
+    await function(
+      argument, // Force split in argument list.
+      another,
+    );
+<<<
+variable = await function(
+  argument, // Force split in argument list.
+  another,
+);
+>>> (indent 4)
+    final response =
+        await post(Uri.parse(webhookUrl), headers: {
+          HttpHeaders.contentTypeHeader: ContentType.json.value,
+        }, body: json.encode(discordPayload));
+<<<
+    final response = await post(Uri.parse(webhookUrl), headers: {
+      HttpHeaders.contentTypeHeader: ContentType.json.value,
+    }, body: json.encode(discordPayload));
+>>> (indent 2)
+  final token =
+      await jwt.verify('<TOKEN>', issuer: '<ISSUER>', audience: {
+        '<AUDIENCE>',
+      }, publicKeysUrl: '<PUBLIC_KEYS_URL>');
+<<<
+  final token = await jwt.verify('<TOKEN>', issuer: '<ISSUER>', audience: {
+    '<AUDIENCE>',
+  }, publicKeysUrl: '<PUBLIC_KEYS_URL>');
+>>> (indent 6)
+      final connection =
+          await connectSocket(
+            uri.host,
+            port: uri.port,
+            timeout: _socketOptions.timeout,
+          );
+<<<
+      final connection = await connectSocket(
+        uri.host,
+        port: uri.port,
+        timeout: _socketOptions.timeout,
+      );

--- a/test/tall/variable/local.stmt
+++ b/test/tall/variable/local.stmt
@@ -244,6 +244,17 @@ var variableName = (notDelimited + expression);
 <<<
 var variableName =
     (notDelimited + expression);
+>>> Use block-like splitting for await whose inner expression is block-like.
+main() async {
+  var variableName = await function(argument, argument);
+}
+<<<
+main() async {
+  var variableName = await function(
+    argument,
+    argument,
+  );
+}
 >>> Split all variables if an initializer has a split internally.
 var a = 1, b = [element, element, element, element];
 <<<


### PR DESCRIPTION
In assignment-like context, if the RHS is an await expression and the inner expression can be block formatted, then let the whole await expression be block formatted.

This comes into play in assignments, but not in argument lists which are the other place where block formatting is a thing. That's because in argument lists, we *don't* treat function calls as block formattable. (This is both for performance and style reasons). There's no point in awaiting any of the other kinds of block-formattable expressions: collection literals or function expressions.

So this really just benefits assignments, named argument expressions, and `=>` bodies. But it definitely makes those look better.

Fix #1531.
