### PR TITLE
Eagerly split argument lists based on their contents.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,33 @@
   );
   ```
 
+* Eagerly split argument lists whose contents are complex enough to be easier
+  to read spread across multiple lines even if they would otherwise fit on a
+  single line (#1660). The rules are basically:
+
+  * If an argument list contains any named arguments and contains any other
+    calls whose argument lists contain any named arguments (directly or
+    indirectly), then split the outer one. We make an exception where a named
+    argument whose expression is a simple number, Boolean, or null literal
+    doesn't count as a named argument.
+
+  * If a list, set, or map literal is the immediate expression in a named
+    argument and one of the above kinds of argument lists (directly or
+    indirectly), then force the collection to split.
+
+  ```dart
+  // Before:
+  Stack(children: [result, Semantics(label: indexLabel)]);
+
+  // After:
+  Stack(
+    children: [
+      result,
+      Semantics(label: indexLabel),
+    ],
+  );
+  ```
+
 * Allow preserving trailing commas and forcing the surrounding construct to
   split even when it would otherwise fit on one line. This is off by default
   (because it breaks [reversibility][] among other reasons) but can be enabled

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -174,11 +174,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitArgumentList(ArgumentList node) {
-    writeArgumentList(
-      node.leftParenthesis,
-      node.arguments,
-      node.rightParenthesis,
-    );
+    writeArgumentList(node);
   }
 
   @override
@@ -199,7 +195,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
   @override
   void visitAssertInitializer(AssertInitializer node) {
     pieces.token(node.assertKeyword);
-    writeArgumentList(node.leftParenthesis, [
+    writeArguments(node.leftParenthesis, [
       node.condition,
       if (node.message case var message?) message,
     ], node.rightParenthesis);
@@ -208,7 +204,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
   @override
   void visitAssertStatement(AssertStatement node) {
     pieces.token(node.assertKeyword);
-    writeArgumentList(node.leftParenthesis, [
+    writeArguments(node.leftParenthesis, [
       node.condition,
       if (node.message case var message?) message,
     ], node.rightParenthesis);
@@ -1307,7 +1303,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
       node.leftBracket,
       node.elements,
       node.rightBracket,
-      splitOnNestedCollection: true,
+      splitEagerly: true,
       preserveNewlines: true,
     );
   }
@@ -1449,7 +1445,12 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitNamedExpression(NamedExpression node) {
-    writeAssignment(node.name.label, node.name.colon, node.expression);
+    writeAssignment(
+      node.name.label,
+      node.name.colon,
+      node.expression,
+      rightHandSideContext: NodeContext.namedExpression,
+    );
   }
 
   @override
@@ -1798,7 +1799,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
       node.leftBracket,
       node.elements,
       node.rightBracket,
-      splitOnNestedCollection: true,
+      splitEagerly: true,
       preserveNewlines: true,
     );
   }

--- a/lib/src/front_end/chain_builder.dart
+++ b/lib/src/front_end/chain_builder.dart
@@ -265,11 +265,7 @@ final class ChainBuilder {
           // Create the argument piece manually so that we can see if it has a
           // block argument or not.
           var arguments = _visitor.pieces.build(() {
-            _visitor.writeArgumentList(
-              expression.argumentList.leftParenthesis,
-              expression.argumentList.arguments,
-              expression.argumentList.rightParenthesis,
-            );
+            _visitor.writeArgumentList(expression.argumentList);
           });
 
           if (arguments is ListPiece && arguments.hasBlockElement) {

--- a/lib/src/front_end/expression_contents.dart
+++ b/lib/src/front_end/expression_contents.dart
@@ -51,19 +51,18 @@ class ExpressionContents {
   /// Begins tracking an argument list.
   void beginCall(List<AstNode> arguments) {
     var type = _Type.otherCall;
+    var hasNontrivialNamedArgument = false;
     for (var argument in arguments) {
       if (argument is NamedExpression) {
         type = _Type.callWithNamedArgument;
         if (!_isTrivial(argument.expression)) {
-          type = _Type.callWithNontrivialNamedArgument;
+          hasNontrivialNamedArgument = true;
           break;
         }
       }
     }
 
-    if (type == _Type.callWithNontrivialNamedArgument) {
-      _stack.last.nontrivialCalls++;
-    }
+    if (hasNontrivialNamedArgument) _stack.last.nontrivialCalls++;
 
     _stack.add(_Contents(type));
   }
@@ -84,8 +83,7 @@ class ExpressionContents {
     // will always be owned by the same call. There may be a named argument at
     // the very beginning of the line owned by the surrounding call which is
     // forced to split.
-    return (contents.type == _Type.callWithNamedArgument ||
-            contents.type == _Type.callWithNontrivialNamedArgument) &&
+    return (contents.type == _Type.callWithNamedArgument) &&
         contents.nontrivialCalls > 0;
   }
 
@@ -189,13 +187,6 @@ enum _Type {
   /// An argument list with at least one named argument and which may be subject
   /// to eager splitting.
   callWithNamedArgument,
-
-  /// An argument list with at least one named argument whose expression is
-  /// non-trivial.
-  ///
-  /// It may be subject to eager splitting and may also force surrounding calls
-  /// to split.
-  callWithNontrivialNamedArgument,
 
   /// An argument list with no named arguments that isn't subject to eager
   /// splitting.

--- a/lib/src/front_end/expression_contents.dart
+++ b/lib/src/front_end/expression_contents.dart
@@ -1,0 +1,203 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+
+/// Tracks the contents of a nested tree of argument lists and collection
+/// literals.
+///
+/// In general, the formatter tries to pack as much as it can on a single line
+/// until it hits the page width. However, with deeply nested call trees (which
+/// are pervasive in Flutter UI code), the expression nesting can get deep even
+/// in a short piece of code.
+///
+/// It can be much easier to track the nesting structure and identify siblings
+/// in the expression tree if it's forced to split more eagerly. Compare:
+///
+///     Apple(banana: [Cherry(date: Eggplant(1, 2))], fig: Grape(4))
+///
+///     Apple(
+///       banana: [
+///         Cherry(date: Eggplant(1, 2)),
+///       ],
+///       fig: Grape(4),
+///     )
+///
+/// This class records the necessary state to determine if a given collection
+/// literal or argument list is complex enough that it should be eagerly split.
+///
+/// It considers an operation A to contain another B if B occurs anywhere
+/// transitively inside the elements or argument list of A, regardless of any
+/// other AST nodes that may intercede. If we only looked at the immediate
+/// expressions in the collection or argument list to count nested calls and
+/// collections, then wrapping one of those expressions in, say, parentheses,
+/// could cause a nested operation to *not* be counted.
+///
+/// That would violate a reasonable principle that *adding* code to a call or
+/// collection should never cause it to go from splitting to not splitting. If a
+/// collection or call is complex enough to warrant splitting it eagerly, then
+/// adding more code in there should always lead to it still splitting.
+/// Tracking the contents transitively ensures that.
+///
+/// The heuristics for which collections and argument lists split are fairly
+/// simple and conservative and are documented below.
+class ExpressionContents {
+  /// The stack of calls and collections whose contents we are tracking and
+  /// that haven't completed yet.
+  final List<_Contents> _stack = [_Contents(_Type.otherCall)];
+
+  /// Begins tracking an argument list.
+  void beginCall(List<AstNode> arguments) {
+    var type = _Type.otherCall;
+    for (var argument in arguments) {
+      if (argument is NamedExpression) {
+        type = _Type.callWithNamedArgument;
+        if (!_isTrivial(argument.expression)) {
+          type = _Type.callWithNontrivialNamedArgument;
+          break;
+        }
+      }
+    }
+
+    if (type == _Type.callWithNontrivialNamedArgument) {
+      _stack.last.nontrivialCalls++;
+    }
+
+    _stack.add(_Contents(type));
+  }
+
+  /// Ends the most recently begun call and returns `true` if its argument list
+  /// should eagerly split.
+  bool endCall() {
+    var contents = _end();
+
+    // If this argument list has any named arguments and it contains another
+    // call with any non-trivial named arguments, then split it. The idea here
+    // is that when scanning a line of code, it's hard to tell which calls own
+    // which named arguments. If there are named arguments at different levels
+    // of nesting in an expression tree, it's better to split the outer one to
+    // make that clearer.
+    //
+    // With this rule, any two named arguments in the middle of the same line
+    // will always be owned by the same call. There may be a named argument at
+    // the very beginning of the line owned by the surrounding call which is
+    // forced to split.
+    return (contents.type == _Type.callWithNamedArgument ||
+            contents.type == _Type.callWithNontrivialNamedArgument) &&
+        contents.nontrivialCalls > 0;
+  }
+
+  /// Begin tracking a collection literal and its contents.
+  void beginCollection({required bool isNamed}) {
+    _stack.last.collections++;
+    _stack.add(_Contents(isNamed ? _Type.namedCollection : _Type.collection));
+  }
+
+  /// Ends the most recently begun collection literal and returns whether it
+  /// should eagerly split.
+  bool endCollection(List<AstNode> elements) {
+    var contents = _end();
+
+    // Split any collection that contains another non-empty collection.
+    if (contents.collections > 0) return true;
+
+    // If the collection is itself a named argument in a surrounding call that
+    // is going to be forced to eagerly split, then split the collection too.
+    // In this case, the collection is sort of like a vararg argument to the
+    // call. Prefers:
+    //
+    //     TabBar(
+    //       tabs: <Widget>[
+    //         Tab(text: 'Tab 1'),
+    //         Tab(text: 'Tab 2'),
+    //       ],
+    //     );
+    //
+    // Over:
+    //
+    //     TabBar(
+    //       tabs: <Widget>[Tab(text: 'Tab 1'), Tab(text: 'Tab 2')],
+    //     );
+    return contents.type == _Type.namedCollection &&
+        contents.nontrivialCalls > 0;
+  }
+
+  /// Ends the most recently begun operation and returns its contents.
+  _Contents _end() {
+    var contents = _stack.removeLast();
+
+    // Transitively include this operation's contents in the surrounding one.
+    var parent = _stack.last;
+    parent.collections += contents.collections;
+    parent.nontrivialCalls += contents.nontrivialCalls;
+
+    return contents;
+  }
+
+  /// Whether [expression] is "trivial".
+  ///
+  /// When deciding whether an argument list should be eagerly split, or should
+  /// force surrounding argument lists to eagerly split, we ignore any named
+  /// arguments whose expression is "trivial". This allows a little more code
+  /// to be packed onto a single line when the inner call is creating a simple
+  /// data structure with literal values, like:
+  ///
+  ///     MediaQueryData(padding: EdgeInsets.only(left: 40));
+  ///
+  /// Here, if we didn't treat `40` as a trivial expression and ignore it, then
+  /// the call to `MediaQueryData(...)` would be forced to split.
+  bool _isTrivial(Expression expression) {
+    return switch (expression) {
+      NullLiteral() => true,
+      BooleanLiteral() => true,
+      IntegerLiteral() => true,
+      DoubleLiteral() => true,
+      PrefixExpression(operator: Token(type: TokenType.MINUS), :var operand)
+          when _isTrivial(operand) =>
+        true,
+      _ => false,
+    };
+  }
+}
+
+/// The number of function calls and collection literals occurring transitively
+/// inside some other operation.
+class _Contents {
+  final _Type type;
+
+  /// The number of non-empty list, set, and map literals transitively inside
+  /// this operation.
+  int collections = 0;
+
+  /// The number of calls with non-trivial named arguments transitively inside
+  /// this operation.
+  int nontrivialCalls = 0;
+
+  _Contents(this.type);
+}
+
+enum _Type {
+  /// A non-empty list, map, or set literal.
+  collection,
+
+  /// A non-empty list, map, or set literal that is the immediate expression in
+  /// a named argument in a surrounding argument list.
+  namedCollection,
+
+  /// An argument list with at least one named argument and which may be subject
+  /// to eager splitting.
+  callWithNamedArgument,
+
+  /// An argument list with at least one named argument whose expression is
+  /// non-trivial.
+  ///
+  /// It may be subject to eager splitting and may also force surrounding calls
+  /// to split.
+  callWithNontrivialNamedArgument,
+
+  /// An argument list with no named arguments that isn't subject to eager
+  /// splitting.
+  otherCall,
+}

--- a/test/tall/invocation/nested.stmt
+++ b/test/tall/invocation/nested.stmt
@@ -1,0 +1,138 @@
+40 columns                              |
+### Test how argument lists split eagerly when they contain other calls.
+>>> Split outer call if both have named arguments.
+outer(name: inner(name: value));
+<<<
+outer(
+  name: inner(name: value),
+);
+>>> Split outer call on indirect inner call.
+outer(name: !(inner(name: value)));
+<<<
+outer(
+  name: !(inner(name: value)),
+);
+>>> Don't split if inner call has only positional arguments.
+a(b(c(d), e(f)), g(h), i(j));
+<<<
+a(b(c(d), e(f)), g(h), i(j));
+>>> Split outer `new` expression.
+new Outer(name: inner(name: value));
+<<<
+new Outer(
+  name: inner(name: value),
+);
+>>> Split outer `const` expression.
+const Outer(name: inner(name: value));
+<<<
+const Outer(
+  name: inner(name: value),
+);
+>>> Split on inner `new` expression.
+outer(name: new Inner(name: value));
+<<<
+outer(
+  name: new Inner(name: value),
+);
+>>> Split on inner `const` expression.
+outer(name: const Inner(name: value));
+<<<
+outer(
+  name: const Inner(name: value),
+);
+>>> Don't split outer call if inner named argument is trivial expression.
+{
+  outer(name: inner(name: 123));
+  outer(name: inner(name: -123));
+  outer(name: inner(name: 12.3));
+  outer(name: inner(name: -12.3));
+  outer(name: inner(name: null));
+  outer(name: inner(name: true));
+  outer(name: inner(name: false));
+}
+<<<
+{
+  outer(name: inner(name: 123));
+  outer(name: inner(name: -123));
+  outer(name: inner(name: 12.3));
+  outer(name: inner(name: -12.3));
+  outer(name: inner(name: null));
+  outer(name: inner(name: true));
+  outer(name: inner(name: false));
+}
+>>> Split on non-trivial expressions.
+### Edge cases of simple expressions that aren't considered trivial.
+{
+  outer(name: inner(name: 'string'));
+  outer(name: inner(name: (123)));
+  outer(name: inner(name: this));
+  outer(name: inner(name: -(1)));
+  outer(name: inner(name: 1+2));
+}
+<<<
+{
+  outer(
+    name: inner(name: 'string'),
+  );
+  outer(
+    name: inner(name: (123)),
+  );
+  outer(
+    name: inner(name: this),
+  );
+  outer(
+    name: inner(name: -(1)),
+  );
+  outer(
+    name: inner(name: 1 + 2),
+  );
+}
+>>> Split named argument collection if arguments split.
+{
+  f(name: [inner(name: value)]);
+  f(name: {inner(name: value)});
+  f(name: {k: inner(name: value)});
+  f(name: (r: inner(name: value)));
+  f(name: (inner(name: value),));
+  f(name: (inner(name: value), 2));
+}
+<<<
+{
+  f(
+    name: [
+      inner(name: value),
+    ],
+  );
+  f(
+    name: {
+      inner(name: value),
+    },
+  );
+  f(
+    name: {
+      k: inner(name: value),
+    },
+  );
+  f(
+    name: (r: inner(name: value)),
+  );
+  f(
+    name: (inner(name: value),),
+  );
+  f(
+    name: (inner(name: value), 2),
+  );
+}
+>>> Split when inner call isn't itself named argument.
+outer(inner(name: x), name: y);
+<<<
+outer(
+  inner(name: x),
+  name: y,
+);
+>>> Don't force split if the outer call can be block formatted.
+outer(() {;}, name: inner(name: x));
+<<<
+outer(() {
+  ;
+}, name: inner(name: x));

--- a/test/tall/regression/0300/0394.stmt
+++ b/test/tall/regression/0300/0394.stmt
@@ -35,6 +35,10 @@ return $.Div(
       ],
     ),
 
-    $.Footer(inner: [$.P(id: "notes", inner: "${seeds} seeds")]),
+    $.Footer(
+      inner: [
+        $.P(id: "notes", inner: "${seeds} seeds"),
+      ],
+    ),
   ],
 );

--- a/test/tall/regression/1500/1527.unit
+++ b/test/tall/regression/1500/1527.unit
@@ -74,7 +74,9 @@ main() {
 <<<
   main() {
     return Scaffold(
-      body: Center(child: AnimatedDigit(value: value % 10)),
+      body: Center(
+        child: AnimatedDigit(value: value % 10),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
           setState(() {


### PR DESCRIPTION
This is similar to the existing rule where nested non-empty collection literals force the outer one to split. The rules are basically:

* If an argument list contains any named arguments and contains any other calls whose argument lists contain any named arguments (directly or indirectly), then split the outer one. We make an exception where a named argument whose expression is a simple number, Boolean, or null literal doesn't count as a named argument.

* If a list, set, or map literal is the immediate expression in a named argument and one of the above kinds of argument lists (directly or indirectly), then force the collection to split.

```dart
// Before:
Stack(children: [result, Semantics(label: indexLabel)]);

// After:
Stack(
  children: [
    result,
    Semantics(label: indexLabel),
  ],
);
```

I've uploaded a diff of this change applied to a corpus here:

https://github.com/munificent/temp-eager-split-sample/commit/b864a67965c4db736e8a067985446134c5e4d9d5

Fix #1660.

@dart-lang/language-team Since this change is more "heuristic-y" than most formatter changes, I'd appreciate some wider feedback from the team. Take a look at the linked diff and let me know what you think.
