### PR TITLE
Don't invalidate solutions from pinned pieces.

### DIFF
--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -193,6 +193,16 @@ final class Solution implements Comparable<Solution> {
   ///
   /// This should only be called by [CodeWriter].
   void invalidate(Piece piece) {
+    // Don't invalidate if the piece is pinned and can't do anything. This only
+    // comes into play when a mandatory newline inside a string interpolation
+    // causes some surrounding interpolation expression to try to split but the
+    // expression is aready pinned to be unsplit to prevent newlines inside
+    // interpolation.
+    // TODO(rnystrom): If we come up with a cleaner way to model how newlines
+    // inside interpolation are handled, we can get rid of this. See the TODO
+    // comment in visitInterpolationString().
+    if (piece.pinnedState != null) return;
+
     _isValid = false;
 
     // TODO(rnystrom): It would be good to mark a solution as a dead end here

--- a/test/tall/expression/interpolation.stmt
+++ b/test/tall/expression/interpolation.stmt
@@ -69,3 +69,25 @@ b} after";
 <<<
 "before ${a + // comment
     b} after";
+>>> Multiline string inside splittable expression inside interpolation.
+var x = f('''
+${operand + """
+nested
+"""}
+''');
+<<<
+var x = f('''
+${operand + """
+nested
+"""}
+''');
+>>> Block function inside splittable expression inside interpolation.
+var x = f('''
+${operand + (){;}}
+''');
+<<<
+var x = f('''
+${operand + () {
+      ;
+    }}
+''');


### PR DESCRIPTION
If a string interpolation contains a splittable expression which in turn contains an expression with a mandatory newline (like a multiline string or `;`), then the solver gets confused.

The splittable expression is already pinned to state 0 to prevent there from being newlines in the string interpolation. But now the newline inside the subexpression tries to force the splittable expression to split.

That leads the solver to invalidate the solution and then try to find something better. Ultimately, it ends up unnecessarily splitting some piece surrounding the interpolated string. (In the examples I've seen in the wild, it's always a function's argument list.)

To avoid that, if a piece is already pinned, then we ignore invalidation from it. This fixes the few rare cases I've seen in a large corpus and doesn't impact anything else.

(Also, this fixes an edge case where the formatter in Dart 3.7 behaves differently from the current formatter. The 3.7 formatter doesn't have this bug. Something about the new shape-based solver seems to tickle it. I'm not sure why.)
