### PR TITLE
Don't drop comments in collection literals with preserved newlines.

### DIFF
--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -138,6 +138,20 @@ final class DelimitedListBuilder {
     _commentsBeforeComma = CommentSequence.empty;
   }
 
+  /// Adds the contents of [lineBuilder] to this outer [DelimitedListBuilder].
+  ///
+  /// This is used when preserving newlines inside a collection literal. The
+  /// [lineBuilder] will be used for the elements that should be packed onto a
+  /// single line, and this builder is for the rows that are each on their own
+  /// line.
+  void addLineBuilder(DelimitedListBuilder lineBuilder) {
+    // Add the elements of the line to this builder.
+    add(lineBuilder.build());
+
+    // Make sure that any trailing comments on the line aren't lost.
+    _commentsBeforeComma = lineBuilder._commentsBeforeComma;
+  }
+
   /// Writes any comments appearing before [token] to the list.
   void addCommentsBefore(Token token) {
     // Handle comments between the preceding element and this one.

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -1082,7 +1082,7 @@ mixin PieceFactory {
               elements[i - 1].endToken, element.beginToken)) {
         // This element begins a new line. Add the elements on the previous
         // line to the list builder and start a new line.
-        builder.add(lineBuilder.build());
+        builder.addLineBuilder(lineBuilder);
         lineBuilder = DelimitedListBuilder(this, lineStyle);
         atLineStart = true;
       }
@@ -1097,7 +1097,8 @@ mixin PieceFactory {
       atLineStart = false;
     }
 
-    if (!atLineStart) builder.add(lineBuilder.build());
+    // Finish the last line if there is anything on it.
+    if (!atLineStart) builder.addLineBuilder(lineBuilder);
   }
 
   /// Writes a [VariablePiece] for a named or wildcard variable pattern.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   Provides an API and a CLI tool.
 repository: https://github.com/dart-lang/dart_style
 environment:
-  sdk: "^3.0.0"
+  sdk: "^3.4.0"
 
 dependencies:
   analyzer: '^6.5.0'

--- a/test/tall/expression/list_comment.stmt
+++ b/test/tall/expression/list_comment.stmt
@@ -144,3 +144,25 @@ var list = [
 var list = [1,/* a */ 2 /* b */  , 3];
 <<<
 var list = [1, /* a */ 2 /* b */, 3];
+>>> Comment before comma with other comments.
+var x = [
+  1 // Comment 1.
+  ,
+  2 // Comment 2.
+];
+<<<
+var x = [
+  1, // Comment 1.
+  2, // Comment 2.
+];
+>>> Comment before comma with other comments.
+var x = [
+  1 // Comment 1.
+  ,
+  // Comment 2.
+];
+<<<
+var x = [
+  1, // Comment 1.
+  // Comment 2.
+];

--- a/test/tall/regression/1500/1584.unit
+++ b/test/tall/regression/1500/1584.unit
@@ -1,0 +1,450 @@
+>>>
+final aaaaaaaaaaaAaaaaaaaAaaa = (AaaaaaaaaaaAaaaaaaaAaaa()
+  ..aaaAaaaaaaa.aaaAaa([
+    (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+      ..aaaaaaaAaaa =
+          'Aaaaaaa aaaa 1 is aaa 2 aaaaa aaa aaaa aa aaaaaaaaa if aa is aaaa '
+              'aaaa aaa aaaaa'
+      ..aaaaaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 1111.0
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.22)
+      ..aaaaaaaAaaaaaaaaAaa =
+          'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+    (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+      ..aaaaaaaAaaa = 'Aaaaaaa aaaa 2 is a aaaaa aaaa'
+      ..aaaaaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 222.0
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.19)
+      ..aaaaaaaAaaaaaaaaAaa =
+          'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+    (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+      ..aaaaaaaAaaa = 'Aaaaaaa aaaa 3'
+      ..aaaaaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 33.3
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.15)
+      ..aaaaaaaAaaaaaaaaAaa =
+          'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+    (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+      ..aaaaaaaAaaa = 'Aaaaaaa aaaa 4'
+      ..aaaaaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 4
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.11)
+      ..aaaaaaaAaaaaaaaaAaa =
+          'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa') // AA AAAA
+    ,
+  ])
+  ..aaaAaaaaaaAaaaa.aaaAaa([
+    (AaaaaaaaaaaAaaaaaaaAaaaaaaAaaa()
+      ..aaaaaaaAaaaAaaa.aaaAaa(['Aaaaaaa', 'Aaaaa', 'Aaaaa'])
+      ..aaaaaaaAaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 1111000000.0
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.22)),
+    (AaaaaaaaaaaAaaaaaaaAaaaaaaAaaa()
+      ..aaaaaaaAaaaAaaa.aaaAaa(['Aaaaaaa', 'Aaaa', 'Aaaaaa', 'Aaaaaa Aaaaaa'])
+      ..aaaaaaaAaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 112000000.0
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.234)),
+    (AaaaaaaaaaaAaaaaaaaAaaaaaaAaaa()
+      ..aaaaaaaAaaaAaaa.aaaAaa(['Aaaaaaa', 'Aaaa', 'Aaaaaaa'])
+      ..aaaaaaaAaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 82000000.0
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.54)),
+    (AaaaaaaaaaaAaaaaaaaAaaaaaaAaaa()
+      ..aaaaaaaAaaaAaaa.aaaAaa([
+        'Aaaaaaa',
+        'Aaaaaaaaaaa',
+        'Aaaa',
+        'Aaaaaaaa Aaaa',
+        'Aaaa Aaaaaaaa Aaaa',
+        'Aaaaaa Aaaa Aaaaaaaa Aaaa',
+        'Aaaaaa Aaaa Aaaaaaaa Aaaa Aaa Aaaaaaaa',
+      ])
+      ..aaaaaaaAaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 82000000.0
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.54)),
+  ]))
+  ..aaaAaaaaaaAaaaaa.aaaAaa([
+    aaaaAaaaaaaAaaaa(aaaaaaaAaaaa1, aaaaaa: 1111000000.0, aaaaaaaAaaaaa: 0.22),
+    aaaaAaaaaaaAaaaa(aaaaaaaAaaaa2, aaaaaa: 112000000.0, aaaaaaaAaaaaa: 0.234),
+    aaaaAaaaaaaAaaaa(aaaaaaaAaaaa3, aaaaaa: 82000000.0, aaaaaaaAaaaaa: 0.54),
+    aaaaAaaaaaaAaaaa(aaaaaaaAaaaa4, aaaaaa: 82000000.0, aaaaaaaAaaaaa: 0.54),
+  ])
+  ..aaaaaa();
+
+final aaaaaaaaaaaAaaaaaaaAaaaAaaAaaaaaa = (AaaaaaaaaaaAaaaaaaaAaaa()
+  ..aaaAaaaaaaa.aaaAaa([
+    (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+      ..aaaaaaaAaaa =
+          'Aaaaaaa aaaa 1 is aaa 2 aaaaa aaa aaaa aa aaaaaaaaa if aa is aaaa '
+              'aaaa aaa aaaaa'
+      ..aaaaaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 1111.0
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.22)
+      ..aaaaaaaAaaaaaaaaAaa =
+          'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+    (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+      ..aaaaaaaAaaa = 'Aaaaaaa aaaa 2 is a aaaaa aaaa'
+      ..aaaaaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 222.0
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.19)
+      ..aaaaaaaAaaaaaaaaAaa =
+          'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+    (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+      ..aaaaaaaAaaa = 'Aaaaaaa aaaa 3'
+      ..aaaaaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 33.3
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.15)
+      ..aaaaaaaAaaaaaaaaAaa =
+          'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+    (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+      ..aaaaaaaAaaa = 'Aaaaaaa aaaa 4'
+      ..aaaaaaaAaaaa = (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+        ..aaaaaAaaaaaAaaaaa = 4
+        ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.11)
+      ..aaaaaaaAaaaaaaaaAaa =
+          'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa') // AA AAAA
+    ,
+  ]))
+  ..aaaaaa();
+<<<
+final aaaaaaaaaaaAaaaaaaaAaaa =
+    (AaaaaaaaaaaAaaaaaaaAaaa()
+        ..aaaAaaaaaaa.aaaAaa([
+          (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+            ..aaaaaaaAaaa =
+                'Aaaaaaa aaaa 1 is aaa 2 aaaaa aaa aaaa aa aaaaaaaaa if aa is aaaa '
+                'aaaa aaa aaaaa'
+            ..aaaaaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 1111.0
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.22)
+            ..aaaaaaaAaaaaaaaaAaa =
+                'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+          (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+            ..aaaaaaaAaaa = 'Aaaaaaa aaaa 2 is a aaaaa aaaa'
+            ..aaaaaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 222.0
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.19)
+            ..aaaaaaaAaaaaaaaaAaa =
+                'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+          (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+            ..aaaaaaaAaaa = 'Aaaaaaa aaaa 3'
+            ..aaaaaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 33.3
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.15)
+            ..aaaaaaaAaaaaaaaaAaa =
+                'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+          (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+            ..aaaaaaaAaaa = 'Aaaaaaa aaaa 4'
+            ..aaaaaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 4
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.11)
+            ..aaaaaaaAaaaaaaaaAaa =
+                'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+        ])
+        ..aaaAaaaaaaAaaaa.aaaAaa([
+          (AaaaaaaaaaaAaaaaaaaAaaaaaaAaaa()
+            ..aaaaaaaAaaaAaaa.aaaAaa(['Aaaaaaa', 'Aaaaa', 'Aaaaa'])
+            ..aaaaaaaAaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 1111000000.0
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.22)),
+          (AaaaaaaaaaaAaaaaaaaAaaaaaaAaaa()
+            ..aaaaaaaAaaaAaaa.aaaAaa([
+              'Aaaaaaa',
+              'Aaaa',
+              'Aaaaaa',
+              'Aaaaaa Aaaaaa',
+            ])
+            ..aaaaaaaAaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 112000000.0
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.234)),
+          (AaaaaaaaaaaAaaaaaaaAaaaaaaAaaa()
+            ..aaaaaaaAaaaAaaa.aaaAaa(['Aaaaaaa', 'Aaaa', 'Aaaaaaa'])
+            ..aaaaaaaAaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 82000000.0
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.54)),
+          (AaaaaaaaaaaAaaaaaaaAaaaaaaAaaa()
+            ..aaaaaaaAaaaAaaa.aaaAaa([
+              'Aaaaaaa',
+              'Aaaaaaaaaaa',
+              'Aaaa',
+              'Aaaaaaaa Aaaa',
+              'Aaaa Aaaaaaaa Aaaa',
+              'Aaaaaa Aaaa Aaaaaaaa Aaaa',
+              'Aaaaaa Aaaa Aaaaaaaa Aaaa Aaa Aaaaaaaa',
+            ])
+            ..aaaaaaaAaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 82000000.0
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.54)),
+        ]))
+      ..aaaAaaaaaaAaaaaa.aaaAaa([
+        aaaaAaaaaaaAaaaa(
+          aaaaaaaAaaaa1,
+          aaaaaa: 1111000000.0,
+          aaaaaaaAaaaaa: 0.22,
+        ),
+        aaaaAaaaaaaAaaaa(
+          aaaaaaaAaaaa2,
+          aaaaaa: 112000000.0,
+          aaaaaaaAaaaaa: 0.234,
+        ),
+        aaaaAaaaaaaAaaaa(
+          aaaaaaaAaaaa3,
+          aaaaaa: 82000000.0,
+          aaaaaaaAaaaaa: 0.54,
+        ),
+        aaaaAaaaaaaAaaaa(
+          aaaaaaaAaaaa4,
+          aaaaaa: 82000000.0,
+          aaaaaaaAaaaaa: 0.54,
+        ),
+      ])
+      ..aaaaaa();
+
+final aaaaaaaaaaaAaaaaaaaAaaaAaaAaaaaaa =
+    (AaaaaaaaaaaAaaaaaaaAaaa()
+        ..aaaAaaaaaaa.aaaAaa([
+          (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+            ..aaaaaaaAaaa =
+                'Aaaaaaa aaaa 1 is aaa 2 aaaaa aaa aaaa aa aaaaaaaaa if aa is aaaa '
+                'aaaa aaa aaaaa'
+            ..aaaaaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 1111.0
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.22)
+            ..aaaaaaaAaaaaaaaaAaa =
+                'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+          (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+            ..aaaaaaaAaaa = 'Aaaaaaa aaaa 2 is a aaaaa aaaa'
+            ..aaaaaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 222.0
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.19)
+            ..aaaaaaaAaaaaaaaaAaa =
+                'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+          (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+            ..aaaaaaaAaaa = 'Aaaaaaa aaaa 3'
+            ..aaaaaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 33.3
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.15)
+            ..aaaaaaaAaaaaaaaaAaa =
+                'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+          (AaaaaaaaaaaAaaaaaaaAaaaaaa()
+            ..aaaaaaaAaaa = 'Aaaaaaa aaaa 4'
+            ..aaaaaaaAaaaa =
+                (AaaaaaaaaaaAaaaaaaaAaaaaaAaaaa()
+                  ..aaaaaAaaaaaAaaaaa = 4
+                  ..aaaaaAaaaaaAaaaaaaAaaaaa = 0.11)
+            ..aaaaaaaAaaaaaaaaAaa =
+                'aaaaa://aaa.aaaaaaa.aaa/aaaaaaa/aaaaaaaaaaaa/aaaaaa/aaaaaaa_aaaaaaaaaaaa.aaa'), // AA AAAA
+        ]))
+      ..aaaaaa();
+>>>
+  void aaaa() {
+  aaaa('aaaaaaaa aaaaa aaaa', () {
+    final aaaaaAaaa = {
+      '/a/11aa9a9aaa', // aaaa
+      '/a/047a6a9', // aaa
+      '/a/020aa3', // aaaaaa
+      '/a/11aa9aaa8_', // aaa
+      '/a/02a1aa', // aaaaaaaa
+      '/a/0a2aaaa', // aaaaaaaaaaaaaaaaa
+      '/a/0a3_aaa', // aaaaaaaa
+      '/a/06_a_', // aaa
+      '/a/02a_aa', // aaaaa
+      '/a/0aaaa8a', // aaaaaaa
+      '/a/11a_7aa2aa', // aaaaaaaaaa
+      '/a/11aaaaaaaa', // aaaa
+      '/a/0a3aa66', // aaaaaaaaa
+      '/a/0a3aaa2', // aaaa
+      '/a/03aaaa', // aaaaaaaa
+      '/a/11aa1a1aaa', // aaaa
+      '/a/11aaa2aa0a', // aaaaa
+      '/a/11aaa8aa35', // aaaaaaaa
+      '/a/06aaaa8', // aaaaaa
+      '/a/026aaa', // aaaaa
+      '/a/0aaa75a', // aaaaaaaa
+      '/a/07aaa', // aaaaaaa
+      '/a/0aaaa5a', // aaaaaaa
+      '/a/0aa2a_a', // aaa
+      '/a/0aaaa7a', // aaa aaaaa
+      '/a/121a7aa2', // aaa aaaaa
+      '/a/04aaaaa', // aaaaaa aaaaaa
+      '/a/0aaaaaa', // aaaaa aaaaaa
+      '/a/0154aa', // aaaaa aaaa aaaaa
+      '/a/0aaaaa3', // aaaaa
+      '/a/03aa4aa', // aa
+      '/a/0a_9a3a', // aaaaaa
+      '/a/0aaaaa1', // aaaaaaaa
+      '/a/11aaaaaaa_', // aaaaaaaa_aaaaaaaa
+      '/a/011a8a4a', // aaaa
+      '/a/11aa0a444a' // aaaaaa aaaaaaaaa
+      ,
+    };
+    for (final aaa in aaaaaAaaa) {
+      aaaaaa(aaaaaaaAaaaAaaaAaa(aaa)).aaAaaAaaa();
+    }
+  });
+
+  aaaa('aaaaaaa null for aa aaaaaaa aaa', () {
+    aaaaaa(aaaaaaaAaaaAaaaAaa('/a/000')).aaAaaa();
+  });
+}
+<<<
+void aaaa() {
+  aaaa('aaaaaaaa aaaaa aaaa', () {
+    final aaaaaAaaa = {
+      '/a/11aa9a9aaa', // aaaa
+      '/a/047a6a9', // aaa
+      '/a/020aa3', // aaaaaa
+      '/a/11aa9aaa8_', // aaa
+      '/a/02a1aa', // aaaaaaaa
+      '/a/0a2aaaa', // aaaaaaaaaaaaaaaaa
+      '/a/0a3_aaa', // aaaaaaaa
+      '/a/06_a_', // aaa
+      '/a/02a_aa', // aaaaa
+      '/a/0aaaa8a', // aaaaaaa
+      '/a/11a_7aa2aa', // aaaaaaaaaa
+      '/a/11aaaaaaaa', // aaaa
+      '/a/0a3aa66', // aaaaaaaaa
+      '/a/0a3aaa2', // aaaa
+      '/a/03aaaa', // aaaaaaaa
+      '/a/11aa1a1aaa', // aaaa
+      '/a/11aaa2aa0a', // aaaaa
+      '/a/11aaa8aa35', // aaaaaaaa
+      '/a/06aaaa8', // aaaaaa
+      '/a/026aaa', // aaaaa
+      '/a/0aaa75a', // aaaaaaaa
+      '/a/07aaa', // aaaaaaa
+      '/a/0aaaa5a', // aaaaaaa
+      '/a/0aa2a_a', // aaa
+      '/a/0aaaa7a', // aaa aaaaa
+      '/a/121a7aa2', // aaa aaaaa
+      '/a/04aaaaa', // aaaaaa aaaaaa
+      '/a/0aaaaaa', // aaaaa aaaaaa
+      '/a/0154aa', // aaaaa aaaa aaaaa
+      '/a/0aaaaa3', // aaaaa
+      '/a/03aa4aa', // aa
+      '/a/0a_9a3a', // aaaaaa
+      '/a/0aaaaa1', // aaaaaaaa
+      '/a/11aaaaaaa_', // aaaaaaaa_aaaaaaaa
+      '/a/011a8a4a', // aaaa
+      '/a/11aa0a444a', // aaaaaa aaaaaaaaa
+    };
+    for (final aaa in aaaaaAaaa) {
+      aaaaaa(aaaaaaaAaaaAaaaAaa(aaa)).aaAaaAaaa();
+    }
+  });
+
+  aaaa('aaaaaaa null for aa aaaaaaa aaa', () {
+    aaaaaa(aaaaaaaAaaaAaaaAaa('/a/000')).aaAaaa();
+  });
+}
+>>>
+void aaaa() {
+  aaaaa(() {
+    aaaa(() {
+      aaaaaa(
+        aaaaaaAaaaaaAaaaaaaAaaAaaa(
+          aaaAaaaaa: [aaaAaaaa1, aaaAaaaa2, aaaAaaaa3, aaaAaaaa4],
+          aaaaaaaaaAaaaaaaaAaa: Aaa.sync(aaaaaaaaaAaaaaaaa),
+        ).aaaaaAaaaaaaaaAaaAaaaaa(
+          aaa: [
+            aaaaAaaaaaaaAa(1),
+            aaaaAaaaaaaaAa(2),
+            aaaaAaaaaaaaAa(3),
+            aaaaAaaaaaaaAa(4),
+          ],
+          aaaaaaaa: null,
+        ).aaaaa,
+      )
+        ..aaaAaaaaa([
+          aaaaa2, // aaaaaaaa
+          aaaaa3, // aaaaa <= aaaaa4.aaaaa
+          aaaaa4,
+          aaaaa1 // aaaa aaaaa aa 3 & 4, aaa aaaaaa
+          ,
+        ])
+        ..aaaAaaaAaaaa(AaaaAaaaAaaaa(aaaaa, aaa))
+        ..aaaAaaaaAaaaAaaaAaaaa(AaaaAaaaAaaaa.AAAA_AAAAA);
+    });
+  });
+}
+<<<
+void aaaa() {
+  aaaaa(() {
+    aaaa(() {
+      aaaaaa(
+          aaaaaaAaaaaaAaaaaaaAaaAaaa(
+                aaaAaaaaa: [aaaAaaaa1, aaaAaaaa2, aaaAaaaa3, aaaAaaaa4],
+                aaaaaaaaaAaaaaaaaAaa: Aaa.sync(aaaaaaaaaAaaaaaaa),
+              )
+              .aaaaaAaaaaaaaaAaaAaaaaa(
+                aaa: [
+                  aaaaAaaaaaaaAa(1),
+                  aaaaAaaaaaaaAa(2),
+                  aaaaAaaaaaaaAa(3),
+                  aaaaAaaaaaaaAa(4),
+                ],
+                aaaaaaaa: null,
+              )
+              .aaaaa,
+        )
+        ..aaaAaaaaa([
+          aaaaa2, // aaaaaaaa
+          aaaaa3, // aaaaa <= aaaaa4.aaaaa
+          aaaaa4,
+          aaaaa1, // aaaa aaaaa aa 3 & 4, aaa aaaaaa
+        ])
+        ..aaaAaaaAaaaa(AaaaAaaaAaaaa(aaaaa, aaa))
+        ..aaaAaaaaAaaaAaaaAaaaa(AaaaAaaaAaaaa.AAAA_AAAAA);
+    });
+  });
+}
+>>>
+Aaa<AaaaaaaaaaAaaa, Aaaaaa> _aaaaAaaaaa({
+  Aaaa<aaa> aaaaaaaAaaaaaaaa = const [
+    361872399767151, // Aaaaaa
+    28531086733713 // AaaaaAaa
+    ,
+  ],
+}) => {};
+<<<
+Aaa<AaaaaaaaaaAaaa, Aaaaaa> _aaaaAaaaaa({
+  Aaaa<aaa> aaaaaaaAaaaaaaaa = const [
+    361872399767151, // Aaaaaa
+    28531086733713, // AaaaaAaa
+  ],
+}) => {};
+>>>
+final aaaa = {
+  // Aaaaa aaaa aaaaaa.
+  1 /* % of aaaaaa aaaaaaa */ : 10 /* aaaaaaaaaaa */,
+  5 /* % of aaaaaa aaaaaaa */ : 20 /* aaaaaaaaaaa */,
+  13 /* % of aaaaaa aaaaaaa */ : 30 /* aaaaaaaaaaa */,
+  14 /* % of aaaaaa aaaaaaa */ : 40 /* aaaaaaaaaaa */,
+  22 /* % of aaaaaa aaaaaaa */ : 50 /* aaaaaaaaaaa */,
+  23 /* % of aaaaaa aaaaaaa */ : 60 /* aaaaaaaaaaa */,
+  24 /* % of aaaaaa aaaaaaa */ : 70 /* aaaaaaaaaaa */,
+  29 /* % of aaaaaa aaaaaaa */ : 80 /* aaaaaaaaaaa */,
+};
+<<<
+final aaaa = {
+  // Aaaaa aaaa aaaaaa.
+  1 /* % of aaaaaa aaaaaaa */ : 10 /* aaaaaaaaaaa */,
+  5 /* % of aaaaaa aaaaaaa */ : 20 /* aaaaaaaaaaa */,
+  13 /* % of aaaaaa aaaaaaa */ : 30 /* aaaaaaaaaaa */,
+  14 /* % of aaaaaa aaaaaaa */ : 40 /* aaaaaaaaaaa */,
+  22 /* % of aaaaaa aaaaaaa */ : 50 /* aaaaaaaaaaa */,
+  23 /* % of aaaaaa aaaaaaa */ : 60 /* aaaaaaaaaaa */,
+  24 /* % of aaaaaa aaaaaaa */ : 70 /* aaaaaaaaaaa */,
+  29 /* % of aaaaaa aaaaaaa */ : 80 /* aaaaaaaaaaa */,
+};


### PR DESCRIPTION
A line comment in a collection literal triggers special formatting where we allow multiple elements in a single line, like:

```
list = [
  // Comment.
  1, 2, 3,
  4, 5,
  6,
];
```

The formatter models that by having a DelimitedListBuilder for the entire collection literal. Then the elements that should be packed onto a single line are formatted using a separate DelimitedListBuilder for each line.

In the very rare case where you have a comment after the last element on a line but *before* the subsequent comma, the comment would get dropped. This is because the comment was sitting in the inner DelimitedListBuilder for the line waiting to be put somewhere, but we then discard that builder to start a new line or when the whole list is done.

This fixes that. Whenever we're done with a line, we hoist any remaining comments up to the outer DelimitedListBuilder. That way the comment gets put after the comma at the end of the line.

Also bump the min SDK constraint to 3.4.0. I don't think dart_style works with an older version because of analyzer's SDK constraints.

Fix #1584.
