### PR TITLE
Preserve trailing commas for enums with members when trailing_commas are preserved

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -626,14 +626,26 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
           builder.leftBracket(node.leftBracket);
 
           for (var constant in node.constants) {
+            var isLast = constant == node.constants.last;
+            var treatAsLast = isLast;
+            if (isLast && formatter.trailingCommas == TrailingCommas.preserve) {
+              treatAsLast = constant.commaAfter == null;
+            }
             builder.addCommentsBefore(constant.firstNonCommentToken);
             builder.add(
               createEnumConstant(
                 constant,
-                isLastConstant: constant == node.constants.last,
+                isLastConstant: treatAsLast,
                 semicolon: node.semicolon,
               ),
             );
+            // If this the last constant and wasn't treated as last, we need
+            // to append the ending semicolon.
+            if (isLast && !treatAsLast) {
+              if (node.semicolon case var token?) {
+                builder.add(tokenPiece(token));
+              }
+            }
           }
 
           // Insert a blank line between the constants and members.

--- a/test/tall/preserve_trailing_commas/enum.unit
+++ b/test/tall/preserve_trailing_commas/enum.unit
@@ -25,13 +25,14 @@ enum E {e,;}
 enum E {
   e,
 }
->>> Remove trailing comma and split if there are members.
+>>> Preserve trailing comma and split if there are members.
 enum E { a, b, c,; int x; }
 <<<
 enum E {
   a,
   b,
-  c;
+  c,
+  ;
 
   int x;
 }


### PR DESCRIPTION
This PR changes the formatter to have it maintain trailing commas of last enum constants when there are members.

So:
```dart
enum E { a, b, c,; int x; }
```

Becomes:
```dart
enum E {
  a,
  b,
  c,
  ;

  int x;
}
```
Instead of:

```dart
enum E {
  a,
  b,
  c;

  int x;
}
```

Fixes #1678 

Additionally, a similar style choice was presented in https://github.com/dart-lang/dart_style/issues/1660#issuecomment-2729244122

**Affected users**:
- Those passing the `trailing_commas: preserve` config option

**Benefits**:
- Maintains developer's intent
- Less churn when adding additional member cases
(Personally, I always add a trailing semicolon to avoid churn and to also make it even clearer this is an advanced enum with members.)

**Downsides**:
- 7 additional logical lines of code to maintain

**Additional considerations**:
I also considered implementing this for `enum E { a, b,; }`, however, that would require more drastic changes to the formatter as far as I can tell.

Additionally, in this case the trailing semicolon provides fewer benefits:
- churn when adding new members is the same if there was a trailing semicolon or not
- giving the enum other members also only amounts to new lines being added rather than changed so again, no real churn.

**Notes**
- One test was changed due to this being a change in behavior.
- This was surprisingly easy and enjoyable to implement.