### PR TITLE
Bump version to publish 3.1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 3.1.0-wip
+## 3.1.0
+
+This release contains a fairly large number of style changes in response to
+feedback we got from shipping the new tall style formatter.
 
 ### Features
 

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '3.1.0-wip';
+const dartStyleVersion = '3.1.0';
 
 /// Global options parsed from the command line that affect how the formatter
 /// produces and uses its outputs.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.1.0-wip
+version: 3.1.0
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
These changes have already rolled into the SDK, Flutter, and google3.
