### PR TITLE
Allow a comment in code to explicitly configure the page width.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -69,7 +69,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
   ///
   /// If there is a `// dart format width=123` comment before the formatted
   /// code, then [pageWidthFromComment] is that width.
-  SourceCode run(SourceCode source, AstNode node, int? pageWidthFromComment) {
+  SourceCode run(SourceCode source, AstNode node, [int? pageWidthFromComment]) {
     Profile.begin('AstNodeVisitor.run()');
 
     Profile.begin('AstNodeVisitor build Piece tree');

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -66,7 +66,10 @@ class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
   ///
   /// This is the only method that should be called externally. Everything else
   /// is effectively private.
-  SourceCode run(SourceCode source, AstNode node) {
+  ///
+  /// If there is a `// dart format width=123` comment before the formatted
+  /// code, then [pageWidthFromComment] is that width.
+  SourceCode run(SourceCode source, AstNode node, int? pageWidthFromComment) {
     Profile.begin('AstNodeVisitor.run()');
 
     Profile.begin('AstNodeVisitor build Piece tree');
@@ -123,7 +126,7 @@ class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
     Profile.end('AstNodeVisitor build Piece tree');
 
     // Finish writing and return the complete result.
-    var result = pieces.finish(source, unitPiece);
+    var result = pieces.finish(source, unitPiece, pageWidthFromComment);
 
     Profile.end('AstNodeVisitor.run()');
 

--- a/lib/src/front_end/comment_writer.dart
+++ b/lib/src/front_end/comment_writer.dart
@@ -42,28 +42,11 @@ import '../comment_type.dart';
 /// written. When that [TextPiece] is output later, it will include the comments
 /// as well.
 class CommentWriter {
-  /// Regular expression that matches a format width comment like:
-  ///
-  ///     // dart format width=123
-  static final RegExp _widthCommentPattern =
-      RegExp(r'^// dart format width=(\d+)$');
-
   final LineInfo _lineInfo;
 
   /// The tokens whose preceding comments have already been taken by calls to
   /// [takeCommentsBefore()].
   final Set<Token> _takenTokens = {};
-
-  /// If we have encountered a comment that sets an explicit page width, that
-  /// width, otherwise `null`.
-  ///
-  /// The comment looks like:
-  ///
-  ///     // dart format width=123
-  ///
-  /// If there are multiple of these comments, the first one wins.
-  int? get pageWidthFromComment => _pageWidthFromComment;
-  int? _pageWidthFromComment;
 
   CommentWriter(this._lineInfo);
 
@@ -121,14 +104,6 @@ class CommentWriter {
 
         // Always add a blank line (if possible) before a doc comment block.
         if (comment == token.precedingComments) linesBefore = 2;
-      }
-
-      // If this comment configures the page width, remember it.
-      if (_widthCommentPattern.firstMatch(text) case var match?
-          when _pageWidthFromComment == null) {
-        // If integer parsing fails for some reason, the returned `null`
-        // means we correctly ignore the comment.
-        _pageWidthFromComment = int.tryParse(match[1]!);
       }
 
       CommentType type;

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -399,7 +399,8 @@ class PieceWriter {
 
     var cache = SolutionCache();
     var solver = Solver(cache,
-        pageWidth: _formatter.pageWidth, leadingIndent: _formatter.indent);
+        pageWidth: _comments.pageWidthFromComment ?? _formatter.pageWidth,
+        leadingIndent: _formatter.indent);
     var solution = solver.format(rootPiece);
     var output = solution.code.build(source, _formatter.lineEnding);
 

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -390,7 +390,11 @@ class PieceWriter {
 
   /// Finishes writing and returns a [SourceCode] containing the final output
   /// and updated selection, if any.
-  SourceCode finish(SourceCode source, Piece rootPiece) {
+  ///
+  /// If there is a `// dart format width=123` comment before the formatted
+  /// code, then [pageWidthFromComment] is that width.
+  SourceCode finish(
+      SourceCode source, Piece rootPiece, int? pageWidthFromComment) {
     if (debug.tracePieceBuilder) {
       debug.log(debug.pieceTree(rootPiece));
     }
@@ -399,7 +403,7 @@ class PieceWriter {
 
     var cache = SolutionCache();
     var solver = Solver(cache,
-        pageWidth: _comments.pageWidthFromComment ?? _formatter.pageWidth,
+        pageWidth: pageWidthFromComment ?? _formatter.pageWidth,
         leadingIndent: _formatter.indent);
     var solution = solver.format(rootPiece);
     var output = solution.code.build(source, _formatter.lineEnding);

--- a/test/tall/other/format_off.unit
+++ b/test/tall/other/format_off.unit
@@ -194,3 +194,133 @@ main() {
       after +
       region;
 }
+>>> "dart format off" whitespace must match exactly.
+main() {
+  //dart format off
+  unformatted  +  code;
+  // dart format on
+
+  //   dart format off
+  unformatted  +  code;
+  // dart format on
+
+  // dart   format off
+  unformatted  +  code;
+  // dart format on
+
+  // dart format   off
+  unformatted  +  code;
+  // dart format on
+}
+<<<
+main() {
+  //dart format off
+  unformatted + code;
+  // dart format on
+
+  //   dart format off
+  unformatted + code;
+  // dart format on
+
+  // dart   format off
+  unformatted + code;
+  // dart format on
+
+  // dart format   off
+  unformatted + code;
+  // dart format on
+}
+>>> "dart format on" whitespace must match exactly.
+main() {
+  // dart format off
+  // Doesn't actually turn back on:
+  //dart format on
+  unformatted  +  code;
+
+  // Does now:
+  // dart format on
+  unformatted  +  code;
+
+  // dart format off
+  // Doesn't actually turn back on:
+  //   dart format on
+  unformatted  +  code;
+
+  // Does now:
+  // dart format on
+  unformatted  +  code;
+
+  // dart format off
+  // Doesn't actually turn back on:
+  // dart   format on
+  unformatted  +  code;
+
+  // Does now:
+  // dart format on
+  unformatted  +  code;
+
+  // dart format off
+  // Doesn't actually turn back on:
+  // dart format   on
+  unformatted  +  code;
+
+  // Does now:
+  // dart format on
+  unformatted  +  code;
+}
+<<<
+main() {
+  // dart format off
+  // Doesn't actually turn back on:
+  //dart format on
+  unformatted  +  code;
+
+  // Does now:
+  // dart format on
+  unformatted + code;
+
+  // dart format off
+  // Doesn't actually turn back on:
+  //   dart format on
+  unformatted  +  code;
+
+  // Does now:
+  // dart format on
+  unformatted + code;
+
+  // dart format off
+  // Doesn't actually turn back on:
+  // dart   format on
+  unformatted  +  code;
+
+  // Does now:
+  // dart format on
+  unformatted + code;
+
+  // dart format off
+  // Doesn't actually turn back on:
+  // dart format   on
+  unformatted  +  code;
+
+  // Does now:
+  // dart format on
+  unformatted + code;
+}
+>>> Can't be doc comment.
+main() {
+  here   +   gets   +   formatted    ;
+  /// dart format off
+  here   +   does    +    too   ;
+  /// dart format on
+  and   +   here   +    does   ;
+}
+<<<
+main() {
+  here + gets + formatted;
+
+  /// dart format off
+  here + does + too;
+
+  /// dart format on
+  and + here + does;
+}

--- a/test/tall/other/format_width.unit
+++ b/test/tall/other/format_width.unit
@@ -1,118 +1,116 @@
 40 columns                              |
 ### Tests for the comment to set formatting width.
 >>> Comment sets page width.
-main() {
-  // dart format width=30
-  fitsUnsplitAt40   +   butNotAt30;
-}
-<<<
-main() {
-  // dart format width=30
-  fitsUnsplitAt40 +
-      butNotAt30;
-}
->>> Comment anywhere affects all code.
-main() {
-  fitsUnsplitAt40   +   butNotAt30;
-}
 // dart format width=30
+main() {
+  fitsUnsplitAt40   +   butNotAt30;
+}
 <<<
+// dart format width=30
 main() {
   fitsUnsplitAt40 +
       butNotAt30;
 }
-
-// dart format width=30
->>> If multiple comments, first one wins.
+>>> Comment only takes effect if it appears before code.
 main() {
   // dart format width=30
-  // dart format width=60
   fitsUnsplitAt40   +   butNotAt30;
 }
 <<<
 main() {
   // dart format width=30
-  // dart format width=60
+  fitsUnsplitAt40 + butNotAt30;
+}
+>>> If there are multiple comments, first one wins.
+// dart format width=30
+// dart format width=60
+main() {
+  fitsUnsplitAt40   +   butNotAt30;
+}
+<<<
+// dart format width=30
+// dart format width=60
+main() {
   fitsUnsplitAt40 +
       butNotAt30;
 }
 >>> Does nothing if width is not an integer.
+// dart format width=wat
 main() {
-  // dart format width=wat
   fitsUnsplitAt40   +   butNotAt30;
 }
 <<<
+// dart format width=wat
 main() {
-  // dart format width=wat
   fitsUnsplitAt40 + butNotAt30;
 }
 >>> Can't have trailing text.
+// dart format width=30 some more text
 main() {
-  // dart format width=30 some more text
   fitsUnsplitAt40   +   butNotAt30;
 }
 <<<
+// dart format width=30 some more text
 main() {
-  // dart format width=30 some more text
   fitsUnsplitAt40 + butNotAt30;
 }
 >>> Whitespace must match exactly.
+//dart format width=30
 main() {
-  //dart format width=30
   fitsUnsplitAt40   +   butNotAt30;
 }
 <<<
+//dart format width=30
 main() {
-  //dart format width=30
   fitsUnsplitAt40 + butNotAt30;
 }
 >>> Whitespace must match exactly.
+// dart   format width=30
 main() {
-  // dart   format width=30
   fitsUnsplitAt40   +   butNotAt30;
 }
 <<<
+// dart   format width=30
 main() {
-  // dart   format width=30
   fitsUnsplitAt40 + butNotAt30;
 }
 >>> Whitespace must match exactly.
+// dart format width = 30
 main() {
-  // dart format width = 30
   fitsUnsplitAt40   +   butNotAt30;
 }
 <<<
+// dart format width = 30
 main() {
-  // dart format width = 30
   fitsUnsplitAt40 + butNotAt30;
 }
->>> Can't be doc comment.
+>>> Can't be a doc comment.
+/// dart format width=30
 main() {
-  /// dart format width=30
   fitsUnsplitAt40 + butNotAt30;
 }
 <<<
+/// dart format width=30
 main() {
-  /// dart format width=30
   fitsUnsplitAt40 + butNotAt30;
 }
->>> Can't be nested inside other comment.
+>>> Can't be nested inside another comment.
+/* // dart format width=30 */
 main() {
-  /* // dart format width=30 */
   fitsUnsplitAt40   +   butNotAt30;
 }
 <<<
+/* // dart format width=30 */
 main() {
-  /* // dart format width=30 */
   fitsUnsplitAt40 + butNotAt30;
 }
->>> Can't be inside string literal.
+>>> Can't be inside a string literal.
+var c = '// dart format width=30';
 main() {
-  var c = '// dart format width=30';
   fitsUnsplitAt40   +   butNotAt30;
 }
 <<<
+var c = '// dart format width=30';
 main() {
-  var c = '// dart format width=30';
   fitsUnsplitAt40 + butNotAt30;
 }

--- a/test/tall/other/format_width.unit
+++ b/test/tall/other/format_width.unit
@@ -1,0 +1,118 @@
+40 columns                              |
+### Tests for the comment to set formatting width.
+>>> Comment sets page width.
+main() {
+  // dart format width=30
+  fitsUnsplitAt40   +   butNotAt30;
+}
+<<<
+main() {
+  // dart format width=30
+  fitsUnsplitAt40 +
+      butNotAt30;
+}
+>>> Comment anywhere affects all code.
+main() {
+  fitsUnsplitAt40   +   butNotAt30;
+}
+// dart format width=30
+<<<
+main() {
+  fitsUnsplitAt40 +
+      butNotAt30;
+}
+
+// dart format width=30
+>>> If multiple comments, first one wins.
+main() {
+  // dart format width=30
+  // dart format width=60
+  fitsUnsplitAt40   +   butNotAt30;
+}
+<<<
+main() {
+  // dart format width=30
+  // dart format width=60
+  fitsUnsplitAt40 +
+      butNotAt30;
+}
+>>> Does nothing if width is not an integer.
+main() {
+  // dart format width=wat
+  fitsUnsplitAt40   +   butNotAt30;
+}
+<<<
+main() {
+  // dart format width=wat
+  fitsUnsplitAt40 + butNotAt30;
+}
+>>> Can't have trailing text.
+main() {
+  // dart format width=30 some more text
+  fitsUnsplitAt40   +   butNotAt30;
+}
+<<<
+main() {
+  // dart format width=30 some more text
+  fitsUnsplitAt40 + butNotAt30;
+}
+>>> Whitespace must match exactly.
+main() {
+  //dart format width=30
+  fitsUnsplitAt40   +   butNotAt30;
+}
+<<<
+main() {
+  //dart format width=30
+  fitsUnsplitAt40 + butNotAt30;
+}
+>>> Whitespace must match exactly.
+main() {
+  // dart   format width=30
+  fitsUnsplitAt40   +   butNotAt30;
+}
+<<<
+main() {
+  // dart   format width=30
+  fitsUnsplitAt40 + butNotAt30;
+}
+>>> Whitespace must match exactly.
+main() {
+  // dart format width = 30
+  fitsUnsplitAt40   +   butNotAt30;
+}
+<<<
+main() {
+  // dart format width = 30
+  fitsUnsplitAt40 + butNotAt30;
+}
+>>> Can't be doc comment.
+main() {
+  /// dart format width=30
+  fitsUnsplitAt40 + butNotAt30;
+}
+<<<
+main() {
+  /// dart format width=30
+  fitsUnsplitAt40 + butNotAt30;
+}
+>>> Can't be nested inside other comment.
+main() {
+  /* // dart format width=30 */
+  fitsUnsplitAt40   +   butNotAt30;
+}
+<<<
+main() {
+  /* // dart format width=30 */
+  fitsUnsplitAt40 + butNotAt30;
+}
+>>> Can't be inside string literal.
+main() {
+  var c = '// dart format width=30';
+  fitsUnsplitAt40   +   butNotAt30;
+}
+<<<
+main() {
+  var c = '// dart format width=30';
+  fitsUnsplitAt40 + butNotAt30;
+}


### PR DESCRIPTION
If the code being formatted contains a comment anywhere in it like:

```
// dart format width=123
```

Then the code is formatted at that width instead of the default width.

The intent is that tools that generate code and then format it will put this comment in the generated code. That way, the tool doesn't have to handle the complex logic to find a surrounding analysis_options.yaml file and get the user's project-wide page width configuration.

End users may also want to use this comment in rare cases. For example, maybe they have a library that contains a large value of data that looks better as a big wide table but they don't want their entire project to have a wider page width.
