### PR TITLE
Don't move a comment between a modifier and return type.

### DIFF
--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:collection/collection.dart';
 
 import '../ast_extensions.dart';
 import '../piece/adjacent.dart';
@@ -626,8 +627,9 @@ mixin PieceFactory {
     //     @meta
     //     // Weird place for comment.
     //     int f() {}
-    var leadingComments =
-        pieces.takeCommentsBefore(returnType.firstNonCommentToken);
+    var firstToken = modifiers.firstWhereOrNull((token) => token != null) ??
+        returnType.firstNonCommentToken;
+    var leadingComments = pieces.takeCommentsBefore(firstToken);
 
     var returnTypePiece = pieces.build(() {
       for (var keyword in modifiers) {

--- a/test/tall/declaration/member_comment.unit
+++ b/test/tall/declaration/member_comment.unit
@@ -22,3 +22,33 @@ class Foo {
     ;
   }
 }
+>>> Comment after `external`.
+class C {
+  external /* c */ int x;
+  external /* c */ int f();
+  external /* c */ int get g;
+}
+<<<
+class C {
+  external /* c */ int x;
+  external /* c */ int f();
+  external /* c */ int get g;
+}
+>>> Comment after `covariant` on function typed parameter.
+class C {
+  method(covariant /* c */ int Function() f) {}
+}
+<<<
+class C {
+  method(
+    covariant /* c */ int Function() f,
+  ) {}
+}
+>>> Comment after `static` on method.
+class C {
+  static /* c */ int method() {}
+}
+<<<
+class C {
+  static /* c */ int method() {}
+}

--- a/test/tall/function/parameter.unit
+++ b/test/tall/function/parameter.unit
@@ -38,3 +38,9 @@ function(
 f({   required    callback()}) {}
 <<<
 f({required callback()}) {}
+>>> Comment after `required` on function type.
+f({required /* c */ int Function() f}) {}
+<<<
+f({
+  required /* c */ int Function() f,
+}) {}

--- a/test/tall/regression/1500/1585.unit
+++ b/test/tall/regression/1500/1585.unit
@@ -1,0 +1,18 @@
+>>>
+class AaaaAaaaa {
+  external Aaaaaa get aa;
+  external Aaaaaa get aaAaa;
+  external Aaaaaa get aa;
+  external aaaa get aaaa;
+  external /*AaaaaaAaaa*/ aaa get aa;
+  external Aaaaaa get aaa;
+}
+<<<
+class AaaaAaaaa {
+  external Aaaaaa get aa;
+  external Aaaaaa get aaAaa;
+  external Aaaaaa get aa;
+  external aaaa get aaaa;
+  external /*AaaaaaAaaa*/ aaa get aa;
+  external Aaaaaa get aaa;
+}


### PR DESCRIPTION
When formatting a function, method, getter, or function type, the formatter hoists any leading comments out so that they don't force a split between the return type and body.

However, it failed to take into account modifiers that may occur before the return type but after the comment. If that happened, the comment would get moved before the modifiers.

Fix #1585.
