### PR TITLE
Tweak block argument heuristics

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -7,6 +7,16 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'piece/list.dart';
 
 extension AstNodeExtensions on AstNode {
+  /// When this node is in an argument list, what kind of block formatting
+  /// category it belongs to.
+  BlockFormat get blockFormatType => switch (this) {
+        AdjacentStrings(indentStrings: true) =>
+          BlockFormat.indentedAdjacentStrings,
+        AdjacentStrings() => BlockFormat.unindentedAdjacentStrings,
+        Expression(:var blockFormatType) => blockFormatType,
+        _ => BlockFormat.none,
+      };
+
   /// The first token at the beginning of this AST node, not including any
   /// tokens for leading doc comments.
   ///

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -62,8 +62,6 @@ class DelimitedListBuilder {
       });
     }
 
-    if (_style.allowBlockElement) _setBlockElementFormatting();
-
     var piece =
         ListPiece(_leftBracket, _elements, _blanksAfter, _rightBracket, _style);
     if (_mustSplit || forceSplit) piece.pin(State.split);
@@ -134,8 +132,8 @@ class DelimitedListBuilder {
   /// [addCommentsBefore()] for the first token in the [piece].
   ///
   /// Assumes there is no comma after this piece.
-  void add(Piece piece, [BlockFormat format = BlockFormat.none]) {
-    _elements.add(ListElementPiece(_leadingComments, piece, format));
+  void add(Piece piece) {
+    _elements.add(ListElementPiece(_leadingComments, piece));
     _leadingComments.clear();
     _commentsBeforeComma = CommentSequence.empty;
   }
@@ -152,23 +150,31 @@ class DelimitedListBuilder {
     // Handle comments between the preceding element and this one.
     addCommentsBefore(element.firstNonCommentToken);
 
-    // See if it's an expression that supports block formatting.
-    var format = switch (element) {
-      AdjacentStrings(indentStrings: true) =>
-        BlockFormat.indentedAdjacentStrings,
-      AdjacentStrings() => BlockFormat.unindentedAdjacentStrings,
-      Expression() => element.blockFormatType,
-      DartPattern() when element.canBlockSplit => BlockFormat.collection,
-      _ => BlockFormat.none,
-    };
-
     // Traverse the element itself.
-    add(_visitor.nodePiece(element), format);
+    add(_visitor.nodePiece(element));
 
     var nextToken = element.endToken.next!;
     if (nextToken.lexeme == ',') {
       _commentsBeforeComma = _visitor.comments.takeCommentsBefore(nextToken);
     }
+  }
+
+  /// Visits a list of [elements].
+  ///
+  /// If [allowBlockArgument] is `true`, then allows one element to receive
+  /// block formatting if appropriate, as in:
+  ///
+  ///     function(argument, [
+  ///       block,
+  ///       like,
+  ///     ], argument);
+  void visitAll(List<AstNode> elements, {bool allowBlockArgument = false}) {
+    for (var i = 0; i < elements.length; i++) {
+      var element = elements[i];
+      visit(element);
+    }
+
+    if (allowBlockArgument) _setBlockArgument(elements);
   }
 
   /// Inserts an inner left delimiter between two elements.
@@ -398,6 +404,14 @@ class DelimitedListBuilder {
     );
   }
 
+  /// Given an argument list, determines which if any of the arguments should
+  /// get special block-like formatting as in the list literal in:
+  ///
+  ///     function(argument, [
+  ///       block,
+  ///       like,
+  ///     ], argument);
+  ///
   /// Looks at the [BlockFormat] types of all of the elements to determine if
   /// one of them should be block formatted.
   ///
@@ -426,14 +440,29 @@ class DelimitedListBuilder {
   ///
   /// Stores the result of this calculation by setting flags on the
   /// [ListElement]s.
-  void _setBlockElementFormatting() {
-    // TODO(tall): These heuristics will probably need some iteration.
+  void _setBlockArgument(List<AstNode> arguments) {
+    var firstIsUnindentedAdjacentStrings = false;
     var functions = <int>[];
     var collections = <int>[];
     var adjacentStrings = <int>[];
 
-    for (var i = 0; i < _elements.length; i++) {
-      switch (_elements[i].blockFormat) {
+    for (var i = 0; i < arguments.length; i++) {
+      var argument = arguments[i];
+      // See if it's an expression that supports block formatting.
+      var format = switch (argument) {
+        AdjacentStrings(indentStrings: true) =>
+          BlockFormat.indentedAdjacentStrings,
+        AdjacentStrings() => BlockFormat.unindentedAdjacentStrings,
+        Expression() => argument.blockFormatType,
+        DartPattern() when argument.canBlockSplit => BlockFormat.collection,
+        _ => BlockFormat.none,
+      };
+
+      if (i == 0 && format == BlockFormat.unindentedAdjacentStrings) {
+        firstIsUnindentedAdjacentStrings = true;
+      }
+
+      switch (format) {
         case BlockFormat.function:
           functions.add(i);
         case BlockFormat.collection:
@@ -471,6 +500,7 @@ class DelimitedListBuilder {
       }
     }
 
+    // TODO(tall): These heuristics will probably need some iteration.
     switch ((functions, collections, adjacentStrings)) {
       // Only allow block formatting in an argument list containing adjacent
       // strings when:
@@ -487,7 +517,7 @@ class DelimitedListBuilder {
       case ([1], _, [0]):
         // The adjacent strings.
         _elements[0].allowNewlinesWhenUnsplit = true;
-        if (_elements[0].blockFormat == BlockFormat.unindentedAdjacentStrings) {
+        if (firstIsUnindentedAdjacentStrings) {
           _elements[0].indentWhenBlockFormatted = true;
         }
 
@@ -503,8 +533,5 @@ class DelimitedListBuilder {
       case ([], [var element], _):
         _elements[element].allowNewlinesWhenUnsplit = true;
     }
-
-    // If we get here, there are no block element, or it's ambiguous as to
-    // which one should be it so none are.
   }
 }

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -441,97 +441,111 @@ class DelimitedListBuilder {
   /// Stores the result of this calculation by setting flags on the
   /// [ListElement]s.
   void _setBlockArgument(List<AstNode> arguments) {
-    var firstIsUnindentedAdjacentStrings = false;
-    var functions = <int>[];
-    var collections = <int>[];
-    var adjacentStrings = <int>[];
+    var candidateIndex = _candidateBlockArgument(arguments);
+    if (candidateIndex == -1) return;
 
-    for (var i = 0; i < arguments.length; i++) {
-      var argument = arguments[i];
-      // See if it's an expression that supports block formatting.
-      var format = switch (argument) {
-        AdjacentStrings(indentStrings: true) =>
-          BlockFormat.indentedAdjacentStrings,
-        AdjacentStrings() => BlockFormat.unindentedAdjacentStrings,
-        Expression() => argument.blockFormatType,
-        DartPattern() when argument.canBlockSplit => BlockFormat.collection,
-        _ => BlockFormat.none,
-      };
+    // Only allow up to one trailing argument after the block argument. This
+    // handles the common `tags` and `timeout` named arguments in `test()` and
+    // `group()` while still mostly having the block argument be at the end of
+    // the argument list.
+    if (candidateIndex < arguments.length - 2) return;
 
-      if (i == 0 && format == BlockFormat.unindentedAdjacentStrings) {
-        firstIsUnindentedAdjacentStrings = true;
+    // If there are multiple named arguments, they should never end up on
+    // separate lines (unless the whole argument list fully splits). Otherwise,
+    // it's too easy for an argument name to get buried in the middle of a line.
+    // So we look for named arguments before, on, and after the candidate
+    // argument. If more than one of those sections of arguments has a named
+    // argument, then we don't allow the block argument.
+    var namedSections = 0;
+    bool hasNamedArgument(int from, int to) {
+      for (var i = from; i < to; i++) {
+        if (arguments[i] is NamedExpression) return true;
       }
 
-      switch (format) {
-        case BlockFormat.function:
-          functions.add(i);
-        case BlockFormat.collection:
-          collections.add(i);
-        case BlockFormat.invocation:
-          // We don't allow function calls as block elements partially for style
-          // and partially for performance. It often doesn't look great to let
-          // nested function calls pack arbitrarily deeply as block arguments:
-          //
-          //     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          //         content: Text(
-          //       localizations.demoSnackbarsAction,
-          //     )));
-          //
-          // This is better when expanded like:
-          //
-          //     ScaffoldMessenger.of(context).showSnackBar(
-          //       SnackBar(
-          //         content: Text(
-          //           localizations.demoSnackbarsAction,
-          //         ),
-          //       ),
-          //     );
-          //
-          // Also, when invocations can be block arguments, which themselves
-          // may contain block arguments, it's easy to run into combinatorial
-          // performance in the solver as it tries to determine which of the
-          // nested calls should and shouldn't be block formatted.
-          break;
-        case BlockFormat.indentedAdjacentStrings:
-        case BlockFormat.unindentedAdjacentStrings:
-          adjacentStrings.add(i);
-        case BlockFormat.none:
-          break; // Not a block element.
-      }
+      return false;
     }
 
-    // TODO(tall): These heuristics will probably need some iteration.
-    switch ((functions, collections, adjacentStrings)) {
-      // Only allow block formatting in an argument list containing adjacent
-      // strings when:
-      //
-      // 1. The block argument is a function expression.
-      // 2. It is the second argument, following an adjacent strings expression.
-      // 3. There are no other adjacent strings in the argument list.
-      //
-      // This matches the `test()` and `group()` and other similar APIs where
-      // you have a message string followed by a block-like function expression
-      // but little else.
-      // TODO(tall): We may want to iterate on these heuristics. For now,
-      // starting with something very narrowly targeted.
-      case ([1], _, [0]):
+    if (hasNamedArgument(0, candidateIndex)) namedSections++;
+    if (hasNamedArgument(candidateIndex, candidateIndex + 1)) namedSections++;
+    if (hasNamedArgument(candidateIndex + 1, arguments.length)) namedSections++;
+
+    if (namedSections > 1) return;
+
+    // Edge case: If the first argument is adjacent strings and the second
+    // argument is a function literal, with optionally a third non-block
+    // argument, then treat the function as the block argument.
+    //
+    // This matches the `test()` and `group()` and other similar APIs where
+    // you have a message string followed by a block-like function expression
+    // but little else, as in:
+    //
+    //     test('Some long test description '
+    //         'that splits into multiple lines.', () {
+    //       expect(1 + 2, 3);
+    //     });
+    if (candidateIndex == 1 &&
+        arguments[0] is! NamedExpression &&
+        arguments[1] is! NamedExpression) {
+      if ((arguments[0].blockFormatType, arguments[1].blockFormatType)
+          case (
+            BlockFormat.unindentedAdjacentStrings ||
+                BlockFormat.indentedAdjacentStrings,
+            BlockFormat.function
+          )) {
         // The adjacent strings.
         _elements[0].allowNewlinesWhenUnsplit = true;
-        if (firstIsUnindentedAdjacentStrings) {
+        if (arguments[0].blockFormatType ==
+            BlockFormat.unindentedAdjacentStrings) {
           _elements[0].indentWhenBlockFormatted = true;
         }
 
         // The block-formattable function.
         _elements[1].allowNewlinesWhenUnsplit = true;
-
-      // A function expression takes precedence over other block arguments.
-      case ([var element], _, _):
-        _elements[element].allowNewlinesWhenUnsplit = true;
-
-      // A single collection literal can be block formatted even if there are
-      // other arguments.
-      case ([], [var element], _):
-        _elements[element].allowNewlinesWhenUnsplit = true;
+        return;
+      }
     }
+
+    // If we get here, we have a block argument.
+    _elements[candidateIndex].allowNewlinesWhenUnsplit = true;
+  }
+
+  /// If an argument in [arguments] is a candidate to be block formatted,
+  /// returns its index.
+  ///
+  /// Otherwise, returns `-1`.
+  int _candidateBlockArgument(List<AstNode> arguments) {
+    var functionIndex = -1;
+    var collectionIndex = -1;
+    // var stringIndex = -1;
+
+    for (var i = 0; i < arguments.length; i++) {
+      // See if it's an expression that supports block formatting.
+      switch (arguments[i].blockFormatType) {
+        case BlockFormat.function:
+          if (functionIndex >= 0) {
+            functionIndex = -2;
+          } else {
+            functionIndex = i;
+          }
+
+        case BlockFormat.collection:
+          if (collectionIndex >= 0) {
+            collectionIndex = -2;
+          } else {
+            collectionIndex = i;
+          }
+
+        case BlockFormat.invocation:
+        case BlockFormat.indentedAdjacentStrings:
+        case BlockFormat.unindentedAdjacentStrings:
+        case BlockFormat.none:
+          break; // Normal argument.
+      }
+    }
+
+    if (functionIndex >= 0) return functionIndex;
+    if (collectionIndex >= 0) return collectionIndex;
+
+    return -1;
   }
 }

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -123,7 +123,7 @@ mixin PieceFactory {
         leftBracket: leftBracket,
         elements,
         rightBracket: rightBracket,
-        style: const ListStyle(allowBlockElement: true));
+        allowBlockArgument: true);
   }
 
   /// Writes a bracket-delimited block or declaration body.
@@ -974,7 +974,8 @@ mixin PieceFactory {
       {required Token leftBracket,
       required Token rightBracket,
       ListStyle style = const ListStyle(),
-      bool preserveNewlines = false}) {
+      bool preserveNewlines = false,
+      bool allowBlockArgument = false}) {
     // If the list is completely empty, write the brackets directly inline so
     // that we create fewer pieces.
     if (!elements.canSplit(rightBracket)) {
@@ -990,7 +991,7 @@ mixin PieceFactory {
     if (preserveNewlines && elements.containsLineComments(rightBracket)) {
       _preserveNewlinesInCollection(elements, builder);
     } else {
-      elements.forEach(builder.visit);
+      builder.visitAll(elements, allowBlockArgument: allowBlockArgument);
     }
 
     builder.rightBracket(rightBracket);

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -398,9 +398,10 @@ enum BlockFormat {
   /// elements.
   function,
 
-  /// The element is a collection literal.
+  /// The element is a collection literal or multiline string literal.
   ///
-  /// These can be block formatted even when there are other arguments.
+  /// If there is only one of these and no [BlockFormat.function] elements, then
+  /// it can be block formatted.
   collection,
 
   /// A function or method invocation.
@@ -410,7 +411,7 @@ enum BlockFormat {
 
   /// The element is an adjacent strings expression that's in an list that
   /// requires its subsequent lines to be indented (because there are other
-  /// string literal in the list).
+  /// string literals in the list).
   indentedAdjacentStrings,
 
   /// The element is an adjacent strings expression that's in an list that

--- a/lib/src/piece/list.dart
+++ b/lib/src/piece/list.dart
@@ -252,9 +252,6 @@ final class ListElementPiece extends Piece {
 
   final Piece? _content;
 
-  /// What kind of block formatting can be applied to this element.
-  final BlockFormat blockFormat;
-
   /// Whether newlines are allowed in this element when this list is unsplit.
   ///
   /// This is generally only true for a single "block" element, as in:
@@ -312,16 +309,13 @@ final class ListElementPiece extends Piece {
   /// delimiter (here `,` and 2).
   int _commentsBeforeDelimiter = 0;
 
-  ListElementPiece(
-      List<Piece> leadingComments, Piece element, BlockFormat format)
+  ListElementPiece(List<Piece> leadingComments, Piece element)
       : _leadingComments = [...leadingComments],
-        _content = element,
-        blockFormat = format;
+        _content = element;
 
   ListElementPiece.comment(Piece comment)
       : _leadingComments = const [],
-        _content = null,
-        blockFormat = BlockFormat.none {
+        _content = null {
     _hangingComments.add(comment);
   }
 
@@ -459,18 +453,8 @@ class ListStyle {
   ///     //              ^                      ^
   final bool spaceWhenUnsplit;
 
-  /// Whether an element in the list is allowed to have block-like formatting,
-  /// as in:
-  ///
-  ///     function(argument, [
-  ///       block,
-  ///       like,
-  ///     ], argument);
-  final bool allowBlockElement;
-
   const ListStyle(
       {this.commas = Commas.trailing,
       this.splitCost = Cost.normal,
-      this.spaceWhenUnsplit = false,
-      this.allowBlockElement = false});
+      this.spaceWhenUnsplit = false});
 }

--- a/test/tall/invocation/block_argument_description.stmt
+++ b/test/tall/invocation/block_argument_description.stmt
@@ -1,0 +1,104 @@
+40 columns                              |
+### Test how block formatting functions like test(), group(), that start with
+### leading adjacent strings behaves.
+>>> Adjacent strings preceding a function expression doesn't prevent block formatting.
+test('First adjacent string' 'second adjacent string'
+'third adjacent string', () async {
+  ;
+});
+<<<
+test('First adjacent string'
+    'second adjacent string'
+    'third adjacent string', () async {
+  ;
+});
+>>> Don't block format a function with a preceding adjacent string if it doesn't fit.
+test('First adjacent string' 'second long adjacent string', () async {
+  ;
+});
+<<<
+test(
+  'First adjacent string'
+  'second long adjacent string',
+  () async {
+    ;
+  },
+);
+>>> Don't block format adjacent strings preceding a non-function block argument.
+test('First adjacent string'
+    'second adjacent string'
+    'third adjacent string', [
+  element1,
+  element2,
+  element3,
+  element4,
+]);
+<<<
+test(
+  'First adjacent string'
+  'second adjacent string'
+  'third adjacent string',
+  [
+    element1,
+    element2,
+    element3,
+    element4,
+  ],
+);
+>>> Another string argument doesn't prevent block formatting.
+test('First string line 1' 'first string line 2', () {
+  ;
+}, 'Another simple string');
+<<<
+test('First string line 1'
+    'first string line 2', () {
+  ;
+}, 'Another simple string');
+>>> Multiple trailing arguments prevent block formatting.
+test('First string line 1' 'first string line 2', () {
+  ;
+}, trailing, another);
+<<<
+test(
+  'First string line 1'
+  'first string line 2',
+  () {
+    ;
+  },
+  trailing,
+  another,
+);
+>>> Don't block format if the leading string is named.
+test(named: 'First string line 1' 'first string line 2', () {
+  ;
+});
+<<<
+test(
+  named:
+      'First string line 1'
+      'first string line 2',
+  () {
+    ;
+  },
+);
+>>> Don't block format if the leading function is named.
+test('First string line 1' 'first string line 2', named: () {
+  ;
+});
+<<<
+test(
+  'First string line 1'
+  'first string line 2',
+  named: () {
+    ;
+  },
+);
+>>> Allow block formatting when the trailing argument is named.
+test('First string line 1' 'first string line 2', () {
+  ;
+}, named: arg);
+<<<
+test('First string line 1'
+    'first string line 2', () {
+  ;
+}, named: arg);

--- a/test/tall/invocation/block_argument_multiple.stmt
+++ b/test/tall/invocation/block_argument_multiple.stmt
@@ -150,7 +150,7 @@ function(switch (a) {}, switch (b) { 1 => 2 }, switch (c) {});
 function(switch (a) {}, switch (b) {
   1 => 2,
 }, switch (c) {});
->>> Collection and multi-line string prevents block formatting.
+>>> Collection and multiline string prevents block formatting.
 function([element, element], '''multiple
 lines''');
 <<<
@@ -158,71 +158,4 @@ function(
   [element, element],
   '''multiple
 lines''',
-);
->>> Adjacent strings preceding a function expression doesn't prevent block formatting.
-test('First adjacent string' 'second adjacent string'
-'third adjacent string', () async {
-  ;
-});
-<<<
-test('First adjacent string'
-    'second adjacent string'
-    'third adjacent string', () async {
-  ;
-});
->>> Don't block format a function with a preceding adjacent string if it doesn't fit.
-test('First adjacent string' 'second long adjacent string', () async {
-  ;
-});
-<<<
-test(
-  'First adjacent string'
-  'second long adjacent string',
-  () async {
-    ;
-  },
-);
->>> Don't block format adjacent strings preceding a non-function block argument.
-test('First adjacent string'
-    'second adjacent string'
-    'third adjacent string', [
-  element1,
-  element2,
-  element3,
-  element4,
-]);
-<<<
-test(
-  'First adjacent string'
-  'second adjacent string'
-  'third adjacent string',
-  [
-    element1,
-    element2,
-    element3,
-    element4,
-  ],
-);
->>> Other string arguments don't prevent block formatting.
-test('First string line 1' 'first string line 2', () {
-  ;
-}, 'Another simple string');
-<<<
-test('First string line 1'
-    'first string line 2', () {
-  ;
-}, 'Another simple string');
->>> Other adjacent string arguments prevent block formatting.
-test('First string line 1' 'first string line 2', () {
-  ;
-}, 'Another adjacent' 'string argument');
-<<<
-test(
-  'First string line 1'
-      'first string line 2',
-  () {
-    ;
-  },
-  'Another adjacent'
-      'string argument',
 );

--- a/test/tall/invocation/block_argument_named.stmt
+++ b/test/tall/invocation/block_argument_named.stmt
@@ -1,0 +1,66 @@
+40 columns                              |
+### Test how named arguments interact with block formatting.
+>>> Block format all positional.
+function(be, fore, [element, element], after);
+<<<
+function(be, fore, [
+  element,
+  element,
+], after);
+>>> Block format named only leading.
+function(a: be, b: fore, [element, element], after);
+<<<
+function(a: be, b: fore, [
+  element,
+  element,
+], after);
+>>> Block format named only block argument.
+function(be, fore, a: [element, element], after);
+<<<
+function(be, fore, a: [
+  element,
+  element,
+], after);
+>>> Block format named only trailing.
+function(be, fore, [element, element], a: after);
+<<<
+function(be, fore, [
+  element,
+  element,
+], a: after);
+>>> Don't block format named leading and block argument.
+function(a: be, fore, b: [element, element], after);
+<<<
+function(
+  a: be,
+  fore,
+  b: [element, element],
+  after,
+);
+>>> Don't block format named leading and trailing.
+function(a: be, fore, [element, element], b: after);
+<<<
+function(
+  a: be,
+  fore,
+  [element, element],
+  b: after,
+);
+>>> Don't block format named block argument and trailing.
+function(be, fore, a: [element, element], b: after);
+<<<
+function(
+  be,
+  fore,
+  a: [element, element],
+  b: after,
+);
+>>> Don't block format all named.
+function(a: be, b: fore, c: [element, element], d: after);
+<<<
+function(
+  a: be,
+  b: fore,
+  c: [element, element],
+  d: after,
+);

--- a/test/tall/invocation/block_argument_other.stmt
+++ b/test/tall/invocation/block_argument_other.stmt
@@ -64,3 +64,11 @@ veryLongFunctionName(
     element,
   ],
 );
+>>> Multiple trailing arguments prevent block formatting.
+function([element, element, element], trailing, argument);
+<<<
+function(
+  [element, element, element],
+  trailing,
+  argument,
+);

--- a/test/tall/invocation/block_argument_string.stmt
+++ b/test/tall/invocation/block_argument_string.stmt
@@ -1,6 +1,6 @@
 40 columns                              |
-### Test multi-line strings as block arguments.
->>> Allow block formatting a multi-line string.
+### Test multiline strings as block arguments.
+>>> Allow block formatting a multiline string.
 someMethod("""first line fits in here
 more stuff down here too that is long
 """);
@@ -16,7 +16,7 @@ more stuff down here too that is long
 someMethod('''first line fits in here
 more stuff down here too that is long
 ''');
->>> Allow block formatting a multi-line string with interpolation.
+>>> Allow block formatting a multiline string with interpolation.
 someMethod("""first line fits in here
 more stuff $down here too that is long
 """);
@@ -40,7 +40,7 @@ someMethod(
   """first line does not fit here
 """,
 );
->>> Block format multi-line string with non-block arguments before.
+>>> Block format multiline string with non-block arguments before.
 someMethod("foo", "bar", """
 some
 text
@@ -50,17 +50,31 @@ someMethod("foo", "bar", """
 some
 text
 """);
->>> Block format multi-line string with non-block arguments after.
+>>> Block format multiline string with one argument after.
+someMethod("""
+some
+text
+""", "foo");
+<<<
+someMethod("""
+some
+text
+""", "foo");
+>>> Don't block format multiline string with multiple arguments after.
 someMethod("""
 some
 text
 """, "foo", "bar");
 <<<
-someMethod("""
+someMethod(
+  """
 some
 text
-""", "foo", "bar");
->>> Block format multi-line string with non-block arguments before and after.
+""",
+  "foo",
+  "bar",
+);
+>>> Block format multiline string with non-block arguments before and after.
 someMethod("foo", """
 some
 text
@@ -71,7 +85,7 @@ someMethod("foo", """
 some
 text
 """, "bar");
->>> Can't have multiple block formatted multi-line strings.
+>>> Can't have multiple block formatted multiline strings.
 someMethod("""
 some
 text

--- a/test/tall/regression/0100/0146.unit
+++ b/test/tall/regression/0100/0146.unit
@@ -3,18 +3,13 @@ main() {
   foo([1, 2, 4, 5, 6, 7, 8, 20], argument, argument, argument, argument, argument);
 }
 <<<
-### TODO(rnystrom): This would look better with the list unsplit and the
-### argument list split. Should we take the number of elements into account
-### when deciding whether or not to do a block argument?
 main() {
-  foo([
-    1,
-    2,
-    4,
-    5,
-    6,
-    7,
-    8,
-    20,
-  ], argument, argument, argument, argument, argument);
+  foo(
+    [1, 2, 4, 5, 6, 7, 8, 20],
+    argument,
+    argument,
+    argument,
+    argument,
+    argument,
+  );
 }

--- a/test/tall/regression/0200/0243.stmt
+++ b/test/tall/regression/0200/0243.stmt
@@ -7,13 +7,16 @@
               style: _content_style,
               children: appChildren)]);
 <<<
-    return new Container(key: 'ChatApp', children: [
-      new Container(
-        key: 'Content',
-        style: _content_style,
-        children: appChildren,
-      ),
-    ]);
+    return new Container(
+      key: 'ChatApp',
+      children: [
+        new Container(
+          key: 'Content',
+          style: _content_style,
+          children: appChildren,
+        ),
+      ],
+    );
 >>> (indent 10)
           return new Container(
               key: 'ChatApp',
@@ -23,10 +26,13 @@
                     style: _content_style,
                     children: appChildren)]);
 <<<
-          return new Container(key: 'ChatApp', children: [
-            new Container(
-              key: 'Content',
-              style: _content_style,
-              children: appChildren,
-            ),
-          ]);
+          return new Container(
+            key: 'ChatApp',
+            children: [
+              new Container(
+                key: 'Content',
+                style: _content_style,
+                children: appChildren,
+              ),
+            ],
+          );

--- a/test/tall/regression/0300/0394.stmt
+++ b/test/tall/regression/0300/0394.stmt
@@ -15,13 +15,24 @@ return $.Div(inner: [
 ]);
 <<<
 return $.Div(inner: [
-  $.Div(id: "container", inner: [
-    $.Canvas(width: maxD, height: maxD, clazz: "center", ref: canvas),
-    $.Form(clazz: "center", inner: [
-      $.Input(type: "range", max: 1000, value: seeds, onChange: onSliderChange),
-    ]),
-    $.Img(src: "math.png", width: "350px", height: "42px", clazz: "center"),
-  ]),
+  $.Div(
+    id: "container",
+    inner: [
+      $.Canvas(width: maxD, height: maxD, clazz: "center", ref: canvas),
+      $.Form(
+        clazz: "center",
+        inner: [
+          $.Input(
+            type: "range",
+            max: 1000,
+            value: seeds,
+            onChange: onSliderChange,
+          ),
+        ],
+      ),
+      $.Img(src: "math.png", width: "350px", height: "42px", clazz: "center"),
+    ],
+  ),
 
   $.Footer(inner: [$.P(id: "notes", inner: "${seeds} seeds")]),
 ]);

--- a/test/tall/regression/0400/0421.unit
+++ b/test/tall/regression/0400/0421.unit
@@ -10,13 +10,16 @@ class MyAmazingComponent {
   var a = [[[1]]];
 }
 <<<
-@Component(selector: 'my-selector', properties: const [
-  'property-1',
-  'property-2',
-  'property-3',
-  'property-4',
-  'property-5',
-])
+@Component(
+  selector: 'my-selector',
+  properties: const [
+    'property-1',
+    'property-2',
+    'property-3',
+    'property-4',
+    'property-5',
+  ],
+)
 @View(
   directives: const [
     OtherComponent1,
@@ -52,13 +55,16 @@ class MyAmazingComponent {
   var a = [[[1]]];
 }
 <<<
-@Component(selector: 'my-selector', properties: const [
-  'property-1',
-  'property-2',
-  'property-3',
-  'property-4',
-  'property-5',
-])
+@Component(
+  selector: 'my-selector',
+  properties: const [
+    'property-1',
+    'property-2',
+    'property-3',
+    'property-4',
+    'property-5',
+  ],
+)
 @View(
   directives: const [
     OtherComponent1,

--- a/test/tall/regression/0400/0478.stmt
+++ b/test/tall/regression/0400/0478.stmt
@@ -38,9 +38,12 @@
         }));
 <<<
         statusBarWidgets.add(
-          new IconButton(icon: "action/swap_vert", onPressed: () {
-            setState(() {
-              _showSplitView = !_showSplitView;
-            });
-          }),
+          new IconButton(
+            icon: "action/swap_vert",
+            onPressed: () {
+              setState(() {
+                _showSplitView = !_showSplitView;
+              });
+            },
+          ),
         );

--- a/test/tall/regression/0500/0568.unit
+++ b/test/tall/regression/0500/0568.unit
@@ -6,7 +6,10 @@ void main() {
 }
 <<<
 void main() {
-  var controller = new StreamController<T>(sync: true, onCancel: () {
-    return Future.wait(operationSet.map((operation) => operation.cancel()));
-  });
+  var controller = new StreamController<T>(
+    sync: true,
+    onCancel: () {
+      return Future.wait(operationSet.map((operation) => operation.cancel()));
+    },
+  );
 }

--- a/test/tall/regression/0800/0809.unit
+++ b/test/tall/regression/0800/0809.unit
@@ -44,19 +44,23 @@ class MyApp extends StatelessWidget {
     );
   }
 
-  Widget buildRow() =>
-      Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [
-        Image.asset('images/pic1.jpg'),
-        Image.asset('images/pic2.jpg'),
-        Image.asset('images/pic3.jpg'),
-      ]);
+  Widget buildRow() => Row(
+    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+    children: [
+      Image.asset('images/pic1.jpg'),
+      Image.asset('images/pic2.jpg'),
+      Image.asset('images/pic3.jpg'),
+    ],
+  );
 
-  Widget buildColumn() =>
-      Column(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [
-        Image.asset('images/pic1.jpg'),
-        Image.asset('images/pic2.jpg'),
-        Image.asset('images/pic3.jpg'),
-      ]);
+  Widget buildColumn() => Column(
+    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+    children: [
+      Image.asset('images/pic1.jpg'),
+      Image.asset('images/pic2.jpg'),
+      Image.asset('images/pic3.jpg'),
+    ],
+  );
 }
 >>>
 class MyApp extends StatelessWidget {

--- a/test/tall/regression/1400/1441.unit
+++ b/test/tall/regression/1400/1441.unit
@@ -32,9 +32,10 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-        const Text('你好'),
-      ]),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [const Text('你好')],
+      ),
     );
   }
 }

--- a/test/tall/regression/1500/1526.stmt
+++ b/test/tall/regression/1500/1526.stmt
@@ -30,10 +30,13 @@
             'nameStartsWith': cleanNameFilter,
         }, cancelToken: cancelToken);
 <<<
-    final response = await _get('characters', queryParameters:
-        <String, Object?>{
-          'offset': offset,
-          if (limit != null) 'limit': limit,
-          if (cleanNameFilter != null && cleanNameFilter.isNotEmpty)
-            'nameStartsWith': cleanNameFilter,
-        }, cancelToken: cancelToken);
+    final response = await _get(
+      'characters',
+      queryParameters: <String, Object?>{
+        'offset': offset,
+        if (limit != null) 'limit': limit,
+        if (cleanNameFilter != null && cleanNameFilter.isNotEmpty)
+          'nameStartsWith': cleanNameFilter,
+      },
+      cancelToken: cancelToken,
+    );

--- a/test/tall/regression/1500/1527.unit
+++ b/test/tall/regression/1500/1527.unit
@@ -1,0 +1,114 @@
+>>>
+class C {
+  Result<Res> chain<Res>(Res Function(T value) cb) {
+    return when(data: (value) {
+      try {
+        return Result.data(cb(value));
+      } catch (err, stack) {
+        return Result.error(err, stack);
+      }
+    }, error: Result.error);
+  }
+
+  T get dataOrThrow {
+    return when(data: (value) => value, error: (err, stack) {
+      // ignore: only_throw_errors
+      throw err;
+    });
+  }
+}
+<<<
+class C {
+  Result<Res> chain<Res>(Res Function(T value) cb) {
+    return when(
+      data: (value) {
+        try {
+          return Result.data(cb(value));
+        } catch (err, stack) {
+          return Result.error(err, stack);
+        }
+      },
+      error: Result.error,
+    );
+  }
+
+  T get dataOrThrow {
+    return when(
+      data: (value) => value,
+      error: (err, stack) {
+        // ignore: only_throw_errors
+        throw err;
+      },
+    );
+  }
+}
+>>>
+main() {
+  test(
+    'Test stuff',
+    () {
+      // Oof, too much indentation...
+      expect(stuff, otherStuff);
+    },
+    tags: ['hi'],
+  );
+}
+<<<
+main() {
+  test('Test stuff', () {
+    // Oof, too much indentation...
+    expect(stuff, otherStuff);
+  }, tags: ['hi']);
+}
+>>> (indent 2)
+  main() {
+    return Scaffold(
+      body: Center(child: AnimatedDigit(value: value % 10)),
+      floatingActionButton: FloatingActionButton(onPressed: () {
+        setState(() {
+          value += 1;
+        });
+      }, tooltip: 'Increment Digit', child: const Icon(Icons.add)),
+    );
+  }
+<<<
+  main() {
+    return Scaffold(
+      body: Center(child: AnimatedDigit(value: value % 10)),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          setState(() {
+            value += 1;
+          });
+        },
+        tooltip: 'Increment Digit',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+>>>
+final CatmullRomSpline path = CatmullRomSpline(const <Offset>[
+  Offset(0.05, 0.75),
+  Offset(0.18, 0.23),
+  Offset(0.32, 0.04),
+  Offset(0.73, 0.5),
+  Offset(0.42, 0.74),
+  Offset(0.73, 0.01),
+  Offset(0.93, 0.93),
+  Offset(0.05, 0.75),
+], startHandle: const Offset(0.93, 0.93), endHandle: const Offset(0.18, 0.23));
+<<<
+final CatmullRomSpline path = CatmullRomSpline(
+  const <Offset>[
+    Offset(0.05, 0.75),
+    Offset(0.18, 0.23),
+    Offset(0.32, 0.04),
+    Offset(0.73, 0.5),
+    Offset(0.42, 0.74),
+    Offset(0.73, 0.01),
+    Offset(0.93, 0.93),
+    Offset(0.05, 0.75),
+  ],
+  startHandle: const Offset(0.93, 0.93),
+  endHandle: const Offset(0.18, 0.23),
+);

--- a/test/tall/regression/1500/1528.stmt
+++ b/test/tall/regression/1500/1528.stmt
@@ -1,0 +1,9 @@
+>>> (indent 10)
+          result = ProviderScope(overrides: [
+            selectedCharacterId.overrideWithValue(split.last),
+          ], child: const CharacterView());
+<<<
+          result = ProviderScope(
+            overrides: [selectedCharacterId.overrideWithValue(split.last)],
+            child: const CharacterView(),
+          );

--- a/test/tall/regression/1500/1531.stmt
+++ b/test/tall/regression/1500/1531.stmt
@@ -15,18 +15,23 @@ variable = await function(
           HttpHeaders.contentTypeHeader: ContentType.json.value,
         }, body: json.encode(discordPayload));
 <<<
-    final response = await post(Uri.parse(webhookUrl), headers: {
-      HttpHeaders.contentTypeHeader: ContentType.json.value,
-    }, body: json.encode(discordPayload));
+    final response = await post(
+      Uri.parse(webhookUrl),
+      headers: {HttpHeaders.contentTypeHeader: ContentType.json.value},
+      body: json.encode(discordPayload),
+    );
 >>> (indent 2)
   final token =
       await jwt.verify('<TOKEN>', issuer: '<ISSUER>', audience: {
         '<AUDIENCE>',
       }, publicKeysUrl: '<PUBLIC_KEYS_URL>');
 <<<
-  final token = await jwt.verify('<TOKEN>', issuer: '<ISSUER>', audience: {
-    '<AUDIENCE>',
-  }, publicKeysUrl: '<PUBLIC_KEYS_URL>');
+  final token = await jwt.verify(
+    '<TOKEN>',
+    issuer: '<ISSUER>',
+    audience: {'<AUDIENCE>'},
+    publicKeysUrl: '<PUBLIC_KEYS_URL>',
+  );
 >>> (indent 6)
       final connection =
           await connectSocket(

--- a/test/tall/regression/1500/1543.unit
+++ b/test/tall/regression/1500/1543.unit
@@ -1,0 +1,15 @@
+>>>
+void main() async {
+  fn(param1: true, paraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaam2: [
+    ['value'],
+  ]);
+}
+<<<
+void main() async {
+  fn(
+    param1: true,
+    paraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaam2: [
+      ['value'],
+    ],
+  );
+}


### PR DESCRIPTION
This produces output that better matches what users expected in the associated issues. I think it also looks better in the affected regression tests. And I ran this on a large corpus and looking at the diffs, these rules seem to be much better across the board.

The new rules are basically:

* A block formatted argument list can't end up with named arguments on multiple lines.

* Only one trailing argument is allowed after the block argument.

The existing rules are also kept:

* Prefer a function block argument over a collection one.

* Only allow a single block argument.

* Allow the first argument to be adjacent strings with a later function block argument (to handle calls like `test()` and `group()`).

Fix #1527.
Fix #1528.
Fix #1543.
