### PR TITLE
Don't write trailing commas in split catch clauses.

### DIFF
--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -775,7 +775,8 @@ mixin PieceFactory {
         pieces.token(catchKeyword);
         pieces.space();
 
-        var parameters = DelimitedListBuilder(this);
+        var parameters = DelimitedListBuilder(
+            this, const ListStyle(commas: Commas.nonTrailing));
         parameters.leftBracket(catchClause.leftParenthesis!);
         if (catchClause.exceptionParameter case var exceptionParameter?) {
           parameters.visit(exceptionParameter);

--- a/test/tall/statement/try.stmt
+++ b/test/tall/statement/try.stmt
@@ -111,3 +111,32 @@ try {
 } on BarException {
   doSomething();
 }
+>>> Split inside catch clause without stack trace.
+try {
+  doSomething();
+} catch (someSurprisinglyLongVariableName) {
+  doSomething();
+}
+<<<
+try {
+  doSomething();
+} catch (
+  someSurprisinglyLongVariableName
+) {
+  doSomething();
+}
+>>> Split inside catch clause with stack trace.
+try {
+  doSomething();
+} catch (longErrorVariable, longStackTrace) {
+  doSomething();
+}
+<<<
+try {
+  doSomething();
+} catch (
+  longErrorVariable,
+  longStackTrace
+) {
+  doSomething();
+}

--- a/test/tall/statement/try_comment.stmt
+++ b/test/tall/statement/try_comment.stmt
@@ -27,7 +27,7 @@ try {
   body;
 } catch (
   // comment
-  e,
+  e
 ) {
   print(e);
 }
@@ -38,7 +38,7 @@ try { body; } catch (e// comment
 try {
   body;
 } catch (
-  e, // comment
+  e // comment
 ) {
   print(e);
 }


### PR DESCRIPTION
Apparently the language doesn't allow them. Who knew?

Fix #1570.
