### PR TITLE
Bump to publish 3.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.0-wip
+## 3.0.0
 
 This is a large change. Under the hood, the formatter was almost completely
 rewritten, with the codebase now containing both the old and new

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -12,7 +12,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '2.3.7';
+const dartStyleVersion = '3.0.0';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 final class FormatterOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.0.0-wip
+version: 3.0.0
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -23,7 +23,7 @@ Future<void> validate() async {
   Analyzer.analyze('bin/format.dart', fatalWarnings: true);
 
   // Format it.
-  Dart.run('bin/format.dart', arguments: ['-w', '.']);
+  Dart.run('bin/format.dart', arguments: ['.']);
 }
 
 /// Gets ready to publish a new version of the package.


### PR DESCRIPTION
Also fixed the format-self call in the grinder script which was still using the old CLI format.
