### PR TITLE
Allow block formatting record types in typedefs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,27 @@
         );
   ```
 
+* Block format record types in typedefs (#1651):
+
+  ```dart
+  // Before:
+  typedef ExampleRecordTypedef =
+      (
+        String firstParameter,
+        int secondParameter,
+        String thirdParameter,
+        String fourthParameter,
+      );
+
+  // After:
+  typedef ExampleRecordTypedef = (
+    String firstParameter,
+    int secondParameter,
+    String thirdParameter,
+    String fourthParameter,
+  );
+  ```
+
 * Don't add a trailing comma in lists that don't allow it, even when there is
   a trailing comment (#1639).
 * Add tests for digit separators.

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -882,7 +882,8 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
       pieces.token(node.name);
       pieces.visit(node.typeParameters);
       pieces.space();
-      pieces.add(AssignPiece(tokenPiece(node.equals), nodePiece(node.type)));
+      pieces.add(AssignPiece(tokenPiece(node.equals), nodePiece(node.type),
+          canBlockSplitRight: node.type is RecordTypeAnnotation));
       pieces.token(node.semicolon);
     });
   }

--- a/test/tall/declaration/typedef.unit
+++ b/test/tall/declaration/typedef.unit
@@ -158,3 +158,10 @@ typedef Generic<T, R> =
       T param,
       R another,
     );
+>>> Allow block-formatting a record typedef.
+typedef SomeType = (int first, int second);
+<<<
+typedef SomeType = (
+  int first,
+  int second,
+);

--- a/test/tall/regression/1600/1651.unit
+++ b/test/tall/regression/1600/1651.unit
@@ -1,0 +1,15 @@
+>>>
+typedef ExampleRecordTypedef =
+    (
+      String firstParameter,
+      int secondParameter,
+      String thirdParameter,
+      String fourthParameter,
+    );
+<<<
+typedef ExampleRecordTypedef = (
+  String firstParameter,
+  int secondParameter,
+  String thirdParameter,
+  String fourthParameter,
+);


### PR DESCRIPTION
Fix #1651.
