### PR TITLE
Don't crash on an index cascade section followed by a method chain.

### DIFF
--- a/lib/src/front_end/chain_builder.dart
+++ b/lib/src/front_end/chain_builder.dart
@@ -327,8 +327,8 @@ class ChainBuilder {
           });
         });
 
-      case IndexExpression():
-        _unwrapPostfix(expression.target!, (target) {
+      case IndexExpression(:var target?):
+        _unwrapPostfix(target, (target) {
           return _visitor.pieces.build(() {
             _visitor.pieces.add(target);
             _visitor.writeIndexExpression(expression);

--- a/lib/src/front_end/chain_builder.dart
+++ b/lib/src/front_end/chain_builder.dart
@@ -328,6 +328,11 @@ class ChainBuilder {
         });
 
       case IndexExpression(:var target?):
+        // We check for a non-null target because the target may be `null` if
+        // the chain we are building is itself in a cascade section that begins
+        // with an index expression like:
+        //
+        //     object..[index].chain();
         _unwrapPostfix(target, (target) {
           return _visitor.pieces.build(() {
             _visitor.pieces.add(target);

--- a/test/tall/invocation/cascade_mixed.stmt
+++ b/test/tall/invocation/cascade_mixed.stmt
@@ -37,3 +37,7 @@ object
   ..cascade()!
   ..cascade()[index]
   ..cascade()(arg);
+>>> Chain with index target.
+object..[index].method();
+<<<
+object..[index].method();


### PR DESCRIPTION
I found this weird corner case in the wild when formatting a large corpus.
