### PR TITLE
Bump version to publish 3.1.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.1-wip
+## 3.1.1
 
 * Update to latest analyzer and enable language version 3.9.
 

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '3.1.1-wip';
+const dartStyleVersion = '3.1.1';
 
 /// Global options parsed from the command line that affect how the formatter
 /// produces and uses its outputs.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.1.1-wip
+version: 3.1.1
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
The only change in this version is allowing 3.9 as a supported language version. This was rolled into the SDK a couple of weeks ago, but not published.

I figure I should publish this before rolling the supported version again to 3.10 just in case any external needs 3.9 support.

I'll land this before landing #1745.
