### PR TITLE
Bump latest supported language version to 3.9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1-wip
+
+* Update to latest analyzer and enable language version 3.9.
+
 ## 3.1.0
 
 This release contains a fairly large number of style changes in response to

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '3.1.0';
+const dartStyleVersion = '3.1.1-wip';
 
 /// Global options parsed from the command line that affect how the formatter
 /// produces and uses its outputs.

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -34,7 +34,7 @@ final RegExp _widthCommentPattern = RegExp(r'^// dart format width=(\d+)$');
 final class DartFormatter {
   /// The latest Dart language version that can be parsed and formatted by this
   /// version of the formatter.
-  static final latestLanguageVersion = Version(3, 8, 0);
+  static final latestLanguageVersion = Version(3, 9, 0);
 
   /// The latest Dart language version that will be formatted using the older
   /// "short" style.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.1.0
+version: 3.1.1-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.
 repository: https://github.com/dart-lang/dart_style
 environment:
-  sdk: "^3.7.0"
+  sdk: ^3.7.0
 
 dependencies:
-  analyzer: ">=7.3.0 <8.0.0"
+  analyzer: ^7.5.2
   args: ">=1.0.0 <3.0.0"
   collection: "^1.17.0"
   package_config: ^2.1.0

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -60,7 +60,7 @@ Future<void> major() async {
 /// 2.  Run this task:
 ///
 ///     ```
-///     dart run grinder bump
+///     dart run grinder ship
 ///     ```
 ///
 /// 3.  Commit the change to a branch, push it to GitHub, and review and merge


### PR DESCRIPTION
There are no language changes in 3.9, so all this does is increment the internally supported version.

cc @itsjustkevin 