### PR TITLE
Allow analyzer ^7.0.0 dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,8 @@ are included, some of them breaking:
   intended to be extended or implemented. They are now all marked `final` to
   make that intention explicit.
 
+* Require `package:analyzer` `>=6.5.0 <8.0.0`.
+
 ## 2.3.7
 
 * Allow passing a language version to `DartFomatter()`. Formatted code will be

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: "^3.4.0"
 
 dependencies:
-  analyzer: '^6.5.0'
+  analyzer: ">=6.5.0 <8.0.0"
   args: ">=1.0.0 <3.0.0"
   collection: "^1.17.0"
   package_config: ^2.1.0


### PR DESCRIPTION
How was this tested? First I set the constraint to `^7.0.0` and ran `dart pub upgrade` with Dart 3.5.0. Dart 3.5.0 did not like that, because of macros, and failed to version-solve. I then ran `dart pub upgrade` with a Dart 3.7.0 dev release, and obtained a successful version-solve, using analyzer 7.0.0. The code analyzes cleanly, and all 5108 tests pass.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
