### PR TITLE
Don't crash on a doc comment before a pattern variable statement.

### DIFF
--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -26,11 +26,19 @@ extension AstNodeExtensions on AstNode {
   /// (if there is any), or the beginning of the code.
   Token get firstNonCommentToken {
     return switch (this) {
+      // If the node is annotated, skip past the doc comments, but not the
+      // metadata.
       AnnotatedNode(metadata: [var annotation, ...]) => annotation.beginToken,
       AnnotatedNode(firstTokenAfterCommentAndMetadata: var token) => token,
+
       // DefaultFormalParameter is not an AnnotatedNode, but its first child
       // (parameter) *is* an AnnotatedNode, so we can't just use beginToken.
       DefaultFormalParameter(:var parameter) => parameter.firstNonCommentToken,
+
+      // A pattern variable statement isn't itself an AnnotatedNode, but the
+      // [PatternVariableDeclaration] that it wraps is.
+      PatternVariableDeclarationStatement(:var declaration) =>
+        declaration.firstNonCommentToken,
       _ => beginToken
     };
   }

--- a/test/tall/regression/1500/1586.unit
+++ b/test/tall/regression/1500/1586.unit
@@ -1,0 +1,10 @@
+>>>
+main() {
+  /// Doc comment.
+  final (a, b) = c;
+}
+<<<
+main() {
+  /// Doc comment.
+  final (a, b) = c;
+}


### PR DESCRIPTION
This is a funny corner of the analyzer AST API where a PatternVariableDeclarationStatement wraps an inner PatternVariableDeclaration. The statement class isn't itself an AnnotatedNode so doesn't get caught by the first couple of cases. But its beginToken comes from the inner PatternVariableDeclaration, which *is* an AnnotatedNode, so we need to recurse into that.

Fix #1586.
