### PR TITLE
Add a regression test for an idempotency bug.

### DIFF
--- a/test/tall/regression/1600/1625.unit
+++ b/test/tall/regression/1600/1625.unit
@@ -1,0 +1,17 @@
+>>>
+bool foo() {
+  if (
+  // Explicitly stated to not be a bot.
+  Platform.environment['BOT'] == 'false'
+  ) {
+    return false;
+  }
+}
+<<<
+bool foo() {
+  if (
+  // Explicitly stated to not be a bot.
+  Platform.environment['BOT'] == 'false') {
+    return false;
+  }
+}


### PR DESCRIPTION
Idempotency bugs where the formatter produces another change if you re-run it on its own output are like Whac-a-mole. We don't have a systematic way to prevent them, so I just fix them as they come up.

We do *test* for them systematically now. Every single test is formatted twice, again on the output of the first format to ensure that what we test is at least idempotent.

This one appears to no longer be an issue because the test is already passing. Probably got fixed in some of the changes around comment handling.

This just adds a regression test.

Close #1625.
