### PR TITLE
Update deps to their lowest allowed, prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 3.1.2-wip
+## 3.1.2
 
 * Support dot shorthand syntax.
+* Update to the latest `package:analyzer`.
 * Enable language version 3.10.
 
 ### Bug fixes

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.1.2-wip
+version: 3.1.2
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.
@@ -10,17 +10,17 @@ environment:
 
 dependencies:
   analyzer: ^8.0.0
-  args: ">=1.0.0 <3.0.0"
-  collection: "^1.17.0"
+  args: ^2.0.0
+  collection: ^1.19.0
   package_config: ^2.1.0
-  path: ^1.0.0
-  pub_semver: ">=1.4.4 <3.0.0"
-  source_span: ^1.4.0
+  path: ^1.9.0
+  pub_semver: ^2.1.4
+  source_span: ^1.8.0
   yaml: ^3.1.2
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.1.0
-  grinder: ^0.9.0-nullsafety.0
-  test: ^1.24.6
+  grinder: ^0.9.0
+  test: ^1.26.3
   test_descriptor: ^2.0.0
   test_process: ^2.0.0


### PR DESCRIPTION
Used
`_PUB_TEST_SDK_VERSION=3.7.0 dart pub downgrade --tighten`
