### PR TITLE
Delete unreachable `default` clause.

### DIFF
--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -837,8 +837,6 @@ mixin PieceFactory {
               tokenPiece(combinatorNode.keyword),
               for (var name in names) tokenPiece(name.token, commaAfter: true),
             ]));
-          default:
-            throw StateError('Unknown combinator type $combinatorNode.');
         }
       }
 


### PR DESCRIPTION
The Dart analyzer will soon be changed so that if the `default` clause of a `switch` statement is determined to be unreachable by the exhaustiveness checker, a new warning of type
`unreachable_switch_default` will be issued. This parallels the behavior of the existing `unreachable_switch_case` warning, which is issued whenever a `case` clause of a `switch` statement is determined to be unreachable. For details see https://github.com/dart-lang/sdk/issues/54575.

This PR deletes an unreachable `default` clause from `dart_style` now, to avoid a spurious warning when the analyzer change lands.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
