### PR TITLE
Add issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/formatting-issue.md
+++ b/.github/ISSUE_TEMPLATE/formatting-issue.md
@@ -1,0 +1,36 @@
+---
+name: Formatting issue
+about: I don't like the output that the formatter produced.
+title: "[Formatting issue]"
+labels: ''
+assignees: ''
+
+---
+
+**What input code did you provide to the formatter?**
+
+```dart
+// Include the code *as text* and not a screenshot.
+// Make sure to include the entire surrounding statement
+// or declaration since that can affect formatting.
+<your original code>
+```
+
+**What output did the formatter produce?**
+
+```dart
+// Include the actual output here.
+<formatter output>
+```
+
+**What output did you expect or want the formatter to produce?**
+
+Describe how you expected the formatter to format the code, ideally by showing what you had in mind as code.
+
+```dart
+<what you hoped the formatter would output>
+```
+
+**Anything else we should know?**
+
+Thanks!

--- a/.github/ISSUE_TEMPLATE/other-request.md
+++ b/.github/ISSUE_TEMPLATE/other-request.md
@@ -1,0 +1,22 @@
+---
+name: Bug or feature request
+about: A bug, crash, feature request, or API change request
+title: "[Bug or feature request]"
+labels: ''
+assignees: ''
+
+---
+
+If the bug is about the formatter producing output you don't like, please use the "Formatting issue" template.
+
+**Describe the issue**
+
+A clear and concise description of what the problem is...
+
+**To Reproduce**
+
+Steps to reproduce the behavior...
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen...


### PR DESCRIPTION
I've been getting a lot of issues lately with screenshots instead of text which isn't super helpful. Adding a couple of issue templates to help guide users towards more actionable issues.
