### PR TITLE
Add configurable category to `FormatCommand`

### DIFF
--- a/lib/src/cli/format_command.dart
+++ b/lib/src/cli/format_command.dart
@@ -25,7 +25,10 @@ final class FormatCommand extends Command<int> {
   String get invocation =>
       '${runner!.executableName} $name [options...] <files or directories...>';
 
-  FormatCommand({bool verbose = false}) {
+  @override
+  final String category;
+
+  FormatCommand({bool verbose = false, this.category = ''}) {
     argParser.addFlag(
       'verbose',
       abbr: 'v',


### PR DESCRIPTION
Make the `FormatCommand.category` configurable.

Context:

* https://github.com/dart-lang/sdk/issues/60980