### PR TITLE
Support a list of include paths in analysis options

### DIFF
--- a/test/analysis_options/analysis_options_file_test.dart
+++ b/test/analysis_options/analysis_options_file_test.dart
@@ -77,18 +77,29 @@ void main() {
           'ab': 'from a',
           'ac': 'from a',
           'abc': 'from a',
+          'ad': 'from a',
         }),
-        'dir|b.yaml': analysisOptions(include: 'c.yaml', other: {
+        'dir|b.yaml': analysisOptions(include: [
+          'c.yaml',
+          'd.yaml'
+        ], other: {
           'ab': 'from b',
           'abc': 'from b',
           'b': 'from b',
           'bc': 'from b',
+          'bd': 'from b',
         }),
         'dir|c.yaml': analysisOptions(other: {
           'ac': 'from c',
           'abc': 'from c',
           'bc': 'from c',
           'c': 'from c',
+          'cd': 'from c',
+        }),
+        'dir|d.yaml': analysisOptions(other: {
+          'ad': 'from d',
+          'bd': 'from d',
+          'cd': 'from d',
         }),
       });
 
@@ -97,10 +108,13 @@ void main() {
       expect(options['a'], 'from a');
       expect(options['ab'], 'from a');
       expect(options['ac'], 'from a');
+      expect(options['ad'], 'from a');
       expect(options['abc'], 'from a');
       expect(options['b'], 'from b');
       expect(options['bc'], 'from b');
+      expect(options['bd'], 'from b');
       expect(options['c'], 'from c');
+      expect(options['cd'], 'from d');
     });
 
     test('removes the include key after merging', () async {

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -205,13 +205,14 @@ String analysisOptions(
     Map<String, Object>? other}) {
   var yaml = StringBuffer();
 
-  if (include is String) {
-    yaml.writeln('include: $include');
-  } else if (include is List<String>) {
-    yaml.writeln('include:');
-    for (var path in include) {
-      yaml.writeln('  - $path');
-    }
+  switch (include) {
+    case String _:
+      yaml.writeln('include: $include');
+    case List<String> _:
+      yaml.writeln('include:');
+      for (var path in include) {
+        yaml.writeln('  - $path');
+      }
   }
 
   if (pageWidth != null) {

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -200,11 +200,18 @@ d.DirectoryDescriptor packageConfig(String rootPackageName,
 /// to include another analysis options file. If [other] is given, then those
 /// are added as other top-level keys in the YAML.
 String analysisOptions(
-    {int? pageWidth, String? include, Map<String, Object>? other}) {
+    {int? pageWidth,
+    Object? /* String | List<String> */ include,
+    Map<String, Object>? other}) {
   var yaml = StringBuffer();
 
-  if (include != null) {
+  if (include is String) {
     yaml.writeln('include: $include');
+  } else if (include is List<String>) {
+    yaml.writeln('include:');
+    for (var path in include) {
+      yaml.writeln('  - $path');
+    }
   }
 
   if (pageWidth != null) {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dart_style/issues/1591

The implementation is fairly simple. If the `include` value in an analysis options file is a List, then iteratively merge included options files.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
