### PR TITLE
Ship the "tall-style" experiment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ are included, some of them breaking:
   surrounding `analysis_options.yaml` file.
 
   This feature is mainly for code generators that generate and immediately
-  format code but don't know what about any surrounding `analysis_options.yaml`
+  format code but don't know about any surrounding `analysis_options.yaml`
   that might be configuring the page width. By inserting this comment in the
   generated code before formatting, it ensures that the code generator's
   behavior matches the behavior of `dart format`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,87 @@
 ## 3.0.0-wip
 
+This is a large change. Under the hood, the formatter was almost completely
+rewritten, with the codebase now containing both the old and new
+implementations. The old formatter exists to support the older "short" style
+and the new code implements [the new "tall" style][tall].
+
+[tall]: https://github.com/dart-lang/dart_style/issues/1253
+
+The formatter uses the language version of the formatted code to determine
+which style you get. If the language version is 3.6 or lower, the code is
+formatted with the old style. If 3.7 or later, you get the new tall style. You
+typically control the language version by [setting a min SDK constraint in your
+package's pubspec][versioning].
+
+[versioning]: https://dart.dev/guides/language/evolution
+
+In addition to the new formatting style, a number of other API and CLI changes
+are included, some of them breaking:
+
+* **Support project-wide page width configuration.** By long request, you can
+  now configure your preferred formatting page width on a project-wide basis.
+  When formatting files, the formatter will look in the file's directory and
+  any surrounding directories for an `analysis_options.yaml` file. If it finds
+  one, it looks for the following YAML:
+
+  ```yaml
+  formatter:
+    page_width: 123
+  ```
+
+  If it finds a `formatter` key containing a map with a `page_width` key whose
+  value is an integer, then that is the page width that the file is formatted
+  using. Since the formatter will walk the surrounding directories until it
+  finds an `analysis_options.yaml` file, this can be used to globally set the
+  page width for an entire directory, package, or even collection of packages.
+
+* **Support overriding the page width for a single file.** In code formatted
+  using the new tall style, you can use a special marker comment to control the
+  page width that it's formatted using:
+
+  ```dart
+  // dart format width=30
+  main() {
+    someExpression +
+        thatSplitsAt30;
+  }
+  ```
+
+  This comment must appear before any code in the file and must match that
+  format exactly. The width set by the comment overrides the width set by any
+  surrounding `analysis_options.yaml` file.
+
+  This feature is mainly for code generators that generate and immediately
+  format code but don't know what about any surrounding `analysis_options.yaml`
+  that might be configuring the page width. By inserting this comment in the
+  generated code before formatting, it ensures that the code generator's
+  behavior matches the behavior of `dart format`.
+
+  End users should mostly use `analysis_options.yaml` for configuring their
+  preferred page width (or do nothing and use the default page width of 80).
+
+* **Support opting out a region of code from formatting.** In code formatted
+  using the new tall style, you can use a pair of special marker comments to
+  opt a region of code out of automated formatting:
+
+  ```dart
+  main() {
+    this.isFormatted();
+    // dart format off
+    no   +   formatting
+      +
+        here;
+    // dart format on
+    formatting.isBackOnHere();
+  }
+  ```
+
+  The comments must be exactly `// dart format off` and `// dart format on`.
+  A file may have multiple regions, but they can't overlap or nest.
+
+  This can be useful for highly structured data where custom layout can help
+  a reader understand the data, like large lists of numbers.
+
 * **Remove support for fixes and `--fix`.** The tools that come with the Dart
   SDK provide two ways to apply automated changes to code: `dart format --fix`
   and `dart fix`. The former is older and used to be faster. But it can only
@@ -16,21 +98,20 @@
 
 * **Make the language version parameter to `DartFormatter()` mandatory.** This
   way, the formatter always knows what language version the input is intended
-  to be treated as. Note that a `// @dart=` language version comment if present
-  overrides the specified language version. You can think of the version passed
-  to the `DartFormatter()` constructor as a "default" language version which
-  the file's contents may then override.
+  to be treated as. Note that a `// @dart=` language version comment, if
+  present, overrides the specified language version. You can think of the
+  version passed to the `DartFormatter()` constructor as a "default" language
+  version which the file's contents may then override.
 
   If you don't particularly care about the version of what you're formatting,
   you can pass in `DartFormatter.latestLanguageVersion` to unconditionally get
   the latest language version that the formatter supports. Note that doing so
-  means you will also implicitly opt into the new tall style when that style
-  becomes available.
+  means you will also implicitly opt into the new tall style.
 
   This change only affects the library API. When using the formatter from the
   command line, you can use `--language-version=` to specify a language version
   or pass `--language-version=latest` to use the latest supported version. If
-  omitted, the formatter will look up the surrounding directories for a package
+  omitted, the formatter will look in the surrounding directories for a package
   config file and infer the language version for the package from that, similar
   to how other Dart tools behave like `dart analyze` and `dart run`.
 
@@ -38,9 +119,8 @@
   `dart format` command was added to the core Dart SDK, users accessed the
   formatter by running a separate `dartfmt` executable that was included with
   the Dart SDK. That executable had a different CLI interface. For example, you
-  had to pass `-w` to get it to overwrite files and if you passed no arguments
-  at all, it silently sat there waiting for input on stdin. When we added
-  `dart format`, we took that opportunity to revamp the CLI options.
+  had to pass `-w` to get it to overwrite files. When we added `dart format`,
+  we took that opportunity to revamp the CLI options.
 
   However, the dart_style package still exposed an executable with the old CLI.
   If you ran `dart pub global activate dart_style`, this would give you a
@@ -64,14 +144,8 @@
   `--language-version=`, or use `--language-version=latest` to parse the input
   using the latest language version supported by the formatter.
 
-  If `--stdin-name` and `--language-version` are both omitted, then parses
-  stdin using the latest supported language version.
-
-* **Apply class modifiers to API classes.** The dart_style package exposes only
-  a few classes in its public API: `DartFormatter`, `SourceCode`,
-  `FormatterException`, and `UnexpectedOutputException`. None were ever
-  intended to be extended or implemented. They are now all marked `final` to
-  make that intention explicit.
+  If `--stdin-name` and `--language-version` are both omitted, then the
+  formatter parses stdin using the latest supported language version.
 
 * **Rename the `--line-length` option to `--page-width`.** This is consistent
   with the public API, internal implementation, and docs, which all use "page
@@ -79,9 +153,15 @@
 
   The `--line-length` name is still supported for backwards compatibility, but
   may be removed at some point in the future. You're encouraged to move to
-  `--page-width`. Use of this option (however its named) is rare, and will
+  `--page-width`. Use of this option (however it's named) is rare, and will
   likely be even rarer now that project-wide configuration is supported, so
   this shouldn't affect many users.
+
+* **Apply class modifiers to API classes.** The dart_style package exposes only
+  a few classes in its public API: `DartFormatter`, `SourceCode`,
+  `FormatterException`, and `UnexpectedOutputException`. None were ever
+  intended to be extended or implemented. They are now all marked `final` to
+  make that intention explicit.
 
 ## 2.3.7
 

--- a/benchmark/directory.dart
+++ b/benchmark/directory.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 import 'package:dart_style/dart_style.dart';
-import 'package:dart_style/src/constants.dart';
 import 'package:dart_style/src/profile.dart';
 import 'package:dart_style/src/testing/benchmark.dart';
 
@@ -64,8 +63,9 @@ void main(List<String> arguments) async {
 void _runFormatter(String source) {
   try {
     var formatter = DartFormatter(
-        languageVersion: DartFormatter.latestLanguageVersion,
-        experimentFlags: [if (!_isShort) tallStyleExperimentFlag]);
+        languageVersion: _isShort
+            ? DartFormatter.latestShortStyleLanguageVersion
+            : DartFormatter.latestLanguageVersion);
 
     var result = formatter.format(source);
 

--- a/benchmark/run.dart
+++ b/benchmark/run.dart
@@ -10,7 +10,6 @@ import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:args/args.dart';
 import 'package:dart_style/dart_style.dart';
-import 'package:dart_style/src/constants.dart';
 import 'package:dart_style/src/debug.dart' as debug;
 import 'package:dart_style/src/front_end/ast_node_visitor.dart';
 import 'package:dart_style/src/profile.dart';
@@ -131,10 +130,11 @@ List<double> _runTrials(String verb, Benchmark benchmark, int trials) {
       throwIfDiagnostics: false);
 
   var formatter = DartFormatter(
-      languageVersion: DartFormatter.latestLanguageVersion,
+      languageVersion: _isShort
+          ? DartFormatter.latestShortStyleLanguageVersion
+          : DartFormatter.latestLanguageVersion,
       pageWidth: benchmark.pageWidth,
-      lineEnding: '\n',
-      experimentFlags: [if (!_isShort) tallStyleExperimentFlag]);
+      lineEnding: '\n');
 
   var measuredTimes = <double>[];
   for (var i = 1; i <= trials; i++) {

--- a/example/format.dart
+++ b/example/format.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dart_style/dart_style.dart';
-import 'package:dart_style/src/constants.dart';
 import 'package:dart_style/src/debug.dart' as debug;
 import 'package:dart_style/src/testing/test_file.dart';
 
@@ -40,9 +39,10 @@ void _runFormatter(String source, int pageWidth,
     {required bool tall, required bool isCompilationUnit}) {
   try {
     var formatter = DartFormatter(
-        languageVersion: DartFormatter.latestLanguageVersion,
-        pageWidth: pageWidth,
-        experimentFlags: [if (tall) tallStyleExperimentFlag]);
+        languageVersion: tall
+            ? DartFormatter.latestShortStyleLanguageVersion
+            : DartFormatter.latestLanguageVersion,
+        pageWidth: pageWidth);
 
     String result;
     if (isCompilationUnit) {
@@ -75,10 +75,7 @@ Future<void> _runTest(String path, int line,
   var formatter = DartFormatter(
       languageVersion: formatTest.languageVersion,
       pageWidth: testFile.pageWidth,
-      indent: formatTest.leadingIndent,
-      experimentFlags: tall
-          ? const ['inline-class', tallStyleExperimentFlag]
-          : const ['inline-class']);
+      indent: formatTest.leadingIndent);
 
   var actual = formatter.formatSource(formatTest.input);
 

--- a/example/format.dart
+++ b/example/format.dart
@@ -40,8 +40,8 @@ void _runFormatter(String source, int pageWidth,
   try {
     var formatter = DartFormatter(
         languageVersion: tall
-            ? DartFormatter.latestShortStyleLanguageVersion
-            : DartFormatter.latestLanguageVersion,
+            ? DartFormatter.latestLanguageVersion
+            : DartFormatter.latestShortStyleLanguageVersion,
         pageWidth: pageWidth);
 
     String result;

--- a/lib/src/cli/format_command.dart
+++ b/lib/src/cli/format_command.dart
@@ -69,8 +69,7 @@ final class FormatCommand extends Command<int> {
         help: 'Language version of formatted code.\n'
             'Use "latest" to parse as the latest supported version.\n'
             'Omit to look for a surrounding package config.',
-        // TODO(rnystrom): Show this when the tall-style experiment ships.
-        hide: true);
+        hide: !verbose);
 
     argParser.addFlag('set-exit-if-changed',
         negatable: false,

--- a/lib/src/config_cache.dart
+++ b/lib/src/config_cache.dart
@@ -62,6 +62,7 @@ final class ConfigCache {
     // Otherwise, walk the file system and look for it.
     var config =
         await _findPackageConfig(file, displayPath, forLanguageVersion: true);
+
     if (config?.packageOf(file.absolute.uri)?.languageVersion
         case var languageVersion?) {
       // Store the version as pub_semver's [Version] type because that's

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -2,15 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// The in-progress "tall" formatting style is enabled by passing an experiment
-/// flag with this name.
-///
-/// Note that this isn't a real Dart SDK experiment: Only the formatter supports
-/// it. We use the [experimentFlags] API to pass this in so that support for it
-/// can be removed in a later version without it being a breaking change to the
-/// dart_style library API.
-const tallStyleExperimentFlag = 'tall-style';
-
 /// Constants for the cost heuristics used to determine which set of splits is
 /// most desirable.
 final class Cost {

--- a/lib/src/testing/test_file.dart
+++ b/lib/src/testing/test_file.dart
@@ -99,8 +99,11 @@ final class TestFile {
         return '';
       });
 
-      // Let the test specify a language version to parse it at.
-      var languageVersion = DartFormatter.latestLanguageVersion;
+      // Let the test specify a language version to parse it at. If not, use
+      // a default version for the style being tested.
+      var languageVersion = p.split(file.path).contains('tall')
+          ? DartFormatter.latestLanguageVersion
+          : DartFormatter.latestShortStyleLanguageVersion;
       description = description.replaceAllMapped(_versionPattern, (match) {
         var major = int.parse(match[1]!);
         var minor = int.parse(match[2]!);

--- a/test/README.md
+++ b/test/README.md
@@ -4,7 +4,7 @@ an expected output.
 
 ## Formatting file format
 
-The actual formatting logic live in test data files ending in ".unit" or
+The formatting test expectations live in test data files ending in ".unit" or
 ".stmt". The ".unit" extension is for tests whose input should be parsed as an
 entire Dart compilation unit (roughly library or part file). The ".stmt" files
 parse each expectation as a statement.
@@ -20,15 +20,15 @@ var a=1+2/(3*-b~/4);
 ```
 
 If the first line contains a `|`, then it indicates the page width that all
-tests in this file should be formatted using. All other text on that line are
-ignored. This is mainly used so that tests can test line wrapping behavior
-without having to create long code to force things to wrap.
+tests in this file should be formatted using. All other text on that line is
+ignored. This is used so that tests can test line wrapping behavior without
+having to create long code to force things to wrap.
 
 The `>>>` line begins a test. It may have comment text afterwards describing the
-test. If the line contains `(indent <n>)` for some `n`, then formatter is told
-to run with that level of indentation. This is mainly for regression tests where
-the erroneous code appeared deeply nested inside some class or function and the
-test wants to reproduce that same surrounding indentation.
+test. If the line contains `(indent <n>)` for some `n`, then the formatter is
+told to run with that level of indentation. This is mainly for regression tests
+where the erroneous code appeared deeply nested inside some class or function
+and the test wants to reproduce that same surrounding indentation.
 
 Lines after the `>>>` line are the input code to be formatted.
 
@@ -68,8 +68,8 @@ tall/declaration/  - Typedef, class, enum, extension, mixin, and member
 tall/expression/   - Expressions and collection elements.
 tall/function/     - Function declarations.
 tall/invocation/   - Function and member invocations.
+tall/other/        - Selections, comment markers, and other odds and ends.
 tall/pattern/      - Patterns.
-tall/selection/    - Test preserving selection information.
 tall/statement/    - Statements.
 tall/top_level/    - Top-level directives.
 tall/type/         - Type annotations.

--- a/test/cli/page_width_test.dart
+++ b/test/cli/page_width_test.dart
@@ -36,10 +36,7 @@ void main() {
         d.file('main.dart', _unformatted),
       ]).create();
 
-      var process = await runFormatterOnDir([
-        '--enable-experiment=tall-style',
-        '--page-width=30',
-      ]);
+      var process = await runFormatterOnDir(['--page-width=30']);
       await process.shouldExit(0);
 
       await d.dir('foo', [d.file('main.dart', _formatted30)]).validate();
@@ -50,27 +47,11 @@ void main() {
         d.file('main.dart', _unformatted),
       ]).create();
 
-      var process = await runFormatterOnDir([
-        '--enable-experiment=tall-style',
-        '--line-length=30',
-      ]);
+      var process = await runFormatterOnDir(['--line-length=30']);
       await process.shouldExit(0);
 
       await d.dir('foo', [d.file('main.dart', _formatted30)]).validate();
     });
-  });
-
-  test('no options search if experiment is off', () async {
-    await d.dir('foo', [
-      analysisOptionsFile(pageWidth: 20),
-      d.file('main.dart', _unformatted),
-    ]).create();
-
-    var process = await runFormatterOnDir();
-    await process.shouldExit(0);
-
-    // Should format the file at the default width.
-    await d.dir('foo', [d.file('main.dart', _formatted80)]).validate();
   });
 
   test('no options search if page width is specified on the CLI', () async {
@@ -79,11 +60,7 @@ void main() {
       d.file('main.dart', _unformatted),
     ]).create();
 
-    var process = await runFormatterOnDir([
-      '--language-version=latest', // Error to not have language version.
-      '--page-width=30',
-      '--enable-experiment=tall-style'
-    ]);
+    var process = await runFormatterOnDir(['--page-width=30']);
     await process.shouldExit(0);
 
     // Should format the file at 30, not 20 or 80.
@@ -123,10 +100,7 @@ void main() {
       d.file('main.dart', _unformatted),
     ]).create();
 
-    var process = await runFormatterOnDir([
-      '--language-version=latest', // Error to not have language version.
-      '--enable-experiment=tall-style'
-    ]);
+    var process = await runFormatterOnDir();
     await process.shouldExit(0);
 
     // Should format the file at 30.
@@ -155,10 +129,7 @@ void main() {
       ]),
     ]).create();
 
-    var process = await runFormatterOnDir([
-      '--language-version=latest', // Error to not have language version.
-      '--enable-experiment=tall-style'
-    ]);
+    var process = await runFormatterOnDir();
     await process.shouldExit(0);
 
     // Should format the file at 30.
@@ -178,10 +149,7 @@ void main() {
       ]),
     ]).create();
 
-    var process = await runFormatterOnDir([
-      '--language-version=latest', // Error to not have language version.
-      '--enable-experiment=tall-style'
-    ]);
+    var process = await runFormatterOnDir();
     await process.shouldExit(0);
 
     // Should format the file at 80.
@@ -196,12 +164,7 @@ void main() {
         analysisOptionsFile(pageWidth: 30),
       ]).create();
 
-      var process = await runFormatter([
-        '--language-version=latest', // Error to not have language version.
-        '--enable-experiment=tall-style',
-        '--stdin-name=foo/main.dart',
-      ]);
-
+      var process = await runFormatter(['--stdin-name=foo/main.dart']);
       process.stdin.writeln(_unformatted);
       await process.stdin.close();
 
@@ -219,10 +182,8 @@ void main() {
       ]).create();
 
       var process = await runFormatter([
-        '--language-version=latest',
-        '--enable-experiment=tall-style',
         '--page-width=30',
-        '--stdin-name=foo/main.dart'
+        '--stdin-name=foo/main.dart',
       ]);
 
       process.stdin.writeln(_unformatted);
@@ -274,10 +235,7 @@ Future<void> _testWithOptions(Object? options,
     d.file('main.dart', _unformatted),
   ]).create();
 
-  var process = await runFormatterOnDir([
-    '--language-version=latest', // Error to not have language version.
-    '--enable-experiment=tall-style'
-  ]);
+  var process = await runFormatterOnDir();
   await process.shouldExit(0);
 
   // Should format the file at the expected width.

--- a/test/dart_formatter_test.dart
+++ b/test/dart_formatter_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dart_style/dart_style.dart';
-import 'package:dart_style/src/constants.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
@@ -21,22 +20,24 @@ void main() async {
 void _runTests({required bool isTall}) {
   DartFormatter makeFormatter(
       {Version? languageVersion, int? indent, String? lineEnding}) {
+    languageVersion ??= isTall
+        ? DartFormatter.latestLanguageVersion
+        : DartFormatter.latestShortStyleLanguageVersion;
+
     return DartFormatter(
-        languageVersion: languageVersion ?? DartFormatter.latestLanguageVersion,
+        languageVersion: languageVersion,
         indent: indent,
-        lineEnding: lineEnding,
-        experimentFlags: [if (isTall) tallStyleExperimentFlag]);
+        lineEnding: lineEnding);
   }
 
   group('language version', () {
     test('defaults to latest if omitted', () {
       var formatter = makeFormatter();
-      expect(formatter.languageVersion, DartFormatter.latestLanguageVersion);
-    });
-
-    test('defaults to latest if null', () {
-      var formatter = makeFormatter(languageVersion: null);
-      expect(formatter.languageVersion, DartFormatter.latestLanguageVersion);
+      expect(
+          formatter.languageVersion,
+          isTall
+              ? DartFormatter.latestLanguageVersion
+              : DartFormatter.latestShortStyleLanguageVersion);
     });
 
     test('parses at given older language version', () {

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';
-import 'package:dart_style/src/constants.dart';
 import 'package:dart_style/src/testing/benchmark.dart';
 import 'package:dart_style/src/testing/test_file.dart';
 import 'package:path/path.dart' as p;
@@ -97,11 +96,11 @@ Future<void> testBenchmarks({required bool useTallStyle}) async {
     for (var benchmark in benchmarks) {
       test(benchmark.name, () {
         var formatter = DartFormatter(
-            languageVersion: DartFormatter.latestLanguageVersion,
+            languageVersion: useTallStyle
+                ? DartFormatter.latestLanguageVersion
+                : DartFormatter.latestShortStyleLanguageVersion,
             pageWidth: benchmark.pageWidth,
-            experimentFlags: useTallStyle
-                ? const ['inline-class', 'macros', tallStyleExperimentFlag]
-                : const ['inline-class', 'macros']);
+            experimentFlags: const ['macros']);
 
         var actual = formatter.formatSource(SourceCode(benchmark.input));
 
@@ -126,9 +125,6 @@ Future<void> testBenchmarks({required bool useTallStyle}) async {
 }
 
 void _testFile(TestFile testFile) {
-  var useTallStyle =
-      testFile.path.startsWith('tall/') || testFile.path.startsWith('tall\\');
-
   group(testFile.path, () {
     for (var formatTest in testFile.tests) {
       test(formatTest.label, () {
@@ -136,9 +132,7 @@ void _testFile(TestFile testFile) {
             languageVersion: formatTest.languageVersion,
             pageWidth: testFile.pageWidth,
             indent: formatTest.leadingIndent,
-            experimentFlags: useTallStyle
-                ? const ['inline-class', 'macros', tallStyleExperimentFlag]
-                : const ['inline-class', 'macros']);
+            experimentFlags: const ['macros']);
 
         var actual = formatter.formatSource(formatTest.input);
 
@@ -174,7 +168,10 @@ void _testFile(TestFile testFile) {
 /// If [packages] is given, it should be a map from package names to root URIs
 /// for each package.
 d.DirectoryDescriptor packageConfig(String rootPackageName,
-    {String version = '3.5', Map<String, String>? packages}) {
+    {String? version, Map<String, String>? packages}) {
+  var defaultVersion = DartFormatter.latestLanguageVersion;
+  version ??= '${defaultVersion.major}.${defaultVersion.minor}';
+
   Map<String, dynamic> package(String name, String rootUri) => {
         'name': name,
         'rootUri': rootUri,

--- a/tool/update_tests.dart
+++ b/tool/update_tests.dart
@@ -4,7 +4,6 @@
 import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';
-import 'package:dart_style/src/constants.dart';
 import 'package:dart_style/src/testing/test_file.dart';
 import 'package:path/path.dart' as p;
 
@@ -87,12 +86,6 @@ Future<void> _updateTestFile(TestFile testFile) async {
   // Write the file-level comments.
   _writeComments(buffer, testFile.comments);
 
-  var experiments = [
-    'inline-class',
-    'macros',
-    if (p.split(testFile.path).contains('tall')) tallStyleExperimentFlag
-  ];
-
   _totalTests += testFile.tests.length;
 
   for (var formatTest in testFile.tests) {
@@ -100,7 +93,7 @@ Future<void> _updateTestFile(TestFile testFile) async {
         languageVersion: formatTest.languageVersion,
         pageWidth: testFile.pageWidth,
         indent: formatTest.leadingIndent,
-        experimentFlags: experiments);
+        experimentFlags: const ['macros']);
 
     var actual = formatter.formatSource(formatTest.input);
 
@@ -113,9 +106,13 @@ Future<void> _updateTestFile(TestFile testFile) async {
     // Insert a newline between each test, but not after the last.
     if (formatTest != testFile.tests.first) buffer.writeln();
 
+    var defaultLanguageVersion = p.split(testFile.path).contains('tall')
+        ? DartFormatter.latestLanguageVersion
+        : DartFormatter.latestShortStyleLanguageVersion;
+
     var descriptionParts = [
       if (formatTest.leadingIndent != 0) '(indent ${formatTest.leadingIndent})',
-      if (formatTest.languageVersion != DartFormatter.latestLanguageVersion)
+      if (formatTest.languageVersion != defaultLanguageVersion)
         '(version ${formatTest.languageVersion.major}.'
             '${formatTest.languageVersion.minor})',
       formatTest.description


### PR DESCRIPTION
This PR does a few things:

- Remove the "tall-style" experiment flag and treat it as always enabled.

- Use language version instead of the experiment flag to determine which style you get. If the version is 3.7 or higher, you get the tall style. Otherwise, you get the short style.

- Clean up the CHANGELOG.md and README.md a bit. I'll probably do some more copy editing on them before this gets published, but I wanted to get things roughly in order.

cc @leafpetersen @mit-mit 