### PR TITLE
Bump version to publish 2.3.7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.3.7-wip
+## 2.3.7
 
 * Allow passing a language version to `DartFomatter()`. Formatted code will be
   parsed at that version. If omitted, defaults to the latest version. In a

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '2.3.6';
+const dartStyleVersion = '2.3.7';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 class FormatterOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.7-wip
+version: 2.3.7
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
Main is two commits ahead of what rolled into google3, but those two changes should be safe, so I'm ready to publish this.

Getting this out will enable other packages that use dart_style as a library to update their constraint on it to require 2.3.7 so that they can start passing in a language version to the `DartFormatter()` constructor.