### PR TITLE
Language version preserving the trailing comma in enums with members.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 * Support dot shorthand syntax.
 * Enable language version 3.10.
 
+### Style changes
+
+This change only applies to code whose language version is 3.10 or higher:
+
+* When `trailing_commas` is `preserve`, preserve a trailing comma after the last
+  enum constant when members are present (#1678, #1729).
+
+  ```dart
+  // Before formatting:
+  enum { constant, ; member() {} }
+
+  // After formatting at language version 3.9 or lower:
+  enum {
+    constant;
+
+    member() {}
+  }
+
+  // After formatting at language version 3.10 or higher:
+  enum {
+    constant,
+    ;
+
+    member() {}
+  }
+  ```
+
+  (Thanks to jellynoone@ for this change.)
+
 ## 3.1.1
 
 * Update to latest analyzer and enable language version 3.9.

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/source/line_info.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 import '../ast_extensions.dart';
 import '../back_end/code_writer.dart';
@@ -672,27 +673,32 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
           var builder = SequenceBuilder(this);
           builder.leftBracket(node.leftBracket);
 
+          // In 3.10 and later, preserved trailing commas will also preserve a
+          // trailing comma in an enum with members. That in turn forces the
+          // `;` onto its own line after the last costant. Prior to 3.10, the
+          // behavior is the same as when preserved trailing commas is off
+          // where the last constant's comma is removed and the `;` is placed
+          // there instead.
+          var preserveTrailingComma =
+              formatter.trailingCommas == TrailingCommas.preserve &&
+              formatter.languageVersion >= Version(3, 10, 0);
+
           for (var constant in node.constants) {
             var isLast = constant == node.constants.last;
-            var treatAsLast = isLast;
-            if (isLast && formatter.trailingCommas == TrailingCommas.preserve) {
-              treatAsLast = constant.commaAfter == null;
-            }
             builder.addCommentsBefore(constant.firstNonCommentToken);
             builder.add(
               createEnumConstant(
                 constant,
-                isLastConstant: treatAsLast,
-                semicolon: node.semicolon,
+                commaAfter: !isLast || preserveTrailingComma,
+                semicolon: isLast ? node.semicolon : null,
               ),
             );
-            // If this the last constant and wasn't treated as last, we need
-            // to append the ending semicolon.
-            if (isLast && !treatAsLast) {
-              if (node.semicolon case var token?) {
-                builder.add(tokenPiece(token));
-              }
-            }
+          }
+
+          // If we are preserving the trailing comma, then put the `;` on its
+          // own line after the last constant.
+          if (preserveTrailingComma) {
+            builder.add(tokenPiece(node.semicolon!));
           }
 
           // Insert a blank line between the constants and members.

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -387,13 +387,14 @@ mixin PieceFactory {
 
   /// Creates a [Piece] for an enum constant.
   ///
-  /// If the constant is in an enum declaration that also declares members, then
-  /// [semicolon] should be the `;` token before the members, and
-  /// [isLastConstant] is `true` if [node] is the last constant before the
-  /// members.
+  /// If [commaAfter] is `true`, then a comma after the constant is written, if
+  /// present. If the constant is the last constant in an enum declaration that
+  /// also declares members (and preserve trailing commas is off), then
+  /// [semicolon] is the `;` token before the members and will be written
+  /// after the constant.
   Piece createEnumConstant(
     EnumConstantDeclaration node, {
-    bool isLastConstant = false,
+    bool commaAfter = false,
     Token? semicolon,
   }) {
     return pieces.build(metadata: node.metadata, () {
@@ -404,17 +405,15 @@ mixin PieceFactory {
         pieces.visit(arguments.argumentList);
       }
 
-      if (semicolon != null) {
-        if (!isLastConstant) {
-          pieces.token(node.commaAfter);
-        } else {
-          // Discard the trailing comma if there is one since there is a
-          // semicolon to use as the separator, but preserve any comments before
-          // the discarded comma.
-          pieces.add(
-            pieces.tokenPiece(discardedToken: node.commaAfter, semicolon),
-          );
-        }
+      if (commaAfter) {
+        pieces.token(node.commaAfter);
+      } else if (semicolon != null) {
+        // Discard the trailing comma if there is one since there is a
+        // semicolon to use as the separator, but preserve any comments before
+        // the discarded comma.
+        pieces.add(
+          pieces.tokenPiece(discardedToken: node.commaAfter, semicolon),
+        );
       }
     });
   }

--- a/test/tall/declaration/enum.unit
+++ b/test/tall/declaration/enum.unit
@@ -51,6 +51,15 @@ enum E { a, b }
 enum E {a,b,c,;}
 <<<
 enum E { a, b, c }
+>>> Split values and add trailing comma but remove semicolon if no members.
+enum Primate{bonobo,chimp,gorilla,organutan;}
+<<<
+enum Primate {
+  bonobo,
+  chimp,
+  gorilla,
+  organutan,
+}
 >>> Argument lists in values.
 enum Args {
 first(),second(a,b,c),

--- a/test/tall/preserve_trailing_commas/enum.unit
+++ b/test/tall/preserve_trailing_commas/enum.unit
@@ -25,9 +25,17 @@ enum E {e,;}
 enum E {
   e,
 }
->>> Preserve trailing comma and split if there are members.
+>>> Trailing comma with members.
 enum E { a, b, c,; int x; }
-<<<
+<<< 3.9 Remove the trailing comma so the semicolon isn't on its own line.
+enum E {
+  a,
+  b,
+  c;
+
+  int x;
+}
+<<< 3.10 Preserve the trailing comma because that's the user intent.
 enum E {
   a,
   b,


### PR DESCRIPTION
Also add the style change to the CHANGELOG.

This build's on @jellynoone's PR #1703 which I merged into a branch instead of main so that I can tweak it a bit. This PR is the tweak. Once this is merged onto the branch, I'll merge the whole branch onto main.
