### PR TITLE
Handle imports with "as" and "if" clauses in either order.

### DIFF
--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -812,8 +812,26 @@ mixin PieceFactory {
         pieces.visit(directive.uri);
       });
 
-      // Include the `as` clause.
+      // Add all of the clauses and combinators.
       var clauses = <Piece>[];
+
+      // The language specifies that configurations must appear after any `as`
+      // clause but the parser incorrectly accepts them before it and code in
+      // the wild relies on that. Instead of failing with an "unexpected output"
+      // error, just preserve the order of the clauses if they are out of order.
+      // See: https://github.com/dart-lang/sdk/issues/56641
+      var wroteConfigurations = false;
+      if (directive.configurations.isNotEmpty &&
+          asKeyword != null &&
+          directive.configurations.first.ifKeyword.offset < asKeyword.offset) {
+        for (var configuration in directive.configurations) {
+          clauses.add(nodePiece(configuration));
+        }
+
+        wroteConfigurations = true;
+      }
+
+      // Include the `as` clause.
       if (asKeyword != null) {
         clauses.add(pieces.build(() {
           pieces.token(deferredKeyword, spaceAfter: true);
@@ -824,8 +842,10 @@ mixin PieceFactory {
       }
 
       // Include any `if` clauses.
-      for (var configuration in directive.configurations) {
-        clauses.add(nodePiece(configuration));
+      if (!wroteConfigurations) {
+        for (var configuration in directive.configurations) {
+          clauses.add(nodePiece(configuration));
+        }
       }
 
       // Include the `show` and `hide` clauses.

--- a/test/short/whitespace/directives.unit
+++ b/test/short/whitespace/directives.unit
@@ -71,3 +71,12 @@ import 'foo.dart' as foo if (config == 'value') 'other.dart';
 <<<
 import 'foo.dart' as foo
     if (config == 'value') 'other.dart';
+>>> Configuration before prefix.
+### This violates the language spec, but the parser currently allows it without
+### reporting an error and code in the wild relies on that. So the formatter
+### handles it gracefully. See: https://github.com/dart-lang/sdk/issues/56641
+import 'foo.dart' if (config == 'value') 'other.dart' as foo;
+<<<
+import 'foo.dart'
+    if (config == 'value') 'other.dart'
+    as foo;

--- a/test/tall/top_level/import.unit
+++ b/test/tall/top_level/import.unit
@@ -74,3 +74,12 @@ import 'foo.dart' as foo if (config == 'value') 'other.dart';
 import 'foo.dart'
     as foo
     if (config == 'value') 'other.dart';
+>>> Configuration before prefix.
+### This violates the language spec, but the parser currently allows it without
+### reporting an error and code in the wild relies on that. So the formatter
+### handles it gracefully. See: https://github.com/dart-lang/sdk/issues/56641
+import 'foo.dart' if (config == 'value') 'other.dart' as foo;
+<<<
+import 'foo.dart'
+    if (config == 'value') 'other.dart'
+    as foo;


### PR DESCRIPTION
PR #1550 fixed the bug where if you had both clauses, it would output them in the *wrong* order. But it turns out that the parser today allows them in *either* order even though the language spec doesn't.

Since I've seen a handful of cases like this in the wild, instead of just failing to format, simply preserve the clause order that the user wrote.
