### PR TITLE
Remove special case handling of dot shorthands in null aware elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.3-wip
+
+* Don't force a space between `?` and `.` if a null-aware element contains a
+  dot shorthand.
+
 ## 3.1.2
 
 * Support dot shorthand syntax.

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -1605,18 +1605,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitNullAwareElement(NullAwareElement node) {
-    // A null-aware element containing a dot shorthand means there is a `?` and
-    // `.` next to each other. In that case, make sure we put a space between
-    // them so that they don't incorrectly get collapsed into a `?.` null-aware
-    // access token.
-    var space = switch (node.value) {
-      DotShorthandConstructorInvocation() => true,
-      DotShorthandInvocation() => true,
-      DotShorthandPropertyAccess() => true,
-      _ => false,
-    };
-
-    writePrefix(node.question, space: space, node.value);
+    writePrefix(node.question, node.value);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.1.2
+version: 3.1.3-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: ^8.0.0
+  analyzer: ^8.1.0
   args: ^2.0.0
   collection: ^1.19.0
   package_config: ^2.1.0

--- a/test/tall/expression/collection_null_aware.stmt
+++ b/test/tall/expression/collection_null_aware.stmt
@@ -31,13 +31,23 @@ var list = [
 ### If the space between `?` and `.` is removed, it would become a single `?.`
 ### token and thus a parse error.
 var list = [
-  ?  .  property  ,
+  ?.  property  ,
   ?  .  invocation  (  )  ,
   ?  .  new  (  )  ,
 ];
 <<< 3.10
 var list = [
-  ? .property,
-  ? .invocation(),
-  ? .new(),
+  ?.property,
+  ?.invocation(),
+  ?.new(),
 ];
+>>> (experiment dot-shorthands) Ambiguous dot shorthand versus null-aware.
+### Because there is no space in "?.", it must be a null-aware access in a map.
+c = {  e1  ?.  e2  :  e3  };
+<<< 3.10
+c = {e1?.e2: e3};
+>>> (experiment dot-shorthands) Ambiguous dot shorthand versus null-aware.
+### Because there is a space in "? .", it must be a dot shorthand in a set.
+c = {  e1  ?  .  e2  :  e3  };
+<<< 3.10
+c = {e1 ? .e2 : e3};


### PR DESCRIPTION
We fixed the parser so that it can correctly handle:

```dart
[?.property]
```

Even if there is no space between `?` and `.`, it knows to treat it as a dot shorthand inside a null-aware element here. So the formatter doesn't need to force insert a space in there to avoid `?.` from being tokenized as a null-aware access.

See: https://github.com/dart-lang/language/issues/4477