### PR TITLE
Fix test that fails on Windows.

### DIFF
--- a/test/command_test.dart
+++ b/test/command_test.dart
@@ -633,7 +633,7 @@ main() {
         expect(await process.stderr.next,
             'Could not format because the source could not be parsed:');
         expect(await process.stderr.next, '');
-        expect(await process.stderr.next, contains(p.join('foo', 'main.dart')));
+        expect(await process.stderr.next, contains('main.dart'));
         await process.shouldExit(65);
       });
 


### PR DESCRIPTION
I guess Dart on Windows uses `/` as a path separator in stack traces?

I'm not sure if it's safe to rely on that, so just tweaking the expectation to not care about the separator at all.
