### PR TITLE
Remove tests of invalid import syntax.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 3.1.3-wip
+
+* No longer format imports with configurations and a prefix in the wrong order.
+  The parser used to accept this without error even though it violated the
+  language spec. The parser is being fixed, so the formatter will no longer
+  accept or format code like:
+
+  ```dart
+  import 'foo.dart' as prefix if (cond) 'bar.dart';
+  ```
+
 ## 3.1.2
 
 * Support dot shorthand syntax.

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -1016,20 +1016,9 @@ mixin PieceFactory {
       // Add all of the clauses and combinators.
       var clauses = <Piece>[];
 
-      // The language specifies that configurations must appear after any `as`
-      // clause but the parser incorrectly accepts them before it and code in
-      // the wild relies on that. Instead of failing with an "unexpected output"
-      // error, just preserve the order of the clauses if they are out of order.
-      // See: https://github.com/dart-lang/sdk/issues/56641
-      var wroteConfigurations = false;
-      if (directive.configurations.isNotEmpty &&
-          asKeyword != null &&
-          directive.configurations.first.ifKeyword.offset < asKeyword.offset) {
-        for (var configuration in directive.configurations) {
-          clauses.add(nodePiece(configuration));
-        }
-
-        wroteConfigurations = true;
+      // Include any `if` clauses.
+      for (var configuration in directive.configurations) {
+        clauses.add(nodePiece(configuration));
       }
 
       // Include the `as` clause.
@@ -1042,13 +1031,6 @@ mixin PieceFactory {
             pieces.visit(prefix!);
           }),
         );
-      }
-
-      // Include any `if` clauses.
-      if (!wroteConfigurations) {
-        for (var configuration in directive.configurations) {
-          clauses.add(nodePiece(configuration));
-        }
       }
 
       // Include the `show` and `hide` clauses.

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -1832,18 +1832,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
       space();
       visit(node.uri);
 
-      // The language specifies that configurations must appear after any `as`
-      // clause but the parser incorrectly accepts them before it and code in
-      // the wild relies on that. Instead of failing with an "unexpected output"
-      // error, just preserve the order of the clauses if they are out of order.
-      // See: https://github.com/dart-lang/sdk/issues/56641
-      var wroteConfigurations = false;
-      if (node.asKeyword case var asKeyword?
-          when node.configurations.isNotEmpty &&
-              node.configurations.first.ifKeyword.offset < asKeyword.offset) {
-        _visitConfigurations(node.configurations);
-        wroteConfigurations = true;
-      }
+      _visitConfigurations(node.configurations);
 
       if (node.asKeyword != null) {
         soloSplit();
@@ -1851,10 +1840,6 @@ final class SourceVisitor extends ThrowingAstVisitor {
         token(node.asKeyword);
         space();
         visit(node.prefix);
-      }
-
-      if (!wroteConfigurations) {
-        _visitConfigurations(node.configurations);
       }
 
       _visitCombinators(node.combinators);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.1.2
+version: 3.1.3-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/short/regression/1500/1544.unit
+++ b/test/short/regression/1500/1544.unit
@@ -1,6 +1,6 @@
 >>>
-import 'package:archive/archive.dart' as archive
-  if (dart.library.io) 'package:archive/archive_io.dart';
+import 'package:archive/archive.dart'
+  if (dart.library.io) 'package:archive/archive_io.dart' as archive;
 import 'package:flutter/services.dart';
 import 'package:fuzzy/web/e621/e621.dart';
 import 'package:fuzzy/web/e621/models/tag_d_b.dart';
@@ -47,8 +47,8 @@ final LazyInitializer<TagDB> tagDbLazy = LazyInitializer(() async {
   }
 });
 <<<
-import 'package:archive/archive.dart' as archive
-    if (dart.library.io) 'package:archive/archive_io.dart';
+import 'package:archive/archive.dart'
+    if (dart.library.io) 'package:archive/archive_io.dart' as archive;
 import 'package:flutter/services.dart';
 import 'package:fuzzy/web/e621/e621.dart';
 import 'package:fuzzy/web/e621/models/tag_d_b.dart';

--- a/test/short/whitespace/directives.unit
+++ b/test/short/whitespace/directives.unit
@@ -67,14 +67,6 @@ part   of'uri.dart'     ;
 <<<
 part of 'uri.dart';
 >>> Both configuration and prefix.
-import 'foo.dart' as foo if (config == 'value') 'other.dart';
-<<<
-import 'foo.dart' as foo
-    if (config == 'value') 'other.dart';
->>> Configuration before prefix.
-### This violates the language spec, but the parser currently allows it without
-### reporting an error and code in the wild relies on that. So the formatter
-### handles it gracefully. See: https://github.com/dart-lang/sdk/issues/56641
 import 'foo.dart' if (config == 'value') 'other.dart' as foo;
 <<<
 import 'foo.dart'

--- a/test/tall/regression/1500/1544.unit
+++ b/test/tall/regression/1500/1544.unit
@@ -1,6 +1,6 @@
 >>>
-import 'package:archive/archive.dart' as archive
-  if (dart.library.io) 'package:archive/archive_io.dart';
+import 'package:archive/archive.dart'
+  if (dart.library.io) 'package:archive/archive_io.dart' as archive;
 import 'package:flutter/services.dart';
 import 'package:fuzzy/web/e621/e621.dart';
 import 'package:fuzzy/web/e621/models/tag_d_b.dart';
@@ -48,8 +48,8 @@ final LazyInitializer<TagDB> tagDbLazy = LazyInitializer(() async {
 });
 <<<
 import 'package:archive/archive.dart'
-    as archive
-    if (dart.library.io) 'package:archive/archive_io.dart';
+    if (dart.library.io) 'package:archive/archive_io.dart'
+    as archive;
 import 'package:flutter/services.dart';
 import 'package:fuzzy/web/e621/e621.dart';
 import 'package:fuzzy/web/e621/models/tag_d_b.dart';

--- a/test/tall/top_level/import.unit
+++ b/test/tall/top_level/import.unit
@@ -69,15 +69,6 @@ import 'some/uri.dart'
     if (config.name.debug ==
         'string') 'c';
 >>> Both configuration and prefix.
-import 'foo.dart' as foo if (config == 'value') 'other.dart';
-<<<
-import 'foo.dart'
-    as foo
-    if (config == 'value') 'other.dart';
->>> Configuration before prefix.
-### This violates the language spec, but the parser currently allows it without
-### reporting an error and code in the wild relies on that. So the formatter
-### handles it gracefully. See: https://github.com/dart-lang/sdk/issues/56641
 import 'foo.dart' if (config == 'value') 'other.dart' as foo;
 <<<
 import 'foo.dart'


### PR DESCRIPTION
The language specifies that import configuration URIs must appear before any import prefix, like:

```dart
import 'foo.dart' if (cond) 'bar.dart' as prefix;
```

If a user wrote them in the wrong order:

```dart
import 'foo.dart' as prefix if (cond) 'bar.dart';
```

Then the parser used to not report an error and would accept the code, which would then be compiled successfully. Some users in the wild, probably inadvertently, ended up relying on this. So I added support in the formatter to handle it.

I also filed:

https://github.com/dart-lang/sdk/issues/56641

That issue will be fixed soon:

https://github.com/dart-lang/sdk/issues/61264

It's going to be a parse error to have the clauses in the wrong order. These formatter tests are failing in the bleeding edge SDK. So now it's time to remove the tests and support for the broken code.

(Note that the comment in the tests are backwards. Configuration before prefix is the correct order. It's prefix before configuration that's wrong.)

cc @jensjoha 