### PR TITLE
Fix bug with comments being reordered.

### DIFF
--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -398,6 +398,7 @@ final class PieceWriter {
     if (comments.isEmpty) return const [];
 
     var leadingComments = <Piece>[];
+    var afterHanging = false;
     for (var i = 0; i < comments.length; i++) {
       var comment = comments[i];
 
@@ -411,12 +412,16 @@ final class PieceWriter {
 
       var piece = commentPiece(comment, trailingWhitespace);
 
-      if (comments.isHanging(i)) {
+      if (!afterHanging && comments.isHanging(i)) {
         // Attach it to the previous CodePiece.
         _previousCode!.addHangingComment(piece);
       } else {
         // Add it to the list of leading comments for the upcoming token.
         leadingComments.add(piece);
+
+        // Once we've found a single non-hanging comment, all subsequent ones
+        // must also be non-hanging since they follow it.
+        afterHanging = true;
       }
     }
 

--- a/test/tall/regression/1600/1667.unit
+++ b/test/tall/regression/1600/1667.unit
@@ -1,0 +1,47 @@
+>>>
+/*Debugger:stepOver*/
+void main() {
+  /*bl*/ /*sl:1*/ var data = [1, 2, 3];
+  for (
+      // comment forcing formatting
+      /*sl:3*/ /*sl:5*/ /*sl:7*/ /*sl:8*/ var datapoint
+      // comment forcing formatting
+      in
+      // comment forcing formatting
+      /*sl:2*/ data
+      // comment forcing formatting
+      ) {
+    /*sl:4*/ /*sl:6*/ /*sl:8*/ print(datapoint);
+  }
+  /*sl:9 */ print('Done');
+}
+<<<
+/*Debugger:stepOver*/
+void main() {
+  /*bl*/ /*sl:1*/
+  var data = [1, 2, 3];
+  for (
+  // comment forcing formatting
+  /*sl:3*/ /*sl:5*/ /*sl:7*/ /*sl:8*/ var datapoint
+      // comment forcing formatting
+      in
+      // comment forcing formatting
+      /*sl:2*/ data
+  // comment forcing formatting
+  ) {
+    /*sl:4*/ /*sl:6*/ /*sl:8*/
+    print(datapoint);
+  }
+  /*sl:9 */
+  print('Done');
+}
+>>> Minimal repro.
+main() {
+  for (
+      /* 1 */ /* 2 */ datapoint in data) {}
+}
+<<<
+main() {
+  for (
+  /* 1 */ /* 2 */ datapoint in data) {}
+}


### PR DESCRIPTION
In certain locations, if you had multiple inline block comments on the same line, they would get reordered. That in turn would (correctly) trip the formatter's internal "whitespace-only changes" sanity check and lead to it aborting.

Fix #1667.
