### PR TITLE
Preserve space between "?" and "." in null aware element dot shorthand.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.1.1-wip
 
-* Update to latest analyzer and enable language version 3.9.
+* Support dot shorthand syntax.
+* Enable language version 3.10.
+* Update to latest analyzer.
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-## 3.1.1-wip
+## 3.1.2-wip
 
 * Support dot shorthand syntax.
 * Enable language version 3.10.
-* Update to latest analyzer.
+
+## 3.1.1
+
+* Update to latest analyzer and enable language version 3.9.
 
 ## 3.1.0
 

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '3.1.1-wip';
+const dartStyleVersion = '3.1.2-wip';
 
 /// Global options parsed from the command line that affect how the formatter
 /// produces and uses its outputs.

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/diagnostic/diagnostic.dart';
 import 'package:analyzer/error/error.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/dart/scanner/scanner.dart';
@@ -176,7 +177,7 @@ final class DartFormatter {
     // Throw if there are syntactic errors.
     var syntacticErrors =
         parseResult.errors.where((error) {
-          return error.errorCode.type == ErrorType.SYNTACTIC_ERROR;
+          return error.diagnosticCode.type == DiagnosticType.SYNTACTIC_ERROR;
         }).toList();
     if (syntacticErrors.isNotEmpty) {
       throw FormatterException(syntacticErrors);
@@ -194,11 +195,11 @@ final class DartFormatter {
       var token = node.endToken.next!;
       if (token.type != TokenType.CLOSE_CURLY_BRACKET) {
         var stringSource = StringSource(text, source.uri);
-        var error = AnalysisError.tmp(
+        var error = Diagnostic.tmp(
           source: stringSource,
           offset: token.offset - inputOffset,
           length: math.max(token.length, 1),
-          errorCode: ParserErrorCode.UNEXPECTED_TOKEN,
+          diagnosticCode: ParserErrorCode.UNEXPECTED_TOKEN,
           arguments: [token.lexeme],
         );
         throw FormatterException([error]);

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -34,7 +34,7 @@ final RegExp _widthCommentPattern = RegExp(r'^// dart format width=(\d+)$');
 final class DartFormatter {
   /// The latest Dart language version that can be parsed and formatted by this
   /// version of the formatter.
-  static final latestLanguageVersion = Version(3, 9, 0);
+  static final latestLanguageVersion = Version(3, 10, 0);
 
   /// The latest Dart language version that will be formatted using the older
   /// "short" style.

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -2,14 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/diagnostic/diagnostic.dart';
 import 'package:source_span/source_span.dart';
 
 /// Thrown when one or more errors occurs while parsing the code to be
 /// formatted.
 final class FormatterException implements Exception {
-  /// The [AnalysisError]s that occurred.
-  final List<AnalysisError> errors;
+  /// The [Diagnostic]s that occurred.
+  final List<Diagnostic> errors;
 
   /// Creates a new FormatterException with an optional error [message].
   const FormatterException(this.errors);

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1587,7 +1587,18 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitNullAwareElement(NullAwareElement node) {
-    writePrefix(node.question, node.value);
+    // A null-aware element containing a dot shorthand means there is a `?` and
+    // `.` next to each other. In that case, make sure we put a space between
+    // them so that they don't incorrectly get collapsed into a `?.` null-aware
+    // access token.
+    var space = switch (node.value) {
+      DotShorthandConstructorInvocation() => true,
+      DotShorthandInvocation() => true,
+      DotShorthandPropertyAccess() => true,
+      _ => false,
+    };
+
+    writePrefix(node.question, space: space, node.value);
   }
 
   @override

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -1970,9 +1970,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
     _visitDirectiveMetadata(node);
     _simpleStatement(node, () {
       token(node.libraryKeyword);
-      if (node.name2 != null) {
-        visit(node.name2, before: space);
-      }
+      if (node.name case var name?) visit(name, before: space);
     });
   }
 
@@ -2184,10 +2182,10 @@ final class SourceVisitor extends ThrowingAstVisitor {
       token(importPrefix.name);
       soloZeroSplit();
       token(importPrefix.period);
-      token(node.name2);
+      token(node.name);
       builder.endSpan();
     } else {
-      token(node.name2);
+      token(node.name);
     }
 
     visit(node.typeArguments);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.1.1-wip
+version: 3.1.2-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: ^7.5.2
+  analyzer: ^8.0.0
   args: ">=1.0.0 <3.0.0"
   collection: "^1.17.0"
   package_config: ^2.1.0

--- a/test/tall/expression/collection_null_aware.stmt
+++ b/test/tall/expression/collection_null_aware.stmt
@@ -27,3 +27,17 @@ var list = [
   ?(veryLongExpression +
       thatIsForcedToSplit),
 ];
+>>> (experiment dot-shorthands) Preserves space for dot shorthand.
+### If the space between `?` and `.` is removed, it would become a single `?.`
+### token and thus a parse error.
+var list = [
+  ?  .  property  ,
+  ?  .  invocation  (  )  ,
+  ?  .  new  (  )  ,
+];
+<<< 3.10
+var list = [
+  ? .property,
+  ? .invocation(),
+  ? .new(),
+];

--- a/test/tall/expression/collection_null_aware_comment.stmt
+++ b/test/tall/expression/collection_null_aware_comment.stmt
@@ -33,3 +33,20 @@ var map = {
       ? // c
       value,
 };
+>>> (experiment dot-shorthands) Comment between `?` and `.` of dot shorthand.
+var list = [
+  ?  /* c */  .  property  ,
+  ?  // c
+  .  invocation  (  )  ,
+  ?  /// c
+  .  new  (  )  ,
+];
+<<< 3.10
+var list = [
+  ? /* c */ .property,
+  ? // c
+  .invocation(),
+  ?
+  /// c
+  .new(),
+];

--- a/test/tall/invocation/dot_shorthand.stmt
+++ b/test/tall/invocation/dot_shorthand.stmt
@@ -1,0 +1,69 @@
+40 columns                              |
+(experiment dot-shorthands)
+>>> Getter.
+variable =  .  getter;
+<<< 3.9
+variable = .getter;
+>>> Method call with unsplit arguments.
+variable = .method(1,x:2,3,y:4);
+<<< 3.9
+variable = .method(1, x: 2, 3, y: 4);
+>>> Method call with split arguments.
+variable = .method(one, x: two, three, y: four);
+<<< 3.9
+variable = .method(
+  one,
+  x: two,
+  three,
+  y: four,
+);
+>>> Generic method call.
+variable =  .  method  <  int  ,  String  >  (  )  ;
+<<< 3.9
+variable = .method<int, String>();
+>>> Constructor.
+variable = .new(1);
+<<< 3.9
+variable = .new(1);
+>>> Const constructor.
+variable = const  .  new  (  );
+<<< 3.9
+variable = const .new();
+>>> Const named constructor.
+variable = const  .  named  (  );
+<<< 3.9
+variable = const .named();
+>>> Unsplit selector chain.
+v =  .  property  .  method()  .  x  .  another();
+<<< 3.9
+v = .property.method().x.another();
+>>> Split selector chain on shorthand getter.
+variable = .shorthand.method().another().third();
+<<< 3.9
+variable = .shorthand
+    .method()
+    .another()
+    .third();
+>>> Split selector chain on shorthand method.
+variable = .shorthand().method().getter.another().third();
+<<< 3.9
+variable = .shorthand()
+    .method()
+    .getter
+    .another()
+    .third();
+>>> Split in shorthand method call argument list.
+context(.shorthand(argument, anotherArgument, thirdArgument)
+.chain().another().third().fourthOne());
+<<< 3.9
+context(
+  .shorthand(
+        argument,
+        anotherArgument,
+        thirdArgument,
+      )
+      .chain()
+      .another()
+      .third()
+      .fourthOne(),
+);

--- a/test/tall/invocation/dot_shorthand.stmt
+++ b/test/tall/invocation/dot_shorthand.stmt
@@ -67,3 +67,11 @@ context(
       .third()
       .fourthOne(),
 );
+>>> Nested call.
+.method(.getter,.method(.new(.new())),const.ctor());
+<<<
+.method(
+  .getter,
+  .method(.new(.new())),
+  const .ctor(),
+);

--- a/test/tall/invocation/dot_shorthand_comment.stmt
+++ b/test/tall/invocation/dot_shorthand_comment.stmt
@@ -1,0 +1,26 @@
+40 columns                              |
+(experiment dot-shorthands)
+>>> Line comment after dot.
+variable = . // Comment.
+whoDoesThis();
+<<< 3.9
+variable =
+    . // Comment.
+    whoDoesThis();
+>>> Block comment after dot.
+variable = ./* Comment. */whoDoesThis();
+<<< 3.9
+variable =
+    . /* Comment. */ whoDoesThis();
+>>> Line comment after `const`.
+variable = const // Comment.
+. whoDoesThis();
+<<< 3.9
+variable =
+    const // Comment.
+    .whoDoesThis();
+>>> Block comment after `const`.
+variable = const/* Comment. */.whoDoesThis();
+<<< 3.9
+variable =
+    const /* Comment. */ .whoDoesThis();


### PR DESCRIPTION
Fix #1642.
