### PR TITLE
Stdin name search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,19 @@
   arguments as the `dart format` command. You can invoke it with
   `dart run dart_style:format <args...>`.
 
+* **Treat the `--stdin-name` name as a path when inferring language version.**
+  When reading input on stdin, the formatter still needs to know what language
+  version to parse the code as. If the `--stdin-name` option is set, then that
+  is treated as a file path and the formatter looks for a package config
+  surrounding that file path to infer the language version from.
+
+  If you don't want that behavior, pass in an explicit language version using
+  `--language-version=`, or use `--language-version=latest` to parse the input
+  using the latest language version supported by the formatter.
+
+  If `--stdin-name` and `--language-version` are both omitted, then parses
+  stdin using the latest supported language version.
+
 ## 2.3.7
 
 * Allow passing a language version to `DartFomatter()`. Formatted code will be

--- a/lib/src/cli/format_command.dart
+++ b/lib/src/cli/format_command.dart
@@ -107,8 +107,12 @@ class FormatCommand extends Command<int> {
         help: 'Track selection (given as "start:length") through formatting.',
         hide: !verbose);
     argParser.addOption('stdin-name',
-        help: 'Use this path in error messages when input is read from stdin.',
-        defaultsTo: 'stdin',
+        help:
+            'The path that code read from stdin is treated as coming from.\n\n'
+            'This path is used in error messages and also to locate a\n'
+            'surrounding package to infer the code\'s language version.\n'
+            'To avoid searching for a surrounding package config, pass\n'
+            'in a language version using --language-version.',
         hide: !verbose);
   }
 
@@ -223,7 +227,7 @@ class FormatCommand extends Command<int> {
     if (argResults.wasParsed('stdin-name') && argResults.rest.isNotEmpty) {
       usageException('Cannot pass --stdin-name when not reading from stdin.');
     }
-    var stdinName = argResults['stdin-name'] as String;
+    var stdinName = argResults['stdin-name'] as String?;
 
     var options = FormatterOptions(
         languageVersion: languageVersion,

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -41,6 +41,8 @@ Future<void> formatStdin(
   // If they didn't specify a version or a path, default to the latest.
   languageVersion ??= DartFormatter.latestLanguageVersion;
 
+  var name = path ?? 'stdin';
+
   var completer = Completer<void>();
   var input = StringBuffer();
   stdin.transform(const Utf8Decoder()).listen(input.write, onDone: () {
@@ -50,13 +52,13 @@ Future<void> formatStdin(
         pageWidth: options.pageWidth,
         experimentFlags: options.experimentFlags);
     try {
-      options.beforeFile(null, path ?? 'stdin');
+      options.beforeFile(null, name);
       var source = SourceCode(input.toString(),
           uri: path,
           selectionStart: selectionStart,
           selectionLength: selectionLength);
       var output = formatter.formatSource(source);
-      options.afterFile(null, path ?? 'stdin', output,
+      options.afterFile(null, name, output,
           changed: source.text != output.text);
     } on FormatterException catch (err) {
       stderr.writeln(err.message());

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -17,7 +17,7 @@ import 'source_code.dart';
 
 /// Reads and formats input from stdin until closed.
 Future<void> formatStdin(
-    FormatterOptions options, List<int>? selection, String name) async {
+    FormatterOptions options, List<int>? selection, String? path) async {
   var selectionStart = 0;
   var selectionLength = 0;
 
@@ -26,23 +26,37 @@ Future<void> formatStdin(
     selectionLength = selection[1];
   }
 
+  var languageVersion = options.languageVersion;
+  if (languageVersion == null && path != null) {
+    // TODO(rnystrom): Remove the experiment check when the experiment ships.
+    if (options.experimentFlags.contains(tallStyleExperimentFlag)) {
+      var cache = LanguageVersionCache();
+      languageVersion = await cache.find(File(path), path);
+
+      // If the lookup failed, don't try to parse the code.
+      if (languageVersion == null) return;
+    }
+  }
+
+  // If they didn't specify a version or a path, default to the latest.
+  languageVersion ??= DartFormatter.latestLanguageVersion;
+
   var completer = Completer<void>();
   var input = StringBuffer();
   stdin.transform(const Utf8Decoder()).listen(input.write, onDone: () {
     var formatter = DartFormatter(
-        languageVersion:
-            options.languageVersion ?? DartFormatter.latestLanguageVersion,
+        languageVersion: languageVersion!,
         indent: options.indent,
         pageWidth: options.pageWidth,
         experimentFlags: options.experimentFlags);
     try {
-      options.beforeFile(null, name);
+      options.beforeFile(null, path ?? 'stdin');
       var source = SourceCode(input.toString(),
-          uri: name,
+          uri: path,
           selectionStart: selectionStart,
           selectionLength: selectionLength);
       var output = formatter.formatSource(source);
-      options.afterFile(null, name, output,
+      options.afterFile(null, path ?? 'stdin', output,
           changed: source.text != output.text);
     } on FormatterException catch (err) {
       stderr.writeln(err.message());
@@ -138,17 +152,10 @@ Future<bool> _processFile(
   // version.
   Version? languageVersion;
   if (cache != null) {
-    try {
-      // Look for a package config. If we don't find one, default to the latest
-      // language version.
-      languageVersion = await cache.find(file);
-    } catch (error) {
-      stderr.writeln('Could not read package configuration for '
-          '$displayPath:\n$error');
-      stderr.writeln('To avoid searching for a package configuration, '
-          'specify a language version using "--language-version".');
-      return false;
-    }
+    languageVersion = await cache.find(file, displayPath);
+
+    // If the lookup failed, don't try to parse the file.
+    if (languageVersion == null) return false;
   } else {
     languageVersion = options.languageVersion;
   }

--- a/lib/src/language_version_cache.dart
+++ b/lib/src/language_version_cache.dart
@@ -33,7 +33,7 @@ class LanguageVersionCache {
 
   /// Looks for a package surrounding [file] and, if found, returns the default
   /// language version specified by that package.
-  Future<Version?> find(File file) async {
+  Future<Version?> find(File file, String displayPath) async {
     Profile.begin('look up package config');
     try {
       // Use the cached version (which may be `null`) if present.
@@ -55,6 +55,12 @@ class LanguageVersionCache {
 
       // We weren't able to resolve this file's directory, so don't try again.
       return _directoryVersions[directory] = null;
+    } catch (error) {
+      stderr.writeln('Could not read package configuration for '
+          '$displayPath:\n$error');
+      stderr.writeln('To avoid searching for a package configuration, '
+          'specify a language version using "--language-version".');
+      return null;
     } finally {
       Profile.end('look up package config');
     }

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -390,7 +390,7 @@ void main() {
   });
 
   group('--stdin-name', () {
-    test('errors if given path', () async {
+    test('errors if also given path', () async {
       var process = await runFormatter(['--stdin-name=name', 'path']);
       await process.shouldExit(64);
     });
@@ -518,87 +518,86 @@ main() {
       await process.stderr.cancel();
       await process.shouldExit(65);
     });
+  });
 
-    group('package config', () {
-      // TODO(rnystrom): Remove this test when the experiment ships.
-      test('no package search if experiment is off', () async {
-        // Put the file in a directory with a malformed package config. If we
-        // search for it, we should get an error.
-        await d.dir('foo', [
-          d.dir('.dart_tool', [
-            d.file('package_config.json', 'this no good json is bad json'),
-          ]),
-          d.file('main.dart', 'main(){    }'),
-        ]).create();
+  group('package config', () {
+    // TODO(rnystrom): Remove this test when the experiment ships.
+    test('no package search if experiment is off', () async {
+      // Put the file in a directory with a malformed package config. If we
+      // search for it, we should get an error.
+      await d.dir('foo', [
+        d.dir('.dart_tool', [
+          d.file('package_config.json', 'this no good json is bad json'),
+        ]),
+        d.file('main.dart', 'main(){    }'),
+      ]).create();
 
-        var process = await runFormatterOnDir();
-        await process.shouldExit(0);
+      var process = await runFormatterOnDir();
+      await process.shouldExit(0);
 
-        // Should format the file without any error reading the package config.
-        await d.dir('foo', [d.file('main.dart', 'main() {}\n')]).validate();
-      });
+      // Should format the file without any error reading the package config.
+      await d.dir('foo', [d.file('main.dart', 'main() {}\n')]).validate();
+    });
 
-      test('no package search if language version is specified', () async {
-        // Put the file in a directory with a malformed package config. If we
-        // search for it, we should get an error.
-        await d.dir('foo', [
-          d.dir('.dart_tool', [
-            d.file('package_config.json', 'this no good json is bad json'),
-          ]),
-          d.file('main.dart', 'main(){    }'),
-        ]).create();
+    test('no package search if language version is specified', () async {
+      // Put the file in a directory with a malformed package config. If we
+      // search for it, we should get an error.
+      await d.dir('foo', [
+        d.dir('.dart_tool', [
+          d.file('package_config.json', 'this no good json is bad json'),
+        ]),
+        d.file('main.dart', 'main(){    }'),
+      ]).create();
 
-        var process = await runFormatterOnDir(
-            ['--language-version=latest', '--enable-experiment=tall-style']);
-        await process.shouldExit(0);
+      var process = await runFormatterOnDir(
+          ['--language-version=latest', '--enable-experiment=tall-style']);
+      await process.shouldExit(0);
 
-        // Should format the file without any error reading the package config.
-        await d.dir('foo', [d.file('main.dart', 'main() {}\n')]).validate();
-      });
+      // Should format the file without any error reading the package config.
+      await d.dir('foo', [d.file('main.dart', 'main() {}\n')]).validate();
+    });
 
-      test('default to language version of surrounding package', () async {
-        // The package config sets the language version to 3.1, but the switch
-        // case uses a syntax which is valid in earlier versions of Dart but an
-        // error in 3.0 and later. Verify that the error is reported (instead of
-        // the formatter falling back to try to parse the file at the older
-        // language version).
-        await d.dir('foo', [
-          packageConfig('foo', 3, 1),
-          d.file('main.dart', 'main() { switch (o) { case 1 + 2: break; } }'),
-        ]).create();
+    test('default to language version of surrounding package', () async {
+      // The package config sets the language version to 3.1, but the switch
+      // case uses a syntax which is valid in earlier versions of Dart but an
+      // error in 3.0 and later. Verify that the error is reported.
+      await d.dir('foo', [
+        packageConfig('foo', 3, 1),
+        d.file('main.dart', 'main() { switch (o) { case 1 + 2: break; } }'),
+      ]).create();
 
-        var path = p.join(d.sandbox, 'foo', 'main.dart');
-        // TODO(rnystrom): Remove experiment flag when it ships.
-        var process =
-            await runFormatter([path, '--enable-experiment=tall-style']);
+      var path = p.join(d.sandbox, 'foo', 'main.dart');
+      // TODO(rnystrom): Remove experiment flag when it ships.
+      var process =
+          await runFormatter([path, '--enable-experiment=tall-style']);
 
-        expect(await process.stderr.next,
-            'Could not format because the source could not be parsed:');
-        expect(await process.stderr.next, '');
-        expect(await process.stderr.next, contains('main.dart'));
-        await process.shouldExit(65);
-      });
+      expect(await process.stderr.next,
+          'Could not format because the source could not be parsed:');
+      expect(await process.stderr.next, '');
+      expect(await process.stderr.next, contains('main.dart'));
+      await process.shouldExit(65);
+    });
 
-      test('language version comment overrides package default', () async {
-        // The package config sets the language version to 3.1, but the switch
-        // case uses a syntax which is valid in earlier versions of Dart but an
-        // error in 3.0 and later. Verify that no error is reported since this
-        // file opts to the older version.
-        await d.dir('foo', [
-          packageConfig('foo', 3, 1),
-          d.file('main.dart', '''
+    test('language version comment overrides package default', () async {
+      // The package config sets the language version to 3.1, but the switch
+      // case uses a syntax which is valid in earlier versions of Dart but an
+      // error in 3.0 and later. Verify that no error is reported since this
+      // file opts to the older version.
+      await d.dir('foo', [
+        packageConfig('foo', 3, 1),
+        d.file('main.dart', '''
           // @dart=2.19
           main() { switch (obj) { case 1 + 2: // Error in 3.1.
             } }
           '''),
-        ]).create();
+      ]).create();
 
-        var process = await runFormatterOnDir();
-        await process.shouldExit(0);
+      var process = await runFormatterOnDir();
+      await process.shouldExit(0);
 
-        // Formats the file.
-        await d.dir('foo', [
-          d.file('main.dart', '''
+      // Formats the file.
+      await d.dir('foo', [
+        d.file('main.dart', '''
 // @dart=2.19
 main() {
   switch (obj) {
@@ -606,28 +605,27 @@ main() {
   }
 }
 ''')
-        ]).validate();
-      });
+      ]).validate();
+    });
 
-      test('malformed', () async {
-        await d.dir('foo', [
-          d.dir('.dart_tool', [
-            d.file('package_config.json', 'this no good json is bad json'),
-          ]),
-          d.file('main.dart', 'main() {}'),
-        ]).create();
+    test('malformed', () async {
+      await d.dir('foo', [
+        d.dir('.dart_tool', [
+          d.file('package_config.json', 'this no good json is bad json'),
+        ]),
+        d.file('main.dart', 'main() {}'),
+      ]).create();
 
-        var path = p.join(d.sandbox, 'foo', 'main.dart');
-        // TODO(rnystrom): Remove experiment flag when it ships.
-        var process =
-            await runFormatter([path, '--enable-experiment=tall-style']);
+      var path = p.join(d.sandbox, 'foo', 'main.dart');
+      // TODO(rnystrom): Remove experiment flag when it ships.
+      var process =
+          await runFormatter([path, '--enable-experiment=tall-style']);
 
-        expect(
-            await process.stderr.next,
-            allOf(startsWith('Could not read package configuration for'),
-                contains(p.join('foo', 'main.dart'))));
-        await process.shouldExit(65);
-      });
+      expect(
+          await process.stderr.next,
+          allOf(startsWith('Could not read package configuration for'),
+              contains(p.join('foo', 'main.dart'))));
+      await process.shouldExit(65);
     });
   });
 }

--- a/test/language_version_cache_test.dart
+++ b/test/language_version_cache_test.dart
@@ -108,11 +108,11 @@ void main() {
 
 Future<void> _expectVersion(
     LanguageVersionCache cache, String path, int major, int minor) async {
-  expect(await cache.find(_expectedFile(path)), Version(major, minor, 0));
+  expect(await cache.find(_expectedFile(path), path), Version(major, minor, 0));
 }
 
 Future<void> _expectNullVersion(LanguageVersionCache cache, String path) async {
-  expect(await cache.find(_expectedFile(path)), null);
+  expect(await cache.find(_expectedFile(path), path), null);
 }
 
 /// Normalize path separators to the host OS separator since that's what the


### PR DESCRIPTION
Use --stdin-name as a file path for inferring the language version.

If --stdin-name is given, then look for a surrounding package config to
infer the default language version from for code read from stdin. To
avoid that behavior, you can pass in a language version explicitly
using --language-version.

Fix #1530.