### PR TITLE
Make the language version parameter to DartFormatter mandatory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0-wip
+
+* Make the language version parameter to `DartFormatter()` mandatory.
+
 ## 2.3.7
 
 * Allow passing a language version to `DartFomatter()`. Formatted code will be

--- a/benchmark/directory.dart
+++ b/benchmark/directory.dart
@@ -64,6 +64,7 @@ void main(List<String> arguments) async {
 void _runFormatter(String source) {
   try {
     var formatter = DartFormatter(
+        languageVersion: DartFormatter.latestLanguageVersion,
         experimentFlags: [if (!_isShort) tallStyleExperimentFlag]);
 
     var result = formatter.format(source);

--- a/benchmark/run.dart
+++ b/benchmark/run.dart
@@ -131,6 +131,7 @@ List<double> _runTrials(String verb, Benchmark benchmark, int trials) {
       throwIfDiagnostics: false);
 
   var formatter = DartFormatter(
+      languageVersion: DartFormatter.latestLanguageVersion,
       pageWidth: benchmark.pageWidth,
       lineEnding: '\n',
       experimentFlags: [if (!_isShort) tallStyleExperimentFlag]);

--- a/example/format.dart
+++ b/example/format.dart
@@ -40,6 +40,7 @@ void _runFormatter(String source, int pageWidth,
     {required bool tall, required bool isCompilationUnit}) {
   try {
     var formatter = DartFormatter(
+        languageVersion: DartFormatter.latestLanguageVersion,
         pageWidth: pageWidth,
         experimentFlags: [if (tall) tallStyleExperimentFlag]);
 
@@ -72,6 +73,7 @@ Future<void> _runTest(String path, int line,
   var formatTest = testFile.tests.firstWhere((test) => test.line == line);
 
   var formatter = DartFormatter(
+      languageVersion: formatTest.languageVersion,
       pageWidth: testFile.pageWidth,
       indent: formatTest.leadingIndent,
       fixes: formatTest.fixes,

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -71,9 +71,7 @@ void defineOptions(ArgParser parser,
     parser.addOption('language-version',
         help: 'Language version of formatted code.\n'
             'Use "latest" to parse as the latest supported version.\n'
-            'Omit to look for a surrounding package config.',
-        // TODO(rnystrom): Show this when the tall-style experiment ships.
-        hide: true);
+            'Omit to look for a surrounding package config.');
   }
 
   parser.addFlag('set-exit-if-changed',

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -4,7 +4,6 @@
 import 'dart:math' as math;
 
 import 'package:analyzer/dart/analysis/features.dart';
-import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
@@ -29,17 +28,10 @@ class DartFormatter {
   /// version of the formatter.
   static final latestLanguageVersion = Version(3, 3, 0);
 
-  /// The highest Dart language version without support for patterns.
-  static final _lastNonPatternsVersion = Version(2, 19, 0);
-
   /// The Dart language version that formatted code should be parsed as.
   ///
   /// Note that a `// @dart=` comment inside the code overrides this.
   final Version languageVersion;
-
-  /// Whether the user passed in a non-`null` language version.
-  // TODO(rnystrom): Remove this when the language version is required.
-  final bool _omittedLanguageVersion;
 
   /// The string that newlines should use.
   ///
@@ -63,14 +55,6 @@ class DartFormatter {
 
   /// Creates a new formatter for Dart code at [languageVersion].
   ///
-  /// If [languageVersion] is omitted, then it defaults to
-  /// [latestLanguageVersion]. In a future major release of dart_style, the
-  /// language version will affect the applied formatting style. At that point,
-  /// this parameter will become required so that the applied style doesn't
-  /// change unexpectedly. It is optional now so that users can migrate to
-  /// versions of dart_style that accept this parameter and be ready for the
-  /// major version when it's released.
-  ///
   /// If [lineEnding] is given, that will be used for any newlines in the
   /// output. Otherwise, the line separator will be inferred from the line
   /// endings in the source file.
@@ -80,15 +64,13 @@ class DartFormatter {
   ///
   /// While formatting, also applies any of the given [fixes].
   DartFormatter(
-      {Version? languageVersion,
+      {required this.languageVersion,
       this.lineEnding,
       int? pageWidth,
       int? indent,
       Iterable<StyleFix>? fixes,
       List<String>? experimentFlags})
-      : languageVersion = languageVersion ?? latestLanguageVersion,
-        _omittedLanguageVersion = languageVersion == null,
-        pageWidth = pageWidth ?? 80,
+      : pageWidth = pageWidth ?? 80,
         indent = indent ?? 0,
         fixes = {...?fixes},
         experimentFlags = [...?experimentFlags];
@@ -141,33 +123,18 @@ class DartFormatter {
       );
     }
 
+    // Don't pass the formatter's own experiment flag to the parser.
+    var experiments = experimentFlags.toList();
+    experiments.remove(tallStyleExperimentFlag);
+    var featureSet = FeatureSet.fromEnableFlags2(
+        sdkLanguageVersion: languageVersion, flags: experiments);
+
     // Parse it.
-    var parseResult = _parse(text, source.uri, languageVersion);
-
-    // If we couldn't parse it, and the language version supports patterns, it
-    // may be because of the breaking syntax changes to switch cases. Try
-    // parsing it again without pattern support.
-    // TODO(rnystrom): This is a pretty big hack. Before Dart 3.0, every
-    // language version was a strict syntactic superset of all previous
-    // versions. When patterns were added, a small number of switch cases
-    // became syntax errors.
-    //
-    // For most of its history, the formatter simply parsed every file at the
-    // latest language version without having to detect each file's actual
-    // version. We are moving towards requiring the language version when
-    // formatting, but for now, try to degrade gracefully if the user omits the
-    // version.
-    //
-    // Remove this when the languageVersion constructor parameter is required.
-    if (_omittedLanguageVersion && parseResult.errors.isNotEmpty) {
-      var withoutPatternsResult =
-          _parse(text, source.uri, _lastNonPatternsVersion);
-
-      // If we succeeded this time, use this parse instead.
-      if (withoutPatternsResult.errors.isEmpty) {
-        parseResult = withoutPatternsResult;
-      }
-    }
+    var parseResult = parseString(
+        content: text,
+        featureSet: featureSet,
+        path: source.uri,
+        throwIfDiagnostics: false);
 
     // Infer the line ending if not given one. Do it here since now we know
     // where the lines start.
@@ -232,21 +199,5 @@ class DartFormatter {
     }
 
     return output;
-  }
-
-  /// Parse [source] from [uri] at language [version].
-  ParseStringResult _parse(String source, String? uri, Version version) {
-    // Don't pass the formatter's own experiment flag to the parser.
-    var experiments = experimentFlags.toList();
-    experiments.remove(tallStyleExperimentFlag);
-
-    var featureSet = FeatureSet.fromEnableFlags2(
-        sdkLanguageVersion: version, flags: experiments);
-
-    return parseString(
-        content: source,
-        featureSet: featureSet,
-        path: uri,
-        throwIfDiagnostics: false);
   }
 }

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -30,7 +30,8 @@ Future<void> formatStdin(
   var input = StringBuffer();
   stdin.transform(const Utf8Decoder()).listen(input.write, onDone: () {
     var formatter = DartFormatter(
-        languageVersion: options.languageVersion,
+        languageVersion:
+            options.languageVersion ?? DartFormatter.latestLanguageVersion,
         indent: options.indent,
         pageWidth: options.pageWidth,
         fixes: options.fixes,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 2.3.7
+version: 3.0.0-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/dart_formatter_test.dart
+++ b/test/dart_formatter_test.dart
@@ -22,7 +22,7 @@ void _runTests({required bool isTall}) {
   DartFormatter makeFormatter(
       {Version? languageVersion, int? indent, String? lineEnding}) {
     return DartFormatter(
-        languageVersion: languageVersion,
+        languageVersion: languageVersion ?? DartFormatter.latestLanguageVersion,
         indent: indent,
         lineEnding: lineEnding,
         experimentFlags: [if (isTall) tallStyleExperimentFlag]);

--- a/test/short/whitespace/switch.stmt
+++ b/test/short/whitespace/switch.stmt
@@ -227,7 +227,7 @@ var x = switch (obj) {
   1 => 'one',
   var two => 'two'
 };
->>> handle cases that are not valid patterns
+>>> (version 2.19) handle cases in old code that are not valid patterns
 switch (obj) {
   case {1, 2}:
   case -pi:

--- a/test/tall/statement/switch_legacy.stmt
+++ b/test/tall/statement/switch_legacy.stmt
@@ -1,7 +1,7 @@
 40 columns                              |
 ### Tests syntax that used to be valid in a switch case before Dart 3.0 but is
 ### invalid in 3.0 and later.
->>> Handle cases that are not valid patterns.
+>>> (version 2.19) Handle cases that are not valid patterns.
 switch (obj) {
   case {1, 2}:
   case -pi:

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -148,6 +148,7 @@ Future<void> testBenchmarks({required bool useTallStyle}) async {
     for (var benchmark in benchmarks) {
       test(benchmark.name, () {
         var formatter = DartFormatter(
+            languageVersion: DartFormatter.latestLanguageVersion,
             pageWidth: benchmark.pageWidth,
             experimentFlags: useTallStyle
                 ? const ['inline-class', 'macros', tallStyleExperimentFlag]
@@ -189,6 +190,7 @@ void _testFile(TestFile testFile, Iterable<StyleFix>? baseFixes) {
         }
 
         var formatter = DartFormatter(
+            languageVersion: formatTest.languageVersion,
             pageWidth: testFile.pageWidth,
             indent: formatTest.leadingIndent,
             fixes: fixes,

--- a/tool/update_tests.dart
+++ b/tool/update_tests.dart
@@ -114,6 +114,7 @@ Future<void> _updateTestFile(TestFile testFile) async {
 
   for (var formatTest in testFile.tests) {
     var formatter = DartFormatter(
+        languageVersion: formatTest.languageVersion,
         pageWidth: testFile.pageWidth,
         indent: formatTest.leadingIndent,
         fixes: [...baseFixes, ...formatTest.fixes],
@@ -132,6 +133,9 @@ Future<void> _updateTestFile(TestFile testFile) async {
 
     var descriptionParts = [
       if (formatTest.leadingIndent != 0) '(indent ${formatTest.leadingIndent})',
+      if (formatTest.languageVersion != DartFormatter.latestLanguageVersion)
+        '(version ${formatTest.languageVersion.major}.'
+            '${formatTest.languageVersion.minor})',
       for (var fix in formatTest.fixes) '(fix ${fix.name})',
       formatTest.description
     ];


### PR DESCRIPTION
This is a breaking change, so bumping the major version of dart_style, the first time I've done that since the null safety migration (!).
