### PR TITLE
Correctly format imports with both `as` and `if` clauses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   flag (#361).
 * Preserve type parameters on old-style function-typed formals that also use
   `this.` or `super.` (#1321).
+* Correctly format imports with both `as` and `if` clauses (#1544).
 * Remove temporary work around for analyzer 6.2.0 from dart_style 2.3.6.
 * Require `package:analyzer` `>=6.5.0 <7.0.0`.
 

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -812,13 +812,8 @@ mixin PieceFactory {
         pieces.visit(directive.uri);
       });
 
-      // Include any `if` clauses.
-      var clauses = <Piece>[];
-      for (var configuration in directive.configurations) {
-        clauses.add(nodePiece(configuration));
-      }
-
       // Include the `as` clause.
+      var clauses = <Piece>[];
       if (asKeyword != null) {
         clauses.add(pieces.build(() {
           pieces.token(deferredKeyword, spaceAfter: true);
@@ -826,6 +821,11 @@ mixin PieceFactory {
           pieces.space();
           pieces.visit(prefix!);
         }));
+      }
+
+      // Include any `if` clauses.
+      for (var configuration in directive.configurations) {
+        clauses.add(nodePiece(configuration));
       }
 
       // Include the `show` and `hide` clauses.

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -1955,8 +1955,6 @@ class SourceVisitor extends ThrowingAstVisitor {
       space();
       visit(node.uri);
 
-      _visitConfigurations(node.configurations);
-
       if (node.asKeyword != null) {
         soloSplit();
         token(node.deferredKeyword, after: space);
@@ -1965,6 +1963,7 @@ class SourceVisitor extends ThrowingAstVisitor {
         visit(node.prefix);
       }
 
+      _visitConfigurations(node.configurations);
       _visitCombinators(node.combinators);
     });
   }

--- a/test/short/regression/1500/1544.unit
+++ b/test/short/regression/1500/1544.unit
@@ -1,0 +1,99 @@
+>>>
+import 'package:archive/archive.dart' as archive
+  if (dart.library.io) 'package:archive/archive_io.dart';
+import 'package:flutter/services.dart';
+import 'package:fuzzy/web/e621/e621.dart';
+import 'package:fuzzy/web/e621/models/tag_d_b.dart';
+import 'package:http/http.dart' as http;
+import 'package:j_util/e621.dart' as e621;
+import 'package:fuzzy/log_management.dart' as lm;
+import 'package:j_util/j_util_full.dart';
+import 'package:flutter/foundation.dart';
+
+// #region Logger
+lm.Printer get _print => lRecord.print;
+lm.FileLogger get _logger => lRecord.logger;
+// ignore: unnecessary_late
+late final lRecord = lm.generateLogger("TagDbImport");
+// #endregion Logger
+const bool DO_NOT_USE_TAG_DB = true;
+final tagDb = LateFinal<TagDB>();
+Future<TagDB> _core(String vf) {
+  _print("Tag Database Decompressed!");
+  return TagDB.makeFromCsvString(vf);
+}
+Future<TagDB> _androidCallback(http.StreamedResponse value) {
+  return decompressGzPlainTextStream(value).then(_core);
+}
+Future<TagDB> _webCallback(ByteData data) {
+  return http.ByteStream.fromBytes(
+            archive.GZipDecoder().decodeBuffer(archive.InputStream(data)))
+        .bytesToString()
+        .then(_core);
+}
+final LazyInitializer<TagDB> tagDbLazy = LazyInitializer(() async {
+  if (Platform.isWeb) {
+    var data = await rootBundle.load("assets/tags-2024-06-05.csv.gz");
+    _print("Tag Database Loaded!");
+    return compute(_webCallback, data);
+  } else {
+    return
+        E621.sendRequest(e621.Api.initDbExportRequest())
+        .then((value) => compute(_androidCallback, value));
+        // E621ApiEndpoints.dbExportTags
+        // .getMoreData()
+        // .sendRequest()
+        // .then((value) => compute(_androidCallback, value));
+  }
+});
+<<<
+import 'package:archive/archive.dart' as archive
+    if (dart.library.io) 'package:archive/archive_io.dart';
+import 'package:flutter/services.dart';
+import 'package:fuzzy/web/e621/e621.dart';
+import 'package:fuzzy/web/e621/models/tag_d_b.dart';
+import 'package:http/http.dart' as http;
+import 'package:j_util/e621.dart' as e621;
+import 'package:fuzzy/log_management.dart' as lm;
+import 'package:j_util/j_util_full.dart';
+import 'package:flutter/foundation.dart';
+
+// #region Logger
+lm.Printer get _print => lRecord.print;
+lm.FileLogger get _logger => lRecord.logger;
+// ignore: unnecessary_late
+late final lRecord = lm.generateLogger("TagDbImport");
+// #endregion Logger
+const bool DO_NOT_USE_TAG_DB = true;
+final tagDb = LateFinal<TagDB>();
+Future<TagDB> _core(String vf) {
+  _print("Tag Database Decompressed!");
+  return TagDB.makeFromCsvString(vf);
+}
+
+Future<TagDB> _androidCallback(http.StreamedResponse value) {
+  return decompressGzPlainTextStream(value).then(_core);
+}
+
+Future<TagDB> _webCallback(ByteData data) {
+  return http.ByteStream.fromBytes(
+          archive.GZipDecoder().decodeBuffer(archive.InputStream(data)))
+      .bytesToString()
+      .then(_core);
+}
+
+final LazyInitializer<TagDB> tagDbLazy = LazyInitializer(() async {
+  if (Platform.isWeb) {
+    var data = await rootBundle.load("assets/tags-2024-06-05.csv.gz");
+    _print("Tag Database Loaded!");
+    return compute(_webCallback, data);
+  } else {
+    return E621
+        .sendRequest(e621.Api.initDbExportRequest())
+        .then((value) => compute(_androidCallback, value));
+    // E621ApiEndpoints.dbExportTags
+    // .getMoreData()
+    // .sendRequest()
+    // .then((value) => compute(_androidCallback, value));
+  }
+});

--- a/test/short/whitespace/directives.unit
+++ b/test/short/whitespace/directives.unit
@@ -66,3 +66,8 @@ export 'a' if (b.c == 'd') 'e';
 part   of'uri.dart'     ;
 <<<
 part of 'uri.dart';
+>>> Both configuration and prefix.
+import 'foo.dart' as foo if (config == 'value') 'other.dart';
+<<<
+import 'foo.dart' as foo
+    if (config == 'value') 'other.dart';

--- a/test/tall/regression/1500/1544.unit
+++ b/test/tall/regression/1500/1544.unit
@@ -1,0 +1,99 @@
+>>>
+import 'package:archive/archive.dart' as archive
+  if (dart.library.io) 'package:archive/archive_io.dart';
+import 'package:flutter/services.dart';
+import 'package:fuzzy/web/e621/e621.dart';
+import 'package:fuzzy/web/e621/models/tag_d_b.dart';
+import 'package:http/http.dart' as http;
+import 'package:j_util/e621.dart' as e621;
+import 'package:fuzzy/log_management.dart' as lm;
+import 'package:j_util/j_util_full.dart';
+import 'package:flutter/foundation.dart';
+
+// #region Logger
+lm.Printer get _print => lRecord.print;
+lm.FileLogger get _logger => lRecord.logger;
+// ignore: unnecessary_late
+late final lRecord = lm.generateLogger("TagDbImport");
+// #endregion Logger
+const bool DO_NOT_USE_TAG_DB = true;
+final tagDb = LateFinal<TagDB>();
+Future<TagDB> _core(String vf) {
+  _print("Tag Database Decompressed!");
+  return TagDB.makeFromCsvString(vf);
+}
+Future<TagDB> _androidCallback(http.StreamedResponse value) {
+  return decompressGzPlainTextStream(value).then(_core);
+}
+Future<TagDB> _webCallback(ByteData data) {
+  return http.ByteStream.fromBytes(
+            archive.GZipDecoder().decodeBuffer(archive.InputStream(data)))
+        .bytesToString()
+        .then(_core);
+}
+final LazyInitializer<TagDB> tagDbLazy = LazyInitializer(() async {
+  if (Platform.isWeb) {
+    var data = await rootBundle.load("assets/tags-2024-06-05.csv.gz");
+    _print("Tag Database Loaded!");
+    return compute(_webCallback, data);
+  } else {
+    return
+        E621.sendRequest(e621.Api.initDbExportRequest())
+        .then((value) => compute(_androidCallback, value));
+        // E621ApiEndpoints.dbExportTags
+        // .getMoreData()
+        // .sendRequest()
+        // .then((value) => compute(_androidCallback, value));
+  }
+});
+<<<
+import 'package:archive/archive.dart'
+    as archive
+    if (dart.library.io) 'package:archive/archive_io.dart';
+import 'package:flutter/services.dart';
+import 'package:fuzzy/web/e621/e621.dart';
+import 'package:fuzzy/web/e621/models/tag_d_b.dart';
+import 'package:http/http.dart' as http;
+import 'package:j_util/e621.dart' as e621;
+import 'package:fuzzy/log_management.dart' as lm;
+import 'package:j_util/j_util_full.dart';
+import 'package:flutter/foundation.dart';
+
+// #region Logger
+lm.Printer get _print => lRecord.print;
+lm.FileLogger get _logger => lRecord.logger;
+// ignore: unnecessary_late
+late final lRecord = lm.generateLogger("TagDbImport");
+// #endregion Logger
+const bool DO_NOT_USE_TAG_DB = true;
+final tagDb = LateFinal<TagDB>();
+Future<TagDB> _core(String vf) {
+  _print("Tag Database Decompressed!");
+  return TagDB.makeFromCsvString(vf);
+}
+
+Future<TagDB> _androidCallback(http.StreamedResponse value) {
+  return decompressGzPlainTextStream(value).then(_core);
+}
+
+Future<TagDB> _webCallback(ByteData data) {
+  return http.ByteStream.fromBytes(
+    archive.GZipDecoder().decodeBuffer(archive.InputStream(data)),
+  ).bytesToString().then(_core);
+}
+
+final LazyInitializer<TagDB> tagDbLazy = LazyInitializer(() async {
+  if (Platform.isWeb) {
+    var data = await rootBundle.load("assets/tags-2024-06-05.csv.gz");
+    _print("Tag Database Loaded!");
+    return compute(_webCallback, data);
+  } else {
+    return E621
+        .sendRequest(e621.Api.initDbExportRequest())
+        .then((value) => compute(_androidCallback, value));
+    // E621ApiEndpoints.dbExportTags
+    // .getMoreData()
+    // .sendRequest()
+    // .then((value) => compute(_androidCallback, value));
+  }
+});

--- a/test/tall/top_level/import.unit
+++ b/test/tall/top_level/import.unit
@@ -68,3 +68,9 @@ import 'some/uri.dart' if (config.name.debug == 'string') 'c';
 import 'some/uri.dart'
     if (config.name.debug ==
         'string') 'c';
+>>> Both configuration and prefix.
+import 'foo.dart' as foo if (config == 'value') 'other.dart';
+<<<
+import 'foo.dart'
+    as foo
+    if (config == 'value') 'other.dart';


### PR DESCRIPTION
It would output the `as` clause after the `if` clauses, which isn't syntactically valid. Apparently no one has ever had a conditional import with as prefix because this was a bug in both the old and new formatters and has been a bug in the old formatter forever.

Fix #1544.
