### PR TITLE
Add an optional configuration to preserve trailing commas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.2-wip
+## 3.1.0-wip
 
 * Format null-aware elements.
 
@@ -63,9 +63,25 @@
   );
   ```
 
+* Allow preserving trailing commas and forcing the surrounding construct to
+  split even when it would otherwise fit on one line. This is off by default
+  (because it breaks [reversibility][] among other reasons) but can be enabled
+  by adding this to a surrounding `analysis_options.yaml` file:
+
+  ```yaml
+  formatter:
+    trailing_commas: preserve
+  ```
+
+  This is similar to how trailing commas worked in the old short style
+  formatter.
+
 * Don't add a trailing comma in lists that don't allow it, even when there is
   a trailing comment (#1639).
+
 * Add tests for digit separators.
+
+[reversibility]: https://github.com/dart-lang/dart_style/wiki/Reversibility-principle
 
 ## 3.0.1
 

--- a/example/format.dart
+++ b/example/format.dart
@@ -30,12 +30,34 @@ void main(List<String> args) {
   _runTest('other/selection.stmt', 2);
 }
 
-void _formatStmt(String source, {bool tall = true, int pageWidth = 40}) {
-  _runFormatter(source, pageWidth, tall: tall, isCompilationUnit: false);
+void _formatStmt(
+  String source, {
+  bool tall = true,
+  int pageWidth = 40,
+  TrailingCommas trailingCommas = TrailingCommas.automate,
+}) {
+  _runFormatter(
+    source,
+    pageWidth,
+    tall: tall,
+    isCompilationUnit: false,
+    trailingCommas: trailingCommas,
+  );
 }
 
-void _formatUnit(String source, {bool tall = true, int pageWidth = 40}) {
-  _runFormatter(source, pageWidth, tall: tall, isCompilationUnit: true);
+void _formatUnit(
+  String source, {
+  bool tall = true,
+  int pageWidth = 40,
+  TrailingCommas trailingCommas = TrailingCommas.automate,
+}) {
+  _runFormatter(
+    source,
+    pageWidth,
+    tall: tall,
+    isCompilationUnit: true,
+    trailingCommas: trailingCommas,
+  );
 }
 
 void _runFormatter(
@@ -43,6 +65,7 @@ void _runFormatter(
   int pageWidth, {
   required bool tall,
   required bool isCompilationUnit,
+  TrailingCommas trailingCommas = TrailingCommas.automate,
 }) {
   try {
     var formatter = DartFormatter(
@@ -51,6 +74,7 @@ void _runFormatter(
               ? DartFormatter.latestLanguageVersion
               : DartFormatter.latestShortStyleLanguageVersion,
       pageWidth: pageWidth,
+      trailingCommas: trailingCommas,
     );
 
     String result;
@@ -84,13 +108,7 @@ Future<void> _runTest(
 }) async {
   var testFile = await TestFile.read('${tall ? 'tall' : 'short'}/$path');
   var formatTest = testFile.tests.firstWhere((test) => test.line == line);
-
-  var formatter = DartFormatter(
-    languageVersion: formatTest.languageVersion,
-    pageWidth: testFile.pageWidth,
-    indent: formatTest.leadingIndent,
-    experimentFlags: formatTest.experimentFlags,
-  );
+  var formatter = testFile.formatterForTest(formatTest);
 
   var actual = formatter.formatSource(formatTest.input);
 

--- a/lib/src/analysis_options/analysis_options_file.dart
+++ b/lib/src/analysis_options/analysis_options_file.dart
@@ -17,14 +17,14 @@ typedef AnalysisOptions = Map<Object?, Object?>;
 /// passed to [FileSystem.join()].
 typedef ResolvePackageUri = Future<String?> Function(Uri packageUri);
 
-/// Reads an `analysis_options.yaml` file in [directory] or in the nearest
+/// Reads an "analysis_options.yaml" file in [directory] or in the nearest
 /// surrounding folder that contains that file using [fileSystem].
 ///
 /// Stops walking parent directories as soon as it finds one that contains an
-/// `analysis_options.yaml` file. If it reaches the root directory without
+/// "analysis_options.yaml" file. If it reaches the root directory without
 /// finding one, returns an empty [YamlMap].
 ///
-/// If an `analysis_options.yaml` file is found, reads it and parses it to a
+/// If an "analysis_options.yaml" file is found, reads it and parses it to a
 /// [YamlMap]. If the map contains an `include` key whose value is a list, then
 /// reads any of the other referenced YAML files and merges them into this one.
 /// Returns the resulting map with the `include` key removed.

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -454,6 +454,9 @@ extension PatternExtensions on DartPattern {
 }
 
 extension TokenExtensions on Token {
+  /// Whether the token before this one is a comma.
+  bool get hasCommaBefore => previous?.type == TokenType.COMMA;
+
   /// Whether this token has a preceding comment that is a line comment.
   bool get hasLineCommentBefore {
     for (

--- a/lib/src/cli/format_command.dart
+++ b/lib/src/cli/format_command.dart
@@ -107,6 +107,22 @@ final class FormatCommand extends Command<int> {
     );
 
     argParser.addOption(
+      'trailing-commas',
+      help: 'How trailing commas in input affect formatting.',
+      defaultsTo: 'automate',
+      allowedHelp: {
+        'automate':
+            'The formatter adds and removes trailing commas based on\n'
+            'its decision to split the surrounding construct.',
+        'preserve':
+            'A trailing comma forces the surrounding construct to split.\n'
+            'The formatter will add a trailing comma when it splits a\n'
+            'construct but will not remove one.',
+      },
+      hide: !verbose,
+    );
+
+    argParser.addOption(
       'indent',
       abbr: 'i',
       help: 'Add this many spaces of leading indentation.',
@@ -255,6 +271,19 @@ final class FormatCommand extends Command<int> {
       }
     }
 
+    TrailingCommas? trailingCommas;
+    if (argResults.wasParsed('trailing-commas')) {
+      // We check the values explicitly here instead of using `allowedValues`
+      // from [ArgParser] because this provides a better error message.
+      trailingCommas = switch (argResults['trailing-commas']) {
+        'automate' => TrailingCommas.automate,
+        'preserve' => TrailingCommas.preserve,
+        var mode => usageException(
+          '--trailing-commas must be "automate" or "preserve", was "$mode".',
+        ),
+      };
+    }
+
     var indent =
         int.tryParse(argResults['indent'] as String) ??
         usageException(
@@ -300,6 +329,7 @@ final class FormatCommand extends Command<int> {
       languageVersion: languageVersion,
       indent: indent,
       pageWidth: pageWidth,
+      trailingCommas: trailingCommas,
       followLinks: followLinks,
       show: show,
       output: output,

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -6,15 +6,17 @@ import 'dart:io';
 
 import 'package:pub_semver/pub_semver.dart';
 
+import '../dart_formatter.dart';
 import '../source_code.dart';
 import 'output.dart';
 import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '3.0.2-wip';
+const dartStyleVersion = '3.1.0-wip';
 
-/// Global options that affect how the formatter produces and uses its outputs.
+/// Global options parsed from the command line that affect how the formatter
+/// produces and uses its outputs.
 final class FormatterOptions {
   /// The language version formatted code should be parsed at or `null` if not
   /// specified.
@@ -29,6 +31,9 @@ final class FormatterOptions {
   /// If omitted, the formatter defaults to a page width of
   /// [DartFormatter.defaultPageWidth].
   final int? pageWidth;
+
+  /// How trailing commas in the input source code affect formatting.
+  final TrailingCommas? trailingCommas;
 
   /// Whether symlinks should be traversed when formatting a directory.
   final bool followLinks;
@@ -53,6 +58,7 @@ final class FormatterOptions {
     this.languageVersion,
     this.indent = 0,
     this.pageWidth,
+    this.trailingCommas,
     this.followLinks = false,
     this.show = Show.changed,
     this.output = Output.write,

--- a/lib/src/config_cache.dart
+++ b/lib/src/config_cache.dart
@@ -130,19 +130,26 @@ final class ConfigCache {
           pageWidth = width;
         }
 
-        if (formatter case {'trailing_commas': String commas}) {
-          trailingCommas = switch (commas) {
-            'automate' => TrailingCommas.automate,
-            'preserve' => TrailingCommas.preserve,
-            // Silently ignore any unrecognized name.
-            _ => null,
-          };
+        if (formatter case {'trailing_commas': var commas}) {
+          switch (commas) {
+            case 'automate':
+              trailingCommas = TrailingCommas.automate;
+            case 'preserve':
+              trailingCommas = TrailingCommas.preserve;
+            default:
+              stderr.writeln(
+                'Warning: "trailing_commas" option should be "automate" or '
+                '"preserve", but was "$commas".',
+              );
+          }
         }
       }
-    } on PackageResolutionException {
-      // Silently ignore any errors coming from the processing the analyis
-      // options. If there are any issues, we just use the default page width
-      // and keep going.
+    } on PackageResolutionException catch (exception) {
+      // Report the error, but use the default settings and keep going.
+      stderr.writeln(
+        'Warning: Package resolution error when reading '
+        '"analysis_options.yaml" file:\n$exception',
+      );
     }
 
     // Cache whichever options we found (or `null` if we didn't find them).

--- a/lib/src/config_cache.dart
+++ b/lib/src/config_cache.dart
@@ -9,13 +9,14 @@ import 'package:pub_semver/pub_semver.dart';
 
 import 'analysis_options/analysis_options_file.dart';
 import 'analysis_options/io_file_system.dart';
+import 'dart_formatter.dart';
 import 'profile.dart';
 
 /// Caches the nearest surrounding package config file for files in directories.
 ///
 /// The formatter reads `.dart_tool/package_config.json` files in order to
 /// determine the default language version of files in that package and to
-/// resolve "package:" URIs in `analysis_options.yaml` files.
+/// resolve "package:" URIs in "analysis_options.yaml" files.
 ///
 /// Walking the file system to find the package config and then reading it off
 /// disk is very slow. We know that every formatted file in the same directory
@@ -40,13 +41,9 @@ final class ConfigCache {
   /// discovered that there is no surrounding package.
   final Map<String, Version?> _directoryVersions = {};
 
-  /// The previously cached page width for all files immediately within a given
-  /// directory.
-  ///
-  /// The width may be `null` if we formatted a file in that directory and
-  /// discovered that there is no surrounding analysis options that sets a
-  /// page width.
-  final Map<String, int?> _directoryPageWidths = {};
+  /// The previously cached configured options for all files immediately within
+  /// a given directory.
+  final Map<String, _FormatterOptions> _directoryOptions = {};
 
   final IOFileSystem _fileSystem = IOFileSystem();
 
@@ -89,23 +86,57 @@ final class ConfigCache {
   ///     formatter:
   ///       page_width: 123
   Future<int?> findPageWidth(File file) async {
-    // Use the cached version (which may be `null`) if present.
+    return (await _findFormatterOptions(file)).pageWidth;
+  }
+
+  /// Looks for an "analysis_options.yaml" file surrounding [file] and, if
+  /// found and valid, returns the trailing comma handling specified by that
+  /// config file.
+  ///
+  /// Otherwise returns `null`.
+  ///
+  /// The schema looks like:
+  ///
+  ///     formatter:
+  ///       trailing_commas: preserve # Or "automate".
+  Future<TrailingCommas?> findTrailingCommas(File file) async {
+    return (await _findFormatterOptions(file)).trailingCommas;
+  }
+
+  /// Looks for an "analysis_options.yaml" file surrounding [file] and, if
+  /// found and valid, returns the configured options.
+  ///
+  /// If no options file could be found or it doesn't contain a "formatter" key
+  /// whose value is a map, returns a default set of options where all settings
+  /// are `null`.
+  Future<_FormatterOptions> _findFormatterOptions(File file) async {
+    // Use the cached version if present.
     var directory = file.parent.path;
-    if (_directoryPageWidths.containsKey(directory)) {
-      return _directoryPageWidths[directory];
-    }
+    if (_directoryOptions[directory] case var options?) return options;
+
+    int? pageWidth;
+    TrailingCommas? trailingCommas;
 
     try {
-      // Look for a surrounding analysis_options.yaml file.
-      var options = await findAnalysisOptions(
+      // Look for a surrounding "analysis_options.yaml" file.
+      var optionsFile = await findAnalysisOptions(
         _fileSystem,
         await _fileSystem.makePath(file.path),
         resolvePackageUri: (uri) => _resolvePackageUri(file, uri),
       );
 
-      if (options['formatter'] case Map<Object?, Object?> formatter) {
-        if (formatter['page_width'] case int pageWidth) {
-          return _directoryPageWidths[directory] = pageWidth;
+      if (optionsFile['formatter'] case Map<Object?, Object?> formatter) {
+        if (formatter case {'page_width': int width}) {
+          pageWidth = width;
+        }
+
+        if (formatter case {'trailing_commas': String commas}) {
+          trailingCommas = switch (commas) {
+            'automate' => TrailingCommas.automate,
+            'preserve' => TrailingCommas.preserve,
+            // Silently ignore any unrecognized name.
+            _ => null,
+          };
         }
       }
     } on PackageResolutionException {
@@ -114,10 +145,11 @@ final class ConfigCache {
       // and keep going.
     }
 
-    // If we get here, the options file either doesn't specify the page width,
-    // or specifies it in some invalid way. When that happens, silently ignore
-    // the config file and use the default width.
-    return _directoryPageWidths[directory] = null;
+    // Cache whichever options we found (or `null` if we didn't find them).
+    return _directoryOptions[directory] = _FormatterOptions(
+      pageWidth,
+      trailingCommas,
+    );
   }
 
   /// Look for and cache the nearest package surrounding [file].
@@ -175,4 +207,18 @@ final class ConfigCache {
 
     return config.resolve(packageUri)?.toFilePath();
   }
+}
+
+/// The formatter options that can be configured in the "analysis_options.yaml"
+/// file.
+final class _FormatterOptions {
+  /// The configured page width, or `null` if there is no options file or the
+  /// options file doesn't specify it.
+  final int? pageWidth;
+
+  /// The configured comma handling, or `null` if there is no options file or
+  /// the options file doesn't specify it.
+  final TrailingCommas? trailingCommas;
+
+  _FormatterOptions(this.pageWidth, this.trailingCommas);
 }

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -65,6 +65,13 @@ final class DartFormatter {
   /// The number of characters of indentation to prefix the output lines with.
   final int indent;
 
+  /// How trailing commas in various constructs should affect formatting.
+  ///
+  /// The default is [TrailingCommas.automate] where the formatter is free to
+  /// add and remove them if it decides a constructor should be split or
+  /// collapsed.
+  final TrailingCommas trailingCommas;
+
   /// Flags to enable experimental language features.
   ///
   /// See dart.dev/go/experiments for details.
@@ -83,9 +90,11 @@ final class DartFormatter {
     this.lineEnding,
     int? pageWidth,
     int? indent,
+    TrailingCommas? trailingCommas,
     List<String>? experimentFlags,
   }) : pageWidth = pageWidth ?? defaultPageWidth,
        indent = indent ?? 0,
+       trailingCommas = trailingCommas ?? TrailingCommas.automate,
        experimentFlags = [...?experimentFlags];
 
   /// Formats the given [source] string containing an entire Dart compilation
@@ -238,4 +247,21 @@ final class DartFormatter {
 
     return output;
   }
+}
+
+/// Configuration for how trailing commas should be handled by the formatter.
+///
+/// Note that this only applies when using the new formatter to format code at
+/// language version 3.7 or later. On older versions, it always behaves as if
+/// it were [TrailingCommas.preserve].
+enum TrailingCommas {
+  /// The formatter will add a trailing comma if a construct is split and
+  /// remove the trailing comma and collapse the construct if it decides to do
+  /// so.
+  automate,
+
+  /// The formatter will add a trailing comma if a construct splits. If the
+  /// construct has a trailing comma, it will always be forced to split and the
+  /// trailing comma is preserved.
+  preserve,
 }

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -167,9 +167,9 @@ final class DelimitedListBuilder {
   /// then become an element in a surrounding [DelimitedListBuilder]. It ensures
   /// that any comments around a trailing comma after [inner] don't get lost and
   /// are instead hoisted up to be captured by this builder.
-  void addInnerBuilder(DelimitedListBuilder inner) {
+  void addInnerBuilder(DelimitedListBuilder inner, {bool forceSplit = false}) {
     // Add the elements of the line to this builder.
-    add(inner.build());
+    add(inner.build(forceSplit: forceSplit));
 
     // Make sure that any trailing comments on the line aren't lost.
     _commentsBeforeComma = inner._commentsBeforeComma;

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -1627,11 +1627,9 @@ mixin PieceFactory {
 
   /// Whether there is a trailing comma at the end of the list delimited by
   /// [rightBracket].
-  bool hasPreservedTrailingComma(Token rightBracket) {
-    if (formatter.trailingCommas != TrailingCommas.preserve) return false;
-
-    return rightBracket.hasCommaBefore;
-  }
+  bool hasPreservedTrailingComma(Token rightBracket) =>
+      formatter.trailingCommas == TrailingCommas.preserve &&
+      rightBracket.hasCommaBefore;
 
   /// Writes a piece for a parameter-like constructor: Either a simple formal
   /// parameter or a record type field, which is syntactically similar to a

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 
 import '../ast_extensions.dart';
+import '../dart_formatter.dart';
 import '../piece/adjacent.dart';
 import '../piece/assign.dart';
 import '../piece/clause.dart';
@@ -107,6 +108,8 @@ mixin PieceFactory {
   /// we pop the last value, If it's `true`, we know we visited a nested
   /// collection so we force this one to split.
   final List<bool> _collectionSplits = [];
+
+  DartFormatter get formatter;
 
   PieceWriter get pieces;
 
@@ -454,17 +457,27 @@ mixin PieceFactory {
         if (forParts.updaters.isNotEmpty) {
           partsList.addCommentsBefore(forParts.updaters.first.beginToken);
 
+          // Unlike most places in the language, if the updaters split, we
+          // don't want to add a trailing comma. But if the user has preserve
+          // trailing commas on, we should preserve the comma if there is one
+          // but not add one if there isn't and it splits.
+          var style = const ListStyle(commas: Commas.nonTrailing);
+          if (formatter.trailingCommas == TrailingCommas.preserve &&
+              rightParenthesis.hasCommaBefore) {
+            style = const ListStyle(commas: Commas.trailing);
+          }
+
           // Create a nested list builder for the updaters so that they can
           // remain unsplit even while the clauses split.
-          var updaterBuilder = DelimitedListBuilder(
-            this,
-            const ListStyle(commas: Commas.nonTrailing),
-          );
+          var updaterBuilder = DelimitedListBuilder(this, style);
           forParts.updaters.forEach(updaterBuilder.visit);
 
           // Add the updater builder to the clause builder so that any comments
           // around a trailing comma after the updaters don't get dropped.
-          partsList.addInnerBuilder(updaterBuilder);
+          partsList.addInnerBuilder(
+            updaterBuilder,
+            forceSplit: hasPreservedTrailingComma(rightParenthesis),
+          );
         }
 
         partsList.rightBracket(rightParenthesis);
@@ -1145,7 +1158,15 @@ mixin PieceFactory {
     }
 
     builder.rightBracket(rightBracket);
-    pieces.add(builder.build());
+    pieces.add(
+      builder.build(
+        // If we are always writing a trailing comma (because it's a
+        // single-element record), then the comma shouldn't force a split.
+        forceSplit:
+            style.commas != Commas.alwaysTrailing &&
+            hasPreservedTrailingComma(rightBracket),
+      ),
+    );
   }
 
   /// Writes [elements] into [builder], preserving the original newlines (or
@@ -1602,6 +1623,14 @@ mixin PieceFactory {
       pieces.space();
       pieces.visit(sequence);
     });
+  }
+
+  /// Whether there is a trailing comma at the end of the list delimited by
+  /// [rightBracket].
+  bool hasPreservedTrailingComma(Token rightBracket) {
+    if (formatter.trailingCommas != TrailingCommas.preserve) return false;
+
+    return rightBracket.hasCommaBefore;
   }
 
   /// Writes a piece for a parameter-like constructor: Either a simple formal

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -7,7 +7,6 @@ import 'package:analyzer/dart/ast/token.dart';
 import '../back_end/code_writer.dart';
 import '../back_end/solution_cache.dart';
 import '../back_end/solver.dart';
-import '../dart_formatter.dart';
 import '../debug.dart' as debug;
 import '../piece/adjacent.dart';
 import '../piece/leading_comment.dart';
@@ -26,8 +25,6 @@ import 'sequence_builder.dart';
 /// Handles updating selection markers and attaching comments to the tokens
 /// before and after the comments.
 final class PieceWriter {
-  final DartFormatter _formatter;
-
   final SourceCode _source;
 
   final CommentWriter _comments;
@@ -77,7 +74,7 @@ final class PieceWriter {
   /// previous code or adding a [SpacePiece] yet.
   bool _pendingSpace = false;
 
-  PieceWriter(this._formatter, this._source, this._comments);
+  PieceWriter(this._source, this._comments);
 
   /// Wires the [PieceWriter] to the [AstNodeVisitor] (which implements
   /// [PieceFactory]) so that [PieceWriter] can visit nodes.
@@ -447,14 +444,13 @@ final class PieceWriter {
 
   /// Finishes writing and returns a [SourceCode] containing the final output
   /// and updated selection, if any.
-  ///
-  /// If there is a `// dart format width=123` comment before the formatted
-  /// code, then [pageWidthFromComment] is that width.
   SourceCode finish(
     SourceCode source,
     Piece rootPiece,
-    int? pageWidthFromComment,
-  ) {
+    String? lineEnding, {
+    required int pageWidth,
+    required int leadingIndent,
+  }) {
     if (debug.tracePieceBuilder) {
       debug.log(debug.pieceTree(rootPiece));
     }
@@ -464,11 +460,11 @@ final class PieceWriter {
     var cache = SolutionCache();
     var solver = Solver(
       cache,
-      pageWidth: pageWidthFromComment ?? _formatter.pageWidth,
-      leadingIndent: _formatter.indent,
+      pageWidth: pageWidth,
+      leadingIndent: leadingIndent,
     );
     var solution = solver.format(rootPiece);
-    var output = solution.code.build(source, _formatter.lineEnding);
+    var output = solution.code.build(source, lineEnding);
 
     Profile.end('PieceWriter.finish() format piece tree');
 

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -46,6 +46,12 @@ Future<void> formatStdin(
     pageWidth = await cache.findPageWidth(File(path));
   }
 
+  var trailingCommas = options.trailingCommas;
+  if (trailingCommas == null && path != null) {
+    // We have a stdin-name, so look for a surrounding analyisis_options.yaml.
+    trailingCommas = await cache.findTrailingCommas(File(path));
+  }
+
   // Use a default page width if we don't have a specified one and couldn't
   // find a configured one.
   pageWidth ??= DartFormatter.defaultPageWidth;
@@ -60,6 +66,7 @@ Future<void> formatStdin(
       languageVersion: languageVersion!,
       indent: options.indent,
       pageWidth: pageWidth,
+      trailingCommas: trailingCommas,
       experimentFlags: options.experimentFlags,
     );
     try {
@@ -182,8 +189,10 @@ Future<bool> _processFile(
   // package, then default to the latest version.
   languageVersion ??= DartFormatter.latestLanguageVersion;
 
-  // Determine the page width.
+  // Determine the configuration options.
   var pageWidth = options.pageWidth ?? await cache.findPageWidth(file);
+  var trailingCommas =
+      options.trailingCommas ?? await cache.findTrailingCommas(file);
 
   // Use a default page width if we don't have a specified one and couldn't
   // find a configured one.
@@ -193,6 +202,7 @@ Future<bool> _processFile(
     languageVersion: languageVersion,
     indent: options.indent,
     pageWidth: pageWidth,
+    trailingCommas: trailingCommas,
     experimentFlags: options.experimentFlags,
   );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.0.2-wip
+version: 3.1.0-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/cli/cli_test.dart
+++ b/test/cli/cli_test.dart
@@ -22,17 +22,16 @@ void main() {
       ]).create();
 
       var process = await runFormatterOnDir();
-      expect(
-        await process.stdout.next,
-        'Formatted ${p.join('code', 'a.dart')}',
+      await expectLater(
+        process.stdout,
+        emitsInOrder([
+          'Formatted ${p.join('code', 'a.dart')}',
+          'Formatted ${p.join('code', 'c.dart')}',
+        ]),
       );
-      expect(
-        await process.stdout.next,
-        'Formatted ${p.join('code', 'c.dart')}',
-      );
-      expect(
-        await process.stdout.next,
-        startsWith(r'Formatted 3 files (2 changed)'),
+      await expectLater(
+        process.stdout,
+        emits(startsWith('Formatted 3 files (2 changed)')),
       );
       await process.shouldExit(0);
 
@@ -52,17 +51,16 @@ void main() {
         p.join('code', 'subdir'),
         p.join('code', 'c.dart'),
       ]);
-      expect(
-        await process.stdout.next,
-        'Formatted ${p.join('code', 'subdir', 'a.dart')}',
+      await expectLater(
+        process.stdout,
+        emitsInOrder([
+          'Formatted ${p.join('code', 'subdir', 'a.dart')}',
+          'Formatted ${p.join('code', 'c.dart')}',
+        ]),
       );
-      expect(
-        await process.stdout.next,
-        'Formatted ${p.join('code', 'c.dart')}',
-      );
-      expect(
-        await process.stdout.next,
-        startsWith(r'Formatted 2 files (2 changed)'),
+      await expectLater(
+        process.stdout,
+        emits(startsWith('Formatted 2 files (2 changed)')),
       );
       await process.shouldExit(0);
 
@@ -91,16 +89,19 @@ void main() {
     var process = await runFormatter(['--version']);
 
     // Match something roughly semver-like.
-    expect(await process.stdout.next, matches(RegExp(r'\d+\.\d+\.\d+.*')));
+    await expectLater(
+      process.stdout,
+      emits(matches(RegExp(r'\d+\.\d+\.\d+.*'))),
+    );
     await process.shouldExit(0);
   });
 
   group('--help', () {
     test('non-verbose shows description and common options', () async {
       var process = await runFormatter(['--help']);
-      expect(
-        await process.stdout.next,
-        'Idiomatically format Dart source code.',
+      await expectLater(
+        process.stdout,
+        emits('Idiomatically format Dart source code.'),
       );
       await expectLater(process.stdout, emitsThrough(contains('-o, --output')));
       await expectLater(process.stdout, neverEmits(contains('--summary')));
@@ -109,9 +110,9 @@ void main() {
 
     test('verbose shows description and all options', () async {
       var process = await runFormatter(['--help', '--verbose']);
-      expect(
-        await process.stdout.next,
-        'Idiomatically format Dart source code.',
+      await expectLater(
+        process.stdout,
+        emits('Idiomatically format Dart source code.'),
       );
       await expectLater(process.stdout, emitsThrough(contains('-o, --output')));
       await expectLater(process.stdout, emitsThrough(contains('--show')));
@@ -133,10 +134,15 @@ void main() {
       process.stdin.writeln("a flush left multi-line string''';}");
       await process.stdin.close();
 
-      expect(await process.stdout.next, '   main() {');
-      expect(await process.stdout.next, "     '''");
-      expect(await process.stdout.next, "a flush left multi-line string''';");
-      expect(await process.stdout.next, '   }');
+      await expectLater(
+        process.stdout,
+        emitsInOrder([
+          '   main() {',
+          "     '''",
+          "a flush left multi-line string''';",
+          '   }',
+        ]),
+      );
       await process.shouldExit(0);
     });
 
@@ -205,7 +211,7 @@ void main() {
         'selection': {'offset': 5, 'length': 9},
       });
 
-      expect(await process.stdout.next, json);
+      await expectLater(process.stdout, emits(json));
       await process.shouldExit();
     });
   });

--- a/test/cli/language_version_test.dart
+++ b/test/cli/language_version_test.dart
@@ -176,12 +176,17 @@ main() {
       process.stdin.writeln('main() { switch (o) { case 1 + 2: break; } }');
       await process.stdin.close();
 
-      expect(await process.stdout.next, 'main() {');
-      expect(await process.stdout.next, '  switch (o) {');
-      expect(await process.stdout.next, '    case 1 + 2:');
-      expect(await process.stdout.next, '      break;');
-      expect(await process.stdout.next, '  }');
-      expect(await process.stdout.next, '}');
+      await expectLater(
+        process.stdout,
+        emitsInOrder([
+          'main() {',
+          '  switch (o) {',
+          '    case 1 + 2:',
+          '      break;',
+          '  }',
+          '}',
+        ]),
+      );
       await process.shouldExit(0);
     });
 
@@ -205,12 +210,17 @@ main() {
       process.stdin.writeln('main() { switch (o) { case 1 + 2: break; } }');
       await process.stdin.close();
 
-      expect(await process.stdout.next, 'main() {');
-      expect(await process.stdout.next, '  switch (o) {');
-      expect(await process.stdout.next, '    case 1 + 2:');
-      expect(await process.stdout.next, '      break;');
-      expect(await process.stdout.next, '  }');
-      expect(await process.stdout.next, '}');
+      await expectLater(
+        process.stdout,
+        emitsInOrder([
+          'main() {',
+          '  switch (o) {',
+          '    case 1 + 2:',
+          '      break;',
+          '  }',
+          '}',
+        ]),
+      );
       await process.shouldExit(0);
     });
 
@@ -222,9 +232,10 @@ main() {
       process.stdin.writeln('main() {var (a,b)=(1,2);}');
       await process.stdin.close();
 
-      expect(await process.stdout.next, 'main() {');
-      expect(await process.stdout.next, '  var (a, b) = (1, 2);');
-      expect(await process.stdout.next, '}');
+      await expectLater(
+        process.stdout,
+        emitsInOrder(['main() {', '  var (a, b) = (1, 2);', '}']),
+      );
       await process.shouldExit(0);
     });
   });

--- a/test/cli/output_test.dart
+++ b/test/cli/output_test.dart
@@ -22,21 +22,17 @@ void main() {
       ]).create();
 
       var process = await runFormatterOnDir(['--show=all']);
-      expect(
-        await process.stdout.next,
-        'Formatted ${p.join('code', 'a.dart')}',
+      await expectLater(
+        process.stdout,
+        emitsInOrder([
+          'Formatted ${p.join('code', 'a.dart')}',
+          'Unchanged ${p.join('code', 'b.dart')}',
+          'Formatted ${p.join('code', 'c.dart')}',
+        ]),
       );
-      expect(
-        await process.stdout.next,
-        'Unchanged ${p.join('code', 'b.dart')}',
-      );
-      expect(
-        await process.stdout.next,
-        'Formatted ${p.join('code', 'c.dart')}',
-      );
-      expect(
-        await process.stdout.next,
-        startsWith(r'Formatted 3 files (2 changed)'),
+      await expectLater(
+        process.stdout,
+        emits(startsWith('Formatted 3 files (2 changed)')),
       );
       await process.shouldExit(0);
     });
@@ -49,9 +45,9 @@ void main() {
       ]).create();
 
       var process = await runFormatterOnDir(['--show=none']);
-      expect(
-        await process.stdout.next,
-        startsWith(r'Formatted 3 files (2 changed)'),
+      await expectLater(
+        process.stdout,
+        emits(startsWith('Formatted 3 files (2 changed)')),
       );
       await process.shouldExit(0);
     });
@@ -64,17 +60,16 @@ void main() {
       ]).create();
 
       var process = await runFormatterOnDir(['--show=changed']);
-      expect(
-        await process.stdout.next,
-        'Formatted ${p.join('code', 'a.dart')}',
+      await expectLater(
+        process.stdout,
+        emitsInOrder([
+          'Formatted ${p.join('code', 'a.dart')}',
+          'Formatted ${p.join('code', 'c.dart')}',
+        ]),
       );
-      expect(
-        await process.stdout.next,
-        'Formatted ${p.join('code', 'c.dart')}',
-      );
-      expect(
-        await process.stdout.next,
-        startsWith(r'Formatted 3 files (2 changed)'),
+      await expectLater(
+        process.stdout,
+        emits(startsWith('Formatted 3 files (2 changed)')),
       );
       await process.shouldExit(0);
     });
@@ -89,11 +84,13 @@ void main() {
         ]).create();
 
         var process = await runFormatterOnDir(['--output=show']);
-        expect(await process.stdout.next, formattedOutput);
-        expect(await process.stdout.next, formattedOutput);
-        expect(
-          await process.stdout.next,
-          startsWith(r'Formatted 2 files (1 changed)'),
+        await expectLater(
+          process.stdout,
+          emitsInOrder([formattedOutput, formattedOutput]),
+        );
+        await expectLater(
+          process.stdout,
+          emits(startsWith('Formatted 2 files (1 changed)')),
         );
         await process.shouldExit(0);
 
@@ -108,19 +105,18 @@ void main() {
         ]).create();
 
         var process = await runFormatterOnDir(['--output=show', '--show=all']);
-        expect(
-          await process.stdout.next,
-          'Changed ${p.join('code', 'a.dart')}',
+        await expectLater(
+          process.stdout,
+          emitsInOrder([
+            'Changed ${p.join('code', 'a.dart')}',
+            formattedOutput,
+            'Unchanged ${p.join('code', 'b.dart')}',
+            formattedOutput,
+          ]),
         );
-        expect(await process.stdout.next, formattedOutput);
-        expect(
-          await process.stdout.next,
-          'Unchanged ${p.join('code', 'b.dart')}',
-        );
-        expect(await process.stdout.next, formattedOutput);
-        expect(
-          await process.stdout.next,
-          startsWith(r'Formatted 2 files (1 changed)'),
+        await expectLater(
+          process.stdout,
+          emits(startsWith('Formatted 2 files (1 changed)')),
         );
         await process.shouldExit(0);
 
@@ -138,14 +134,16 @@ void main() {
           '--output=show',
           '--show=changed',
         ]);
-        expect(
-          await process.stdout.next,
-          'Changed ${p.join('code', 'a.dart')}',
+        await expectLater(
+          process.stdout,
+          emitsInOrder([
+            'Changed ${p.join('code', 'a.dart')}',
+            formattedOutput,
+          ]),
         );
-        expect(await process.stdout.next, formattedOutput);
-        expect(
-          await process.stdout.next,
-          startsWith(r'Formatted 2 files (1 changed)'),
+        await expectLater(
+          process.stdout,
+          emits(startsWith('Formatted 2 files (1 changed)')),
         );
         await process.shouldExit(0);
 
@@ -175,8 +173,7 @@ void main() {
 
         var process = await runFormatterOnDir(['--output=json']);
 
-        expect(await process.stdout.next, jsonA);
-        expect(await process.stdout.next, jsonB);
+        await expectLater(process.stdout, emitsInOrder([jsonA, jsonB]));
         await process.shouldExit();
       });
 
@@ -197,17 +194,16 @@ void main() {
         ]).create();
 
         var process = await runFormatterOnDir(['--output=none', '--show=all']);
-        expect(
-          await process.stdout.next,
-          'Changed ${p.join('code', 'a.dart')}',
+        await expectLater(
+          process.stdout,
+          emitsInOrder([
+            'Changed ${p.join('code', 'a.dart')}',
+            'Unchanged ${p.join('code', 'b.dart')}',
+          ]),
         );
-        expect(
-          await process.stdout.next,
-          'Unchanged ${p.join('code', 'b.dart')}',
-        );
-        expect(
-          await process.stdout.next,
-          startsWith(r'Formatted 2 files (1 changed)'),
+        await expectLater(
+          process.stdout,
+          emits(startsWith('Formatted 2 files (1 changed)')),
         );
         await process.shouldExit(0);
 
@@ -225,13 +221,13 @@ void main() {
           '--output=none',
           '--show=changed',
         ]);
-        expect(
-          await process.stdout.next,
-          'Changed ${p.join('code', 'a.dart')}',
+        await expectLater(
+          process.stdout,
+          emits('Changed ${p.join('code', 'a.dart')}'),
         );
-        expect(
-          await process.stdout.next,
-          startsWith(r'Formatted 2 files (1 changed)'),
+        await expectLater(
+          process.stdout,
+          emits(startsWith('Formatted 2 files (1 changed)')),
         );
         await process.shouldExit(0);
 
@@ -249,13 +245,13 @@ void main() {
       ]).create();
 
       var process = await runFormatterOnDir(['--summary=line']);
-      expect(
-        await process.stdout.next,
-        'Formatted ${p.join('code', 'a.dart')}',
+      await expectLater(
+        process.stdout,
+        emits('Formatted ${p.join('code', 'a.dart')}'),
       );
-      expect(
-        await process.stdout.next,
-        matches(r'Formatted 2 files \(1 changed\) in \d+\.\d+ seconds.'),
+      await expectLater(
+        process.stdout,
+        emits(matches(r'Formatted 2 files \(1 changed\) in \d+\.\d+ seconds.')),
       );
       await process.shouldExit(0);
     });

--- a/test/cli/page_width_test.dart
+++ b/test/cli/page_width_test.dart
@@ -50,7 +50,7 @@ void main() {
     });
   });
 
-  test('no options search if page width is specified on the CLI', () async {
+  test('ignore options file if page width specified on the CLI', () async {
     await d.dir('foo', [
       analysisOptionsFile(pageWidth: 20),
       d.file('main.dart', _unformatted),
@@ -157,7 +157,7 @@ void main() {
       await process.shouldExit(0);
     });
 
-    test('no options search if page width is specified', () async {
+    test('ignore options file if page width is specified', () async {
       await d.dir('foo', [
         analysisOptionsFile(pageWidth: 20),
         d.file('main.dart', _unformatted),

--- a/test/cli/page_width_test.dart
+++ b/test/cli/page_width_test.dart
@@ -151,9 +151,10 @@ void main() {
       await process.stdin.close();
 
       // Formats at page width 30.
-      expect(await process.stdout.next, 'var x =');
-      expect(await process.stdout.next, '    operand +');
-      expect(await process.stdout.next, '    another * andAnother;');
+      await expectLater(
+        process.stdout,
+        emitsInOrder(['var x =', '    operand +', '    another * andAnother;']),
+      );
       await process.shouldExit(0);
     });
 
@@ -172,9 +173,10 @@ void main() {
       await process.stdin.close();
 
       // Formats at page width 30, not 20.
-      expect(await process.stdout.next, 'var x =');
-      expect(await process.stdout.next, '    operand +');
-      expect(await process.stdout.next, '    another * andAnother;');
+      await expectLater(
+        process.stdout,
+        emitsInOrder(['var x =', '    operand +', '    another * andAnother;']),
+      );
       await process.shouldExit(0);
     });
   });

--- a/test/cli/stdin_test.dart
+++ b/test/cli/stdin_test.dart
@@ -29,7 +29,7 @@ void main() {
       await process.stdin.close();
 
       // No trailing newline at the end.
-      expect(await process.stdout.next, formattedOutput);
+      await expectLater(process.stdout, emits(formattedOutput));
       await process.shouldExit(0);
     });
   });

--- a/test/cli/trailing_commas_test.dart
+++ b/test/cli/trailing_commas_test.dart
@@ -98,9 +98,10 @@ void main() {
       await process.stdin.close();
 
       // Preserves trailing commas.
-      expect(await process.stdout.next, 'var x = function(');
-      expect(await process.stdout.next, '  argument,');
-      expect(await process.stdout.next, ');');
+      await expectLater(
+        process.stdout,
+        emitsInOrder(['var x = function(', '  argument,', ');']),
+      );
       await process.shouldExit(0);
     });
 
@@ -119,9 +120,10 @@ void main() {
       await process.stdin.close();
 
       // Preserves trailing commas.
-      expect(await process.stdout.next, 'var x = function(');
-      expect(await process.stdout.next, '  argument,');
-      expect(await process.stdout.next, ');');
+      await expectLater(
+        process.stdout,
+        emitsInOrder(['var x = function(', '  argument,', ');']),
+      );
       await process.shouldExit(0);
     });
   });

--- a/test/cli/trailing_commas_test.dart
+++ b/test/cli/trailing_commas_test.dart
@@ -1,0 +1,160 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:dart_style/src/dart_formatter.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import '../utils.dart';
+
+void main() {
+  compileFormatter();
+
+  group('--trailing-commas', () {
+    test('preserves commas if "preserve"', () async {
+      await d.dir('foo', [d.file('main.dart', _unformatted)]).create();
+
+      var process = await runFormatterOnDir(['--trailing-commas=preserve']);
+      await process.shouldExit(0);
+
+      await d.dir('foo', [d.file('main.dart', _formattedPreserve)]).validate();
+    });
+
+    test('automates commas if "automate"', () async {
+      await d.dir('foo', [d.file('main.dart', _unformatted)]).create();
+
+      var process = await runFormatterOnDir(['--trailing-commas=automate']);
+      await process.shouldExit(0);
+
+      await d.dir('foo', [d.file('main.dart', _formattedAutomate)]).validate();
+    });
+
+    test('error if any other value', () async {
+      var process = await runFormatter(['--trailing-commas=wombat']);
+      await process.shouldExit(64);
+    });
+  });
+
+  test('ignore options file if trailing commas specified on the CLI', () async {
+    await d.dir('foo', [
+      analysisOptionsFile(trailingCommas: TrailingCommas.preserve),
+      d.file('main.dart', _unformatted),
+    ]).create();
+
+    var process = await runFormatterOnDir(['--trailing-commas=automate']);
+    await process.shouldExit(0);
+
+    await d.dir('foo', [d.file('main.dart', _formattedAutomate)]).validate();
+  });
+
+  test('use mode from surrounding options', () async {
+    await _testWithOptions({
+      'formatter': {'trailing_commas': 'preserve'},
+    }, preserve: true);
+  });
+
+  test('use default mode on invalid analysis options', () async {
+    await _testWithOptions({'unrelated': 'stuff'}, preserve: false);
+    await _testWithOptions({'formatter': 'not a map'}, preserve: false);
+    await _testWithOptions({
+      'formatter': {'no': 'trailing_commas'},
+    }, preserve: false);
+    await _testWithOptions({
+      'formatter': {'trailing_commas': 'wombat'},
+    }, preserve: false);
+  });
+
+  test('get mode from included options file', () async {
+    await d.dir('foo', [
+      analysisOptionsFile(include: 'other.yaml'),
+      analysisOptionsFile(name: 'other.yaml', include: 'sub/third.yaml'),
+      d.dir('sub', [
+        analysisOptionsFile(
+          name: 'third.yaml',
+          trailingCommas: TrailingCommas.preserve,
+        ),
+      ]),
+      d.file('main.dart', _unformatted),
+    ]).create();
+
+    var process = await runFormatterOnDir();
+    await process.shouldExit(0);
+
+    // Should preserve trailing commas.
+    await d.dir('foo', [d.file('main.dart', _formattedPreserve)]).validate();
+  });
+
+  group('stdin', () {
+    test('use mode from surrounding package', () async {
+      await d.dir('foo', [
+        analysisOptionsFile(trailingCommas: TrailingCommas.preserve),
+      ]).create();
+
+      var process = await runFormatter(['--stdin-name=foo/main.dart']);
+      process.stdin.writeln(_unformatted);
+      await process.stdin.close();
+
+      // Preserves trailing commas.
+      expect(await process.stdout.next, 'var x = function(');
+      expect(await process.stdout.next, '  argument,');
+      expect(await process.stdout.next, ');');
+      await process.shouldExit(0);
+    });
+
+    test('ignore options file if mode is specified', () async {
+      await d.dir('foo', [
+        analysisOptionsFile(trailingCommas: TrailingCommas.preserve),
+        d.file('main.dart', _unformatted),
+      ]).create();
+
+      var process = await runFormatter([
+        '--trailing-commas=preserve',
+        '--stdin-name=foo/main.dart',
+      ]);
+
+      process.stdin.writeln(_unformatted);
+      await process.stdin.close();
+
+      // Preserves trailing commas.
+      expect(await process.stdout.next, 'var x = function(');
+      expect(await process.stdout.next, '  argument,');
+      expect(await process.stdout.next, ');');
+      await process.shouldExit(0);
+    });
+  });
+}
+
+const _unformatted = '''
+var x = function(argument,);
+''';
+
+const _formattedPreserve = '''
+var x = function(
+  argument,
+);
+''';
+
+const _formattedAutomate = '''
+var x = function(argument);
+''';
+
+/// Test that formatting a file with surrounding analysis_options.yaml
+/// containing [options] formats the input with trailing commas preserved if
+/// [preserve] is `true`.
+Future<void> _testWithOptions(Object? options, {required bool preserve}) async {
+  var expected = preserve ? _formattedPreserve : _formattedAutomate;
+
+  await d.dir('foo', [
+    d.FileDescriptor('analysis_options.yaml', jsonEncode(options)),
+    d.file('main.dart', _unformatted),
+  ]).create();
+
+  var process = await runFormatterOnDir();
+  await process.shouldExit(0);
+
+  // Should format the file with the expected mode.
+  await d.dir('foo', [d.file('main.dart', expected)]).validate();
+}

--- a/test/config_cache_test.dart
+++ b/test/config_cache_test.dart
@@ -16,9 +16,9 @@ import 'utils.dart';
 void main() {
   group('findLanguageVersion()', () {
     test('no surrounding package config', () async {
-      // Note: In theory this test could fail if machine it's run on happens to
-      // have a `.dart_tool` directory containing a package config in one of the
-      // parent directories of the system temporary directory.
+      // Note: In theory this test could fail if the machine it runs on happens
+      // to have a `.dart_tool` directory containing a package config in one of
+      // the parent directories of the system temporary directory.
 
       await d.dir('dir', [d.file('main.dart', 'f() {}')]).create();
 

--- a/test/config_cache_test.dart
+++ b/test/config_cache_test.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_style/src/config_cache.dart';
+import 'package:dart_style/src/dart_formatter.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
@@ -168,7 +169,7 @@ void main() {
       await _expectWidth(width: null);
     });
 
-    test('null page width if no "page_width" not an int', () async {
+    test('null page width if "page_width" not an int', () async {
       await d.dir('dir', [
         d.FileDescriptor(
           'analysis_options.yaml',
@@ -244,7 +245,7 @@ void main() {
       //
       // The answer we want is 40. A file is being formatted in the context of
       // some package and we want that package's own transitive dependency solve
-      // to be used for analysis options, look up, not the dependency solves of
+      // to be used for analysis options look up, not the dependency solves of
       // those dependencies.
       await d.dir('dir', [
         d.dir('foo', [
@@ -307,6 +308,88 @@ void main() {
       );
     });
   });
+
+  group('findTrailingCommas()', () {
+    test('null if no surrounding options', () async {
+      await d.dir('dir', [d.file('main.dart', 'main() {}')]).create();
+
+      var cache = ConfigCache();
+      expect(
+        await cache.findTrailingCommas(_expectedFile('dir/main.dart')),
+        isNull,
+      );
+    });
+
+    test('automate trailing commas if option is "automate"', () async {
+      await d.dir('dir', [
+        analysisOptionsFile(trailingCommas: TrailingCommas.automate),
+        d.file('main.dart', 'main() {}'),
+      ]).create();
+
+      await _expectTrailingCommas(TrailingCommas.automate);
+    });
+
+    test('preserve trailing commas if option is "preserve"', () async {
+      await d.dir('dir', [
+        analysisOptionsFile(trailingCommas: TrailingCommas.preserve),
+        d.file('main.dart', 'main() {}'),
+      ]).create();
+
+      await _expectTrailingCommas(TrailingCommas.preserve);
+    });
+
+    test('null if no "formatter" key in options', () async {
+      await d.dir('dir', [
+        d.FileDescriptor(
+          'analysis_options.yaml',
+          jsonEncode({'unrelated': 'stuff'}),
+        ),
+        d.file('main.dart', 'main() {}'),
+      ]).create();
+
+      await _expectTrailingCommas(null);
+    });
+
+    test('null if "formatter" is not a map', () async {
+      await d.dir('dir', [
+        d.FileDescriptor(
+          'analysis_options.yaml',
+          jsonEncode({'formatter': 'not a map'}),
+        ),
+        d.file('main.dart', 'main() {}'),
+      ]).create();
+
+      await _expectTrailingCommas(null);
+    });
+
+    test('null if no "trailing_commas" key in formatter', () async {
+      await d.dir('dir', [
+        d.FileDescriptor(
+          'analysis_options.yaml',
+          jsonEncode({
+            'formatter': {'no': 'trailing_commas'},
+          }),
+        ),
+        d.file('main.dart', 'main() {}'),
+      ]).create();
+
+      await _expectTrailingCommas(null);
+    });
+
+    test('null if "trailing_commas" not a string', () async {
+      await d.dir('dir', [
+        d.FileDescriptor(
+          'analysis_options.yaml',
+          jsonEncode({
+            'formatter': {'trailing_commas': 123},
+          }),
+        ),
+        d.file('main.dart', 'main() {}'),
+      ]).create();
+
+      await _expectTrailingCommas(null);
+    });
+  });
 }
 
 Future<void> _expectVersion(
@@ -333,6 +416,16 @@ Future<void> _expectWidth({
 }) async {
   var cache = ConfigCache();
   expect(await cache.findPageWidth(_expectedFile(file)), width);
+}
+
+/// Test that a [file] with some some surrounding "analysis_options.yaml" is
+/// interpreted as having the given [trailingCommas] setting.
+Future<void> _expectTrailingCommas(
+  TrailingCommas? trailingCommas, {
+  String file = 'dir/main.dart',
+}) async {
+  var cache = ConfigCache();
+  expect(await cache.findTrailingCommas(_expectedFile(file)), trailingCommas);
 }
 
 /// Normalize path separators to the host OS separator since that's what the

--- a/test/tall/expression/collection_null_aware.stmt
+++ b/test/tall/expression/collection_null_aware.stmt
@@ -1,25 +1,26 @@
 40 columns                              |
->>> (experiment null-aware-elements) List element.
+(experiment null-aware-elements)
+>>> List element.
 var list = [  ?  x  ];
 <<<
 var list = [?x];
->>> (experiment null-aware-elements) Set element.
+>>> Set element.
 var set = {  ?  x  };
 <<<
 var set = {?x};
->>> (experiment null-aware-elements) Map key.
+>>> Map key.
 var map = {  ?  key  : value};
 <<<
 var map = {?key: value};
->>> (experiment null-aware-elements) Map value.
+>>> Map value.
 var map = { key:  ?  value  };
 <<<
 var map = {key: ?value};
->>> (experiment null-aware-elements) Both key and value.
+>>> Both key and value.
 var map = {  ?  key  :  ?  value  };
 <<<
 var map = {?key: ?value};
->>> (experiment null-aware-elements) Split inside element.
+>>> Split inside element.
 var list = [?(veryLongExpression +thatIsForcedToSplit)];
 <<<
 var list = [

--- a/test/tall/expression/collection_null_aware_comment.stmt
+++ b/test/tall/expression/collection_null_aware_comment.stmt
@@ -1,15 +1,16 @@
 40 columns                              |
->>> (experiment null-aware-elements) Inline comment after `?`.
+(experiment null-aware-elements)
+>>> Inline comment after `?`.
 var list = [  ?  /* c */  x  ];
 <<<
 var list = [? /* c */ x];
->>> (experiment null-aware-elements)
+>>>
 var map = {  ?  /* c */  key  :  ?  /* c */  value  };
 <<<
 var map = {
   ? /* c */ key: ? /* c */ value,
 };
->>> (experiment null-aware-elements) Line comment after `?`.
+>>> Line comment after `?`.
 var list = [  ?  // c
 x  ];
 <<<
@@ -19,7 +20,7 @@ var list = [
   ? // c
   x,
 ];
->>> (experiment null-aware-elements)
+>>>
 var map = {  ?  // c
 key  :  ?  // c
 value  };

--- a/test/tall/preserve_trailing_commas/collection_for.stmt
+++ b/test/tall/preserve_trailing_commas/collection_for.stmt
@@ -1,0 +1,30 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Trailing comma in increments forces them to split.
+list = [
+  for (x = 1;true;x += 1, x += 2,) e
+];
+<<<
+list = [
+  for (
+    x = 1;
+    true;
+    x += 1,
+    x += 2,
+  )
+    e,
+];
+>>> Don't add trailing comma if updaters split.
+list = [
+for (x = 1;true;variable += longValue, another += value) e
+];
+<<<
+list = [
+  for (
+    x = 1;
+    true;
+    variable += longValue,
+    another += value
+  )
+    e,
+];

--- a/test/tall/preserve_trailing_commas/constructor.unit
+++ b/test/tall/preserve_trailing_commas/constructor.unit
@@ -1,0 +1,80 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Parameter list splits with trailing comma.
+class A {
+  A(int x,);
+}
+<<<
+class A {
+  A(
+    int x,
+  );
+}
+>>> Doesn't force split parameter list without trailing comma.
+class A {
+  A(int x, int y);
+}
+<<<
+class A {
+  A(int x, int y);
+}
+>>> May still split without trailing comma if doesn't fit.
+class A {
+  A(int parameter1, int parameter2, int parameter3);
+}
+<<<
+class A {
+  A(
+    int parameter1,
+    int parameter2,
+    int parameter3,
+  );
+}
+>>> Parameter list splits with trailing comma after optional parameter.
+class A {
+  A(int x, [int y,]);
+}
+<<<
+class A {
+  A(
+    int x, [
+    int y,
+  ]);
+}
+>>> Parameter list splits with trailing comma after named parameter.
+class A {
+  A(int x, {int y,});
+}
+<<<
+class A {
+  A(
+    int x, {
+    int y,
+  });
+}
+>>> Redirecting constructor argument list splits with trailing comma.
+class A {
+  A(int x) : this.named(x,);
+  A.named(int x) : this(x,);
+}
+<<<
+class A {
+  A(int x)
+    : this.named(
+        x,
+      );
+  A.named(int x)
+    : this(
+        x,
+      );
+}
+>>> Doesn't force split redirecting constructor argument list without trailing comma.
+class A {
+  A(int x) : this.named(x);
+  A.named(int x) : this(x);
+}
+<<<
+class A {
+  A(int x) : this.named(x);
+  A.named(int x) : this(x);
+}

--- a/test/tall/preserve_trailing_commas/enum.unit
+++ b/test/tall/preserve_trailing_commas/enum.unit
@@ -1,0 +1,52 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma.
+enum E {e,}
+<<<
+enum E {
+  e,
+}
+>>> Doesn't force split without trailing comma.
+enum E {e,f,g}
+<<<
+enum E { e, f, g }
+>>> May still split without trailing comma if doesn't fit.
+enum E { value1, value2, value3, value4 }
+<<<
+enum E {
+  value1,
+  value2,
+  value3,
+  value4,
+}
+>>> Preserve trailing comma but remove semicolon if no members.
+enum E {e,;}
+<<<
+enum E {
+  e,
+}
+>>> Remove trailing comma and split if there are members.
+enum E { a, b, c,; int x; }
+<<<
+enum E {
+  a,
+  b,
+  c;
+
+  int x;
+}
+>>> Force split in enum value argument list with trailing comma.
+enum Args {
+value(a,b,),
+another(named:1,)
+}
+<<<
+enum Args {
+  value(
+    a,
+    b,
+  ),
+  another(
+    named: 1,
+  ),
+}

--- a/test/tall/preserve_trailing_commas/for.stmt
+++ b/test/tall/preserve_trailing_commas/for.stmt
@@ -1,0 +1,24 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Trailing comma in increments forces them to split.
+for (x = 1;true;x += 1, x += 2,) {stmt;}
+<<<
+for (
+  x = 1;
+  true;
+  x += 1,
+  x += 2,
+) {
+  stmt;
+}
+>>> Don't add trailing comma if updaters split.
+for (x = 1;true;variable += longValue, another += value) {stmt;}
+<<<
+for (
+  x = 1;
+  true;
+  variable += longValue,
+  another += value
+) {
+  stmt;
+}

--- a/test/tall/preserve_trailing_commas/function_call.stmt
+++ b/test/tall/preserve_trailing_commas/function_call.stmt
@@ -1,0 +1,26 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma.
+function(1,);
+<<<
+function(
+  1,
+);
+>>> Doesn't force split without trailing comma.
+function(1,2,3);
+<<<
+function(1, 2, 3);
+>>> May still split without trailing comma if doesn't fit.
+function(argument1, argument2, argument3);
+<<<
+function(
+  argument1,
+  argument2,
+  argument3,
+);
+>>> With named argument.
+function(name: 1,);
+<<<
+function(
+  name: 1,
+);

--- a/test/tall/preserve_trailing_commas/list_literal.stmt
+++ b/test/tall/preserve_trailing_commas/list_literal.stmt
@@ -1,0 +1,21 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma.
+[1,];
+<<<
+[
+  1,
+];
+>>> Doesn't force split without trailing comma.
+[1,2,3];
+<<<
+[1, 2, 3];
+>>> May still split without trailing comma if doesn't fit.
+[element1, element2, element3, element4];
+<<<
+[
+  element1,
+  element2,
+  element3,
+  element4,
+];

--- a/test/tall/preserve_trailing_commas/list_pattern.stmt
+++ b/test/tall/preserve_trailing_commas/list_pattern.stmt
@@ -1,0 +1,21 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma.
+var [x,] = list;
+<<<
+var [
+  x,
+] = list;
+>>> Doesn't force split without trailing comma.
+var [x,y,z] = list;
+<<<
+var [x, y, z] = list;
+>>> May still split without trailing comma if doesn't fit.
+var [element1, element2, element3, element4] = list;
+<<<
+var [
+  element1,
+  element2,
+  element3,
+  element4,
+] = list;

--- a/test/tall/preserve_trailing_commas/map_literal.stmt
+++ b/test/tall/preserve_trailing_commas/map_literal.stmt
@@ -1,0 +1,21 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma.
+map = {a:1,};
+<<<
+map = {
+  a: 1,
+};
+>>> Doesn't force split without trailing comma.
+map = {a:1,b:2,c:3};
+<<<
+map = {a: 1, b: 2, c: 3};
+>>> May still split without trailing comma if doesn't fit.
+map = {a: value1, b: value2, c: value3, d: value4};
+<<<
+map = {
+  a: value1,
+  b: value2,
+  c: value3,
+  d: value4,
+};

--- a/test/tall/preserve_trailing_commas/map_pattern.stmt
+++ b/test/tall/preserve_trailing_commas/map_pattern.stmt
@@ -1,0 +1,20 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma.
+var {a: x,} = map;
+<<<
+var {
+  a: x,
+} = map;
+>>> Doesn't force split without trailing comma.
+var {a:x,b:y,c:z} = map;
+<<<
+var {a: x, b: y, c: z} = map;
+>>> May still split without trailing comma if doesn't fit.
+var {a: element1, b: element2, c: element3} = map;
+<<<
+var {
+  a: element1,
+  b: element2,
+  c: element3,
+} = map;

--- a/test/tall/preserve_trailing_commas/member.unit
+++ b/test/tall/preserve_trailing_commas/member.unit
@@ -1,0 +1,38 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces parameter list to split with trailing comma.
+class Foo {
+  method(int x,) {}
+  static staticMethod(int x,) {}
+  set setter(int x,) {}
+  operator +(int x,) {}
+}
+<<<
+class Foo {
+  method(
+    int x,
+  ) {}
+  static staticMethod(
+    int x,
+  ) {}
+  set setter(
+    int x,
+  ) {}
+  operator +(
+    int x,
+  ) {}
+}
+>>> Doesn't force split without trailing comma.
+class Foo {
+  method(int x) {}
+  static staticMethod(int x) {}
+  set setter(int x) {}
+  operator +(int x) {}
+}
+<<<
+class Foo {
+  method(int x) {}
+  static staticMethod(int x) {}
+  set setter(int x) {}
+  operator +(int x) {}
+}

--- a/test/tall/preserve_trailing_commas/metadata.unit
+++ b/test/tall/preserve_trailing_commas/metadata.unit
@@ -1,0 +1,27 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma.
+@meta(1,)
+class A {}
+<<<
+@meta(
+  1,
+)
+class A {}
+>>> Doesn't force split without trailing comma.
+@meta(1)
+class A {}
+<<<
+@meta(1)
+class A {}
+>>> May still split without trailing comma if doesn't fit.
+@meta(argument1, argument2, argument3, argument4)
+class A {}
+<<<
+@meta(
+  argument1,
+  argument2,
+  argument3,
+  argument4,
+)
+class A {}

--- a/test/tall/preserve_trailing_commas/object_pattern.stmt
+++ b/test/tall/preserve_trailing_commas/object_pattern.stmt
@@ -1,0 +1,20 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma.
+var C(a:x,) = obj;
+<<<
+var C(
+  a: x,
+) = obj;
+>>> Doesn't force split without trailing comma.
+var C(a:x,b:y,c:z) = obj;
+<<<
+var C(a: x, b: y, c: z) = obj;
+>>> May still split without trailing comma if doesn't fit.
+var C(a: element1, b: element2, c: element3) = obj;
+<<<
+var C(
+  a: element1,
+  b: element2,
+  c: element3,
+) = obj;

--- a/test/tall/preserve_trailing_commas/parameter.unit
+++ b/test/tall/preserve_trailing_commas/parameter.unit
@@ -1,0 +1,49 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Parameter list splits with trailing comma.
+function(int x,) {}
+<<<
+function(
+  int x,
+) {}
+>>> Doesn't force split parameter list without trailing comma.
+function(int x,int y) {}
+<<<
+function(int x, int y) {}
+>>> May still split without trailing comma if doesn't fit.
+function(int parameter1, int parameter2, int parameter3) {}
+<<<
+function(
+  int parameter1,
+  int parameter2,
+  int parameter3,
+) {}
+>>> Parameter list splits with trailing comma after optional parameter.
+function(int x, [int y,]) {}
+<<<
+function(
+  int x, [
+  int y,
+]) {}
+>>> Parameter list splits with trailing comma after named parameter.
+function(int x, {int y,}) {}
+<<<
+function(
+  int x, {
+  int y,
+}) {}
+>>> Trailing comma in function expression parameter list forces split.
+var f = (int i,) {};
+<<<
+var f =
+    (
+      int i,
+    ) {};
+>>> Trailing comma in old style function typed parameter list forces split.
+bool doStuff(void f(int i,)) {}
+<<<
+bool doStuff(
+  void f(
+    int i,
+  ),
+) {}

--- a/test/tall/preserve_trailing_commas/record_literal.stmt
+++ b/test/tall/preserve_trailing_commas/record_literal.stmt
@@ -1,0 +1,32 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with multiple fields and trailing comma.
+(1,2,);
+<<<
+(
+  1,
+  2,
+);
+>>> Forces split with one named field and trailing comma.
+(name: 1,);
+<<<
+(
+  name: 1,
+);
+>>> Doesn't force split with one positional field.
+(1,);
+<<<
+(1,);
+>>> Doesn't force split without trailing comma.
+(1,2,3);
+<<<
+(1, 2, 3);
+>>> May still split without trailing comma if doesn't fit.
+(element1, element2, element3, element4);
+<<<
+(
+  element1,
+  element2,
+  element3,
+  element4,
+);

--- a/test/tall/preserve_trailing_commas/record_pattern.stmt
+++ b/test/tall/preserve_trailing_commas/record_pattern.stmt
@@ -1,0 +1,32 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma and multiple positional fields.
+var (x,y,) = rec;
+<<<
+var (
+  x,
+  y,
+) = rec;
+>>> Forces split with trailing comma and named field.
+var (a:x,) = rec;
+<<<
+var (
+  a: x,
+) = rec;
+>>> Doesn't force split with single positional field.
+var (x,) = rec;
+<<<
+var (x,) = rec;
+>>> Doesn't force split without trailing comma.
+var (x,y,z) = rec;
+<<<
+var (x, y, z) = rec;
+>>> May still split without trailing comma if doesn't fit.
+var (element1, element2, element3, element4) = rec;
+<<<
+var (
+  element1,
+  element2,
+  element3,
+  element4,
+) = rec;

--- a/test/tall/preserve_trailing_commas/set_literal.stmt
+++ b/test/tall/preserve_trailing_commas/set_literal.stmt
@@ -1,0 +1,21 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma.
+set = {1,};
+<<<
+set = {
+  1,
+};
+>>> Doesn't force split without trailing comma.
+set = {1,2,3};
+<<<
+set = {1, 2, 3};
+>>> May still split without trailing comma if doesn't fit.
+set = {element1, element2, element3, element4};
+<<<
+set = {
+  element1,
+  element2,
+  element3,
+  element4,
+};

--- a/test/tall/preserve_trailing_commas/super_call.stmt
+++ b/test/tall/preserve_trailing_commas/super_call.stmt
@@ -1,0 +1,27 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma.
+super(1,);
+<<<
+super(
+  1,
+);
+>>> Doesn't force split without trailing comma.
+super(1,2,3);
+<<<
+super(1, 2, 3);
+>>> May still split without trailing comma if doesn't fit.
+super(argument1, argument2, argument3, argument4);
+<<<
+super(
+  argument1,
+  argument2,
+  argument3,
+  argument4,
+);
+>>> Named super call.
+super.named(1,);
+<<<
+super.named(
+  1,
+);

--- a/test/tall/preserve_trailing_commas/switch_expression.stmt
+++ b/test/tall/preserve_trailing_commas/switch_expression.stmt
@@ -1,0 +1,11 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Forces split with trailing comma.
+### Note that switch expressions always split even when preserve trailing commas
+### is off, so this test is redundant, but ensures that the option doesn't
+### change how switch expressions behave.
+e = switch(y){0=>a,};
+<<<
+e = switch (y) {
+  0 => a,
+};

--- a/test/tall/preserve_trailing_commas/typedef.unit
+++ b/test/tall/preserve_trailing_commas/typedef.unit
@@ -1,0 +1,21 @@
+40 columns                              |
+(trailing_commas preserve)
+### Old generic typedef syntax.
+>>> Forces split with trailing comma.
+typedef Foo(int x,);
+<<<
+typedef Foo(
+  int x,
+);
+>>> Doesn't force split without trailing comma.
+typedef Foo(int x);
+<<<
+typedef Foo(int x);
+>>> May still split without trailing comma if doesn't fit.
+typedef Foo(parameter1, parameter2, parameter3);
+<<<
+typedef Foo(
+  parameter1,
+  parameter2,
+  parameter3,
+);

--- a/test/tall_format_test.dart
+++ b/test/tall_format_test.dart
@@ -16,6 +16,7 @@ void main() async {
   await testDirectory('tall/invocation');
   await testDirectory('tall/other');
   await testDirectory('tall/pattern');
+  await testDirectory('tall/preserve_trailing_commas');
   await testDirectory('tall/statement');
   await testDirectory('tall/top_level');
   await testDirectory('tall/type');

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -136,12 +136,7 @@ void _testFile(TestFile testFile) {
   group(testFile.path, () {
     for (var formatTest in testFile.tests) {
       test(formatTest.label, () {
-        var formatter = DartFormatter(
-          languageVersion: formatTest.languageVersion,
-          pageWidth: testFile.pageWidth,
-          indent: formatTest.leadingIndent,
-          experimentFlags: formatTest.experimentFlags,
-        );
+        var formatter = testFile.formatterForTest(formatTest);
 
         var actual = _validateFormat(
           formatter,
@@ -235,11 +230,14 @@ d.DirectoryDescriptor packageConfig(
 /// Creates the YAML string contents of an analysis options file.
 ///
 /// If [pageWidth] is given, then the result has a "formatter" section to
-/// specify the page width. If [include] is given, then adds an "include" key
-/// to include another analysis options file. If [other] is given, then those
-/// are added as other top-level keys in the YAML.
+/// specify the page width. If [trailingCommas] is given, then the result has a
+/// "formatter" section specifying the trailing commas mode. If [include] is
+/// given, then adds an "include" key to include another analysis options file.
+/// If [other] is given, then those are added as other top-level keys in the
+/// YAML.
 String analysisOptions({
   int? pageWidth,
+  TrailingCommas? trailingCommas,
   Object? /* String | List<String> */ include,
   Map<String, Object>? other,
 }) {
@@ -255,9 +253,15 @@ String analysisOptions({
       }
   }
 
-  if (pageWidth != null) {
+  if (pageWidth != null || trailingCommas != null) {
     yaml.writeln('formatter:');
-    yaml.writeln('  page_width: $pageWidth');
+    if (pageWidth != null) {
+      yaml.writeln('  page_width: $pageWidth');
+    }
+
+    if (trailingCommas != null) {
+      yaml.writeln('  trailing_commas: ${trailingCommas.name}');
+    }
   }
 
   if (other != null) {
@@ -275,8 +279,13 @@ String analysisOptions({
 d.FileDescriptor analysisOptionsFile({
   String name = 'analysis_options.yaml',
   int? pageWidth,
+  TrailingCommas? trailingCommas,
   String? include,
 }) {
-  var yaml = analysisOptions(pageWidth: pageWidth, include: include);
+  var yaml = analysisOptions(
+    pageWidth: pageWidth,
+    trailingCommas: trailingCommas,
+    include: include,
+  );
   return d.FileDescriptor(name, yaml.toString());
 }


### PR DESCRIPTION
In the old short formatter, when a delimited construct had a trailing comma, it had two effects:

1.  The construct would be formatted "Flutter style" where the closing bracket would be moved to the next line and the contents indented +2, as opposed to the earlier style where the bracket stays on the same line as the last element and the elements are indented +4).

2.  The construct is forced to split even if it otherwise wouldn't.

The new formatter always uses a Flutter-like style for commas-separated constructors, so trailing commas are no longer needed for point 1.

When it does split a construct, it always adds a trailing comma. This means that point 2 breaks reversibility. Because of that, and because many users don't want to decide for every construct whether it should split or not, the new tall formatter no longer does point 2. It will remove a trailing comma and collapse a construct if it decides to.

However, some users rely heavily on that feature and strongly prefer control over forcing argument lists and other constructs to split.

This PR restores that functionality with an opt-in configuration:

```
formatter:
  trailing_commas: preserve
```

When enabled, if a construct has a trailing comma, the formatter will always split it. Users that preferred that behavior from the old formatter can enable the option and continue to work that way.

This does not mean we are generally moving in the direction of a more configurable formatter. This was a behavior that the formatter already supported and we removed it to the detriment of some users' experience. We're restoring that existing behavior for those users who want it.

Fix #1652.
