### PR TITLE
Don't split return type if there is a comment after function metadata.

### DIFF
--- a/test/tall/function/comment.unit
+++ b/test/tall/function/comment.unit
@@ -22,3 +22,11 @@ main() {
     }
   }
 }
+>>> Don't split return type if comment before.
+// Comment.
+int f() {;}
+<<<
+// Comment.
+int f() {
+  ;
+}

--- a/test/tall/function/metadata.unit
+++ b/test/tall/function/metadata.unit
@@ -96,3 +96,13 @@ f([
   @another(argument, argument)
   callback() = constantFunction,
 ]) {}
+>>> Don't split return type if comment after metadata.
+@meta
+// Comment.
+int f() {;}
+<<<
+@meta
+// Comment.
+int f() {
+  ;
+}

--- a/test/tall/regression/other/dart.unit
+++ b/test/tall/regression/other/dart.unit
@@ -40,3 +40,18 @@ main() {
           .transform(const LineSplitter())
           .asBroadcastStream();
 }
+>>> Don't split return type if comment after metadata annotation.
+class Benchmark {
+  @override
+  // A rate of one run per 2s, with a millisecond of noise.  Some variation is
+  // needed for Golem's noise-based filtering and regression detection.
+  double
+  measure() => (2000 + Random().nextDouble() - 0.5) * 1000;
+}
+<<<
+class Benchmark {
+  @override
+  // A rate of one run per 2s, with a millisecond of noise.  Some variation is
+  // needed for Golem's noise-based filtering and regression detection.
+  double measure() => (2000 + Random().nextDouble() - 0.5) * 1000;
+}


### PR DESCRIPTION
This situation rarely occurs in practice, since users typically put the comment before the metadata too (which is why we never noticed this bug until now).

But if it does occur, it's definitely wrong to force the return type to split unnecessarily.
