### PR TITLE
Don't allow a block argument to be named.

### DIFF
--- a/benchmark/case/flutter_scrollbar_test.expect
+++ b/benchmark/case/flutter_scrollbar_test.expect
@@ -19,23 +19,25 @@ void main() {
                   child: SizedBox(
                     height: 1000.0,
                     width: double.infinity,
-                    child: Column(children: <Widget>[
-                      Scrollbar(
-                        key: key1,
-                        child: SizedBox(
-                          height: 300.0,
-                          width: double.infinity,
-                          child: SingleChildScrollView(
-                            key: innerKey,
-                            child: const SizedBox(
-                              key: Key('Inner scrollable'),
-                              height: 1000.0,
-                              width: double.infinity,
+                    child: Column(
+                      children: <Widget>[
+                        Scrollbar(
+                          key: key1,
+                          child: SizedBox(
+                            height: 300.0,
+                            width: double.infinity,
+                            child: SingleChildScrollView(
+                              key: innerKey,
+                              child: const SizedBox(
+                                key: Key('Inner scrollable'),
+                                height: 1000.0,
+                                width: double.infinity,
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ]),
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/test/tall/invocation/block_argument_named.stmt
+++ b/test/tall/invocation/block_argument_named.stmt
@@ -1,66 +1,52 @@
 40 columns                              |
 ### Test how named arguments interact with block formatting.
->>> Block format all positional.
-function(be, fore, [element, element], after);
-<<<
-function(be, fore, [
-  element,
-  element,
-], after);
->>> Block format named only leading.
-function(a: be, b: fore, [element, element], after);
-<<<
-function(a: be, b: fore, [
-  element,
-  element,
-], after);
->>> Block format named only block argument.
-function(be, fore, a: [element, element], after);
-<<<
-function(be, fore, a: [
-  element,
-  element,
-], after);
->>> Block format named only trailing.
-function(be, fore, [element, element], a: after);
-<<<
-function(be, fore, [
-  element,
-  element,
-], a: after);
->>> Don't block format named leading and block argument.
-function(a: be, fore, b: [element, element], after);
+>>> A function block argument can't be named.
+function(name: () {;});
 <<<
 function(
-  a: be,
-  fore,
-  b: [element, element],
-  after,
+  name: () {
+    ;
+  },
 );
->>> Don't block format named leading and trailing.
-function(a: be, fore, [element, element], b: after);
+>>> A collection block argument can't be named.
+function(name: [element, element, element, element]);
 <<<
 function(
-  a: be,
-  fore,
-  [element, element],
-  b: after,
+  name: [
+    element,
+    element,
+    element,
+    element,
+  ],
 );
->>> Don't block format named block argument and trailing.
-function(be, fore, a: [element, element], b: after);
+>>> If there are multiple functions, don't block format, even if only one is positional.
+function(a: () {;}, () {;});
 <<<
 function(
-  be,
-  fore,
-  a: [element, element],
-  b: after,
+  a: () {
+    ;
+  },
+  () {
+    ;
+  },
 );
->>> Don't block format all named.
-function(a: be, b: fore, c: [element, element], d: after);
+>>> If there are multiple collections, don't block format, even if only one is positional.
+function(a: [element], [element, element, element, element, element]);
 <<<
 function(
-  a: be,
-  b: fore,
-  c: [element, element],
-  d: after,
+  a: [element],
+  [
+    element,
+    element,
+    element,
+    element,
+    element,
+  ],
 );
+>>> Other non-block arguments can be named or not.
+function(1, a: 2, 3, b: 4, [element, element], c: 5);
+<<<
+function(1, a: 2, 3, b: 4, [
+  element,
+  element,
+], c: 5);

--- a/test/tall/invocation/block_argument_other.stmt
+++ b/test/tall/invocation/block_argument_other.stmt
@@ -34,20 +34,6 @@ function(
     element,
   ],
 );
->>> A function block argument can be named.
-function(name: () { body; });
-<<<
-function(name: () {
-  body;
-});
->>> A non-function block argument can be named.
-function(name: [element, element, element]);
-<<<
-function(name: [
-  element,
-  element,
-  element,
-]);
 >>> A long argument name can prevent block formatting.
 veryLongFunctionName(veryLongArgumentName: [element]);
 <<<

--- a/test/tall/regression/0100/0198.stmt
+++ b/test/tall/regression/0100/0198.stmt
@@ -24,38 +24,38 @@
     });
   });
 <<<
-  testThat('backward navigation is disabled when at end of stream', when: (
-    TaskList taskList,
-    TaskService taskService,
-  ) {
-    var cursorPageNo = 0;
-    final streamCtrl = initCustomTaskServiceMock(
-      taskService,
-      canMoveTo: (pageNo) => pageNo < 0 ? false : true,
-      getCurrentPageNumber: () => cursorPageNo,
-    );
+  testThat(
+    'backward navigation is disabled when at end of stream',
+    when: (TaskList taskList, TaskService taskService) {
+      var cursorPageNo = 0;
+      final streamCtrl = initCustomTaskServiceMock(
+        taskService,
+        canMoveTo: (pageNo) => pageNo < 0 ? false : true,
+        getCurrentPageNumber: () => cursorPageNo,
+      );
 
-    first('attach tasklist', () {
-          taskList.attach();
-          addTasks(streamCtrl);
-        })
-        .thenExpect(
-          'pager at page 1',
-          () => {
-            taskList.currentPageNo: 1,
-            taskList.backwardPaginationDisabled: isFalse,
-          },
-        )
-        .then('go to page 2', () {
-          taskList.nextPage();
-          addTasks(streamCtrl, count: 1);
-          cursorPageNo = 1;
-        })
-        .thenExpect(
-          'pager unchanged',
-          () => {
-            taskList.currentPageNo: 2,
-            taskList.backwardPaginationDisabled: isTrue,
-          },
-        );
-  });
+      first('attach tasklist', () {
+            taskList.attach();
+            addTasks(streamCtrl);
+          })
+          .thenExpect(
+            'pager at page 1',
+            () => {
+              taskList.currentPageNo: 1,
+              taskList.backwardPaginationDisabled: isFalse,
+            },
+          )
+          .then('go to page 2', () {
+            taskList.nextPage();
+            addTasks(streamCtrl, count: 1);
+            cursorPageNo = 1;
+          })
+          .thenExpect(
+            'pager unchanged',
+            () => {
+              taskList.currentPageNo: 2,
+              taskList.backwardPaginationDisabled: isTrue,
+            },
+          );
+    },
+  );

--- a/test/tall/regression/0300/0394.stmt
+++ b/test/tall/regression/0300/0394.stmt
@@ -14,25 +14,27 @@ return $.Div(inner: [
     ]),
 ]);
 <<<
-return $.Div(inner: [
-  $.Div(
-    id: "container",
-    inner: [
-      $.Canvas(width: maxD, height: maxD, clazz: "center", ref: canvas),
-      $.Form(
-        clazz: "center",
-        inner: [
-          $.Input(
-            type: "range",
-            max: 1000,
-            value: seeds,
-            onChange: onSliderChange,
-          ),
-        ],
-      ),
-      $.Img(src: "math.png", width: "350px", height: "42px", clazz: "center"),
-    ],
-  ),
+return $.Div(
+  inner: [
+    $.Div(
+      id: "container",
+      inner: [
+        $.Canvas(width: maxD, height: maxD, clazz: "center", ref: canvas),
+        $.Form(
+          clazz: "center",
+          inner: [
+            $.Input(
+              type: "range",
+              max: 1000,
+              value: seeds,
+              onChange: onSliderChange,
+            ),
+          ],
+        ),
+        $.Img(src: "math.png", width: "350px", height: "42px", clazz: "center"),
+      ],
+    ),
 
-  $.Footer(inner: [$.P(id: "notes", inner: "${seeds} seeds")]),
-]);
+    $.Footer(inner: [$.P(id: "notes", inner: "${seeds} seeds")]),
+  ],
+);

--- a/test/tall/regression/0300/0398.stmt
+++ b/test/tall/regression/0300/0398.stmt
@@ -5,11 +5,13 @@
             direction: FlexDirection.vertical)]));
 <<<
     children.add(
-      new DrawerHeader(children: [
-        new Flex(
-          [avatar, username],
-          justifyContent: FlexJustifyContent.center,
-          direction: FlexDirection.vertical,
-        ),
-      ]),
+      new DrawerHeader(
+        children: [
+          new Flex(
+            [avatar, username],
+            justifyContent: FlexJustifyContent.center,
+            direction: FlexDirection.vertical,
+          ),
+        ],
+      ),
     );

--- a/test/tall/regression/0700/0798.stmt
+++ b/test/tall/regression/0700/0798.stmt
@@ -24,26 +24,28 @@ if (false) {
             )
           ]);
 <<<
-        f(actions: <Widget>[
-          IconButton(
-            // action button
-            icon: Icon(choices[0].icon),
-            onPressed: () {
-              _select(choices[0]);
-            },
-          ),
-          IconButton(
-            // action button
-            icon: Icon(choices[1].icon),
-            onPressed: () {
-              _select(choices[1]);
-            },
-          ),
-          PopupMenuButton<Choice>(
-            // overflow menu
-            onSelected: _select,
-            itemBuilder: (BuildContext context) {
-              ;
-            },
-          ),
-        ]);
+        f(
+          actions: <Widget>[
+            IconButton(
+              // action button
+              icon: Icon(choices[0].icon),
+              onPressed: () {
+                _select(choices[0]);
+              },
+            ),
+            IconButton(
+              // action button
+              icon: Icon(choices[1].icon),
+              onPressed: () {
+                _select(choices[1]);
+              },
+            ),
+            PopupMenuButton<Choice>(
+              // overflow menu
+              onSelected: _select,
+              itemBuilder: (BuildContext context) {
+                ;
+              },
+            ),
+          ],
+        );

--- a/test/tall/regression/0800/0809.unit
+++ b/test/tall/regression/0800/0809.unit
@@ -106,15 +106,19 @@ class MyApp extends StatelessWidget {
     );
   }
 
-  Widget buildRow() => Row(children: [
-    Image.asset('images/pic1.jpg'),
-    Image.asset('images/pic2.jpg'),
-    Image.asset('images/pic3.jpg'),
-  ]);
+  Widget buildRow() => Row(
+    children: [
+      Image.asset('images/pic1.jpg'),
+      Image.asset('images/pic2.jpg'),
+      Image.asset('images/pic3.jpg'),
+    ],
+  );
 
-  Widget buildColumn() => Column(children: [
-    Image.asset('images/pic1.jpg'),
-    Image.asset('images/pic2.jpg'),
-    Image.asset('images/pic3.jpg'),
-  ]);
+  Widget buildColumn() => Column(
+    children: [
+      Image.asset('images/pic1.jpg'),
+      Image.asset('images/pic2.jpg'),
+      Image.asset('images/pic3.jpg'),
+    ],
+  );
 }

--- a/test/tall/regression/1100/1197.unit
+++ b/test/tall/regression/1100/1197.unit
@@ -27,28 +27,28 @@ main() {
 <<<
 main() {
   {
-    return TextFieldTapRegion(onLongPressMoveUpdate: (
-      longPressMoveUpdateDetails,
-    ) {
-      (switch (Theme.of(this.context).platform) {
-        TargetPlatform.iOS || TargetPlatform.macOS => _renderEditable
-            .selectPositionAt(
-              from: longPressMoveUpdateDetails.globalPosition,
+    return TextFieldTapRegion(
+      onLongPressMoveUpdate: (longPressMoveUpdateDetails) {
+        (switch (Theme.of(this.context).platform) {
+          TargetPlatform.iOS || TargetPlatform.macOS => _renderEditable
+              .selectPositionAt(
+                from: longPressMoveUpdateDetails.globalPosition,
+                cause: SelectionChangedCause.longPress,
+              ),
+          TargetPlatform.android ||
+          TargetPlatform.fuchsia ||
+          TargetPlatform.linux ||
+          TargetPlatform.windows =>
+            _renderEditable.selectWordsInRange(
+              from:
+                  longPressMoveUpdateDetails.globalPosition -
+                  longPressMoveUpdateDetails.offsetFromOrigin,
+              to: longPressMoveUpdateDetails.globalPosition,
               cause: SelectionChangedCause.longPress,
             ),
-        TargetPlatform.android ||
-        TargetPlatform.fuchsia ||
-        TargetPlatform.linux ||
-        TargetPlatform.windows =>
-          _renderEditable.selectWordsInRange(
-            from:
-                longPressMoveUpdateDetails.globalPosition -
-                longPressMoveUpdateDetails.offsetFromOrigin,
-            to: longPressMoveUpdateDetails.globalPosition,
-            cause: SelectionChangedCause.longPress,
-          ),
-      });
-    });
+        });
+      },
+    );
   }
 }
 >>>


### PR DESCRIPTION
There are three ways an argument list can be formatted:

```dart
// 1. All inline:
function(argument, another);

// 2. Block formatted:
function(argument, [
  element,
  element,
]);

// 3. Tall style:
function(
  argument,
  another,
);
```

One of the trickiest parts of the formatter is deciding the heuristics to choose between 2 and 3.

Prior to this PR, there is a fairly subtle rule: Arguments before the block argument can be named or not, the block argument can be named or not, and the argument after the block argument can be named or not, but only one of those three sections can have a named argument.

The intent of that rule is to allow named block arguments and named non-block arguments, while avoiding multiple argument names on the same line when block formatted. Also, it allows an argument list containing only a named argument to be block formatted:

```dart
function(name: [
  element,
]);
```

From looking at how contributors to Flutter have hand-formatted their code, it doesn't look like this level of complexity is well motivated. And allowing a single named argument to be block formatted but not if there are other named arguments means that adding a second named argument to a function can cause the entire argument list to be reformatted and indented differently. That can be a lot of churn if the block argument is itself a large nested widget tree.

This PR tweaks that rule to something simpler:

1. The block argument must be positional.

2. Other non-block arguments have no restrictions on whether they can be named or not.

This reduces diff churn and means that widget trees (which almost always use named arguments) have a more consistent (but taller) style across the entire tree.

From talking to Michael Goderbauer, this seems like a reasonable trade-off to me.

Fix #1552.
Fix #1559.
