### PR TITLE
Avoid splitting chains containing only properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 * Format null-aware elements.
 
+* Avoid splitting chains containing only properties.
+
+  ```dart
+  // Before:
+  variable = target
+      .property
+      .another;
+
+  // After:
+  variable =
+      target.property.another;
+  ```
+
+  Note that this only applies to `.` chains that are only properties. If there
+  are method calls in the chain, then it prefers to split the chain instead of
+  splitting at `=`, `:`, or `=>`.
+
 * Allow the target or property chain part of a split method chain on the RHS of
   `=`, `:`, and `=>` (#1466).
 

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -110,19 +110,33 @@ final class ChainPiece extends Piece {
 
   @override
   int stateCost(State state) {
-    // If the chain is a cascade, lower the cost so that we prefer splitting
-    // the cascades instead of the target. Prefers:
-    //
-    //     [element1, element2]
-    //       ..cascade();
-    //
-    // Over:
-    //
-    //     [
-    //       element1,
-    //       element2,
-    //     ]..cascade();
-    if (state == State.split) return _isCascade ? 0 : 1;
+    if (state == State.split) {
+      // If the chain is a cascade, lower the cost so that we prefer splitting
+      // the cascades instead of the target. Prefers:
+      //
+      //     [element1, element2]
+      //       ..cascade();
+      //
+      // Over:
+      //
+      //     [
+      //       element1,
+      //       element2,
+      //     ]..cascade();
+      if (_isCascade) return 0;
+
+      // If the chain is only properties, try to keep them together. Prefers:
+      //
+      //     variable =
+      //         target.property.another;
+      //
+      // Over:
+      //
+      //     variable = target
+      //         .property
+      //         .another;
+      if (_leadingProperties == _calls.length) return 2;
+    }
 
     return super.stateCost(state);
   }

--- a/test/tall/invocation/chain_property.stmt
+++ b/test/tall/invocation/chain_property.stmt
@@ -51,3 +51,21 @@ avian
     .feline
     .piscine
     .method();
+>>> Prefer splitting an assignment over splitting a pure property chain.
+variable = avian.bovine.canine.equine.feline;
+<<<
+variable =
+    avian.bovine.canine.equine.feline;
+>>> Don't prefer splitting an assignment if there are methods in the chain.
+variable = avian.bovine.canine.equine.feline();
+<<<
+variable = avian.bovine.canine.equine
+    .feline();
+>>> Don't prefer splitting an assignment if there are methods in the chain.
+variable = avian.bovine().canine.equine().feline;
+<<<
+variable = avian
+    .bovine()
+    .canine
+    .equine()
+    .feline;

--- a/test/tall/invocation/chain_property.stmt
+++ b/test/tall/invocation/chain_property.stmt
@@ -56,6 +56,15 @@ variable = avian.bovine.canine.equine.feline;
 <<<
 variable =
     avian.bovine.canine.equine.feline;
+>>> Split the property chain if moving it to the next line still doesn't fit.
+variable = avian.bovine.canine.equine.feline.galline;
+<<<
+variable = avian
+    .bovine
+    .canine
+    .equine
+    .feline
+    .galline;
 >>> Don't prefer splitting an assignment if there are methods in the chain.
 variable = avian.bovine.canine.equine.feline();
 <<<


### PR DESCRIPTION
I was trying out the new formatter on a corpus after #1687 and saw a bunch of diffs like:

```dart
// Before:
Widget(
  name:
      some.property.chain,
)

// After:
Widget(
  name: some
      .property
      .chain,
)
```

While the new headline style looks nice for most method call chains, it looks weird if it's only just a series of properties. In particular, a single `foo.bar` looks really silly when split.

This PR bumps the split cost of a chain up if it only contains properties. That leads the solver to prefer splitting the surrounding construct when possible.
