### PR TITLE
Format `||` patterns like fallthrough cases in switch expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.1-wip
 
 * Handle trailing commas in for-loop updaters (#1354).
+* Format `||` patterns like fallthrough cases in switch expressions (#1602).
 * Handle comments and metadata before variables more gracefully (#1604).
 * Ensure comment formatting is idempotent (#1606).
 * Better indentation of leading comments on property accesses in binary operator

--- a/test/tall/expression/switch.stmt
+++ b/test/tall/expression/switch.stmt
@@ -120,8 +120,7 @@ e = switch (obj) {
 e = switch (obj) {
   oneConstant ||
   twoConstant ||
-  threeConstant =>
-    body,
+  threeConstant => body,
 };
 >>> Nested logic-or operands are indented.
 e = switch (obj) {
@@ -175,4 +174,15 @@ e = switch (obj) {
       veryLongElement,
       veryLongElement,
     ),
+};
+>>> Prefer to split `||` pattern instead of case body.
+e = switch (obj) {
+  pattern || another => function(
+    argument,
+  ),
+};
+<<<
+e = switch (obj) {
+  pattern ||
+  another => function(argument),
 };

--- a/test/tall/expression/switch_guard.stmt
+++ b/test/tall/expression/switch_guard.stmt
@@ -96,8 +96,7 @@ e = switch (obj) {
 <<<
 e = switch (obj) {
   veryVeryLongPattern ||
-  reallyMustSplitHere when true =>
-    body,
+  reallyMustSplitHere when true => body,
 };
 >>> Outermost logic-or split in pattern, expression split in guard.
 e = switch (obj) {

--- a/test/tall/regression/1100/1197.unit
+++ b/test/tall/regression/1100/1197.unit
@@ -25,6 +25,9 @@ main() {
   }
 }
 <<<
+### TODO(1466): Ideally, the first case would also split at the `||` instead of
+### of before `.`, but the formatter can't distinguish that case without fixing
+### #1466.
 main() {
   {
     return TextFieldTapRegion(
@@ -38,14 +41,13 @@ main() {
           TargetPlatform.android ||
           TargetPlatform.fuchsia ||
           TargetPlatform.linux ||
-          TargetPlatform.windows =>
-            _renderEditable.selectWordsInRange(
-              from:
-                  longPressMoveUpdateDetails.globalPosition -
-                  longPressMoveUpdateDetails.offsetFromOrigin,
-              to: longPressMoveUpdateDetails.globalPosition,
-              cause: SelectionChangedCause.longPress,
-            ),
+          TargetPlatform.windows => _renderEditable.selectWordsInRange(
+            from:
+                longPressMoveUpdateDetails.globalPosition -
+                longPressMoveUpdateDetails.offsetFromOrigin,
+            to: longPressMoveUpdateDetails.globalPosition,
+            cause: SelectionChangedCause.longPress,
+          ),
         });
       },
     );
@@ -77,6 +79,9 @@ main() {
   }
 }
 <<<
+### TODO(1466): Ideally, the first case would also split at the `||` instead of
+### of before `.`, but the formatter can't distinguish that case without fixing
+### #1466.
 main() {
   {
     return TextFieldTapRegion(
@@ -92,14 +97,13 @@ main() {
             TargetPlatform.android ||
             TargetPlatform.fuchsia ||
             TargetPlatform.linux ||
-            TargetPlatform.windows =>
-              _renderEditable.selectWordsInRange(
-                from:
-                    longPressMoveUpdateDetails.globalPosition -
-                    longPressMoveUpdateDetails.offsetFromOrigin,
-                to: longPressMoveUpdateDetails.globalPosition,
-                cause: SelectionChangedCause.longPress,
-              ),
+            TargetPlatform.windows => _renderEditable.selectWordsInRange(
+              from:
+                  longPressMoveUpdateDetails.globalPosition -
+                  longPressMoveUpdateDetails.offsetFromOrigin,
+              to: longPressMoveUpdateDetails.globalPosition,
+              cause: SelectionChangedCause.longPress,
+            ),
           },
     );
   }

--- a/test/tall/regression/1600/1602.stmt
+++ b/test/tall/regression/1600/1602.stmt
@@ -1,0 +1,12 @@
+>>> (indent 4)
+    return switch (_advance().type) {
+      TokenType.float || TokenType.int || TokenType.string => LiteralExpression(
+        _previous.value!,
+      ),
+    };
+<<<
+    return switch (_advance().type) {
+      TokenType.float ||
+      TokenType.int ||
+      TokenType.string => LiteralExpression(_previous.value!),
+    };


### PR DESCRIPTION
Switch statements allow multiple cases to share a body like:

```dart
switch (obj) {
  case pattern1:
  case pattern2:
    body;
}
```

Switch expressions don't support that, but `||` patterns are the idiomatic way to accomplish the same thing. Because of that, the formatter has some special formatting when the outermost pattern in a switch expression case is `||`:

```dart
x = switch (obj) {
  pattern1 ||
  pattern2 =>
    body,
};
```

Note how the `pattern2` operand isn't indented.

This PR extends that special handling to allow the `=>` on the same line as the `=>` even if the pattern is a split `||` pattern, like:

```dart
x = switch (obj) {
  pattern1 ||
  pattern2 => body,
};
```

And it prefers to split the `||` over the body when the body is block formatted:

```dart
// Prefer:
x = switch (obj) {
  pattern1 ||
  pattern2 => function(argument),
};

// Over:
x = switch (obj) {
  pattern1 || pattern2 => function(
    argument,
  ),
};
```

This is one of those rules that's mostly a matter of taste, but I ran this on a large corpus and most of the diffs look better to me. Here are a few examples:

```dart
// Before:
      typeName = switch (targetType) {
        DriftSqlType.int || DriftSqlType.bigInt || DriftSqlType.bool =>
          'INTEGER',
        DriftSqlType.string => 'CHAR',
        DriftSqlType.double => 'DOUBLE',
        DriftSqlType.blob => 'BINARY',
        DriftSqlType.dateTime => 'DATETIME',
        DriftSqlType.any => '',
        CustomSqlType() || DialectAwareSqlType() => targetType.sqlTypeName(
          context,
        ),
      };

// After:
      typeName = switch (targetType) {
        DriftSqlType.int ||
        DriftSqlType.bigInt ||
        DriftSqlType.bool => 'INTEGER',
        DriftSqlType.string => 'CHAR',
        DriftSqlType.double => 'DOUBLE',
        DriftSqlType.blob => 'BINARY',
        DriftSqlType.dateTime => 'DATETIME',
        DriftSqlType.any => '',
        CustomSqlType() ||
        DialectAwareSqlType() => targetType.sqlTypeName(context),
      };

// Before:
    return switch (side) {
      AxisSide.right || AxisSide.left =>
        titlesPadding.vertical + borderPadding.vertical,
      AxisSide.top || AxisSide.bottom =>
        titlesPadding.horizontal + borderPadding.horizontal,
    };

// After:
    return switch (side) {
      AxisSide.right ||
      AxisSide.left => titlesPadding.vertical + borderPadding.vertical,
      AxisSide.top ||
      AxisSide.bottom => titlesPadding.horizontal + borderPadding.horizontal,
    };

// Before:
    final defaultConstraints = switch (side) {
      ShadSheetSide.top || ShadSheetSide.bottom => BoxConstraints(
        minWidth: mSize.width,
      ),
      ShadSheetSide.left || ShadSheetSide.right => BoxConstraints(
        minHeight: mSize.height,
      ),
    };

    final defaultConstraints = switch (side) {
      ShadSheetSide.top ||
      ShadSheetSide.bottom => BoxConstraints(minWidth: mSize.width),
      ShadSheetSide.left ||
      ShadSheetSide.right => BoxConstraints(minHeight: mSize.height),
    };
```

Fix #1602.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
