### PR TITLE
Update grinder script.

### DIFF
--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -12,7 +12,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '3.0.0';
+const dartStyleVersion = '3.0.1-wip';
 
 /// Global options that affect how the formatter produces and uses its outputs.
 final class FormatterOptions {

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -59,7 +59,7 @@ Future<void> major() async {
 /// 2.  Run this task:
 ///
 ///     ```
-///     pub run grinder bump
+///     dart run grinder bump
 ///     ```
 ///
 /// 3.  Commit the change to a branch, push it to GitHub, and review and merge


### PR DESCRIPTION
The workflow for shipping dart_style used to be that we published a new version on pub and then rolled it into the Dart SDK. That meant that the dart_style version number in the SDK accurately described what was in dart_style.

A few years ago, we changed to rolling into the SDK first. That lets us validate dart_style inside google3 before irrevocably publishing, which is a good thing. But it has an unfortunate side effect. If you run `dart format --version`, it shows the *previous* version number of dart_style because the version number only gets bumped when we publish. This is really confusing if you're trying to debug the formatter in the SDK and it appears to be an older version than it actually is.

To fix that, I'm tweaking the workflow slightly. When we begin working on a new version of the formatter, we bump the version number in the pubspec to, say, 3.4.5-wip. At that point, we immediately update the version number constant shown by `--version` to "3.4.5" (the version it *will* be). That way, when it gets rolled into the SDK, it prints the upcoming version number.

When a version of dart_style is about to be published, we remove `-wip` from the pubspec but the constant printed by `--version` is already done.

To make this workflow a little less error-prone, I updated the grinder script to add tasks for starting a new patch, minor, and major version.

I also updated the docs for the old task now that we use the workflow automation for publishing.
