### PR TITLE
Stop using deprecated ParserErrorCode.UNEXPECTED_TOKEN.

### DIFF
--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -200,7 +200,7 @@ final class DartFormatter {
           source: stringSource,
           offset: token.offset - inputOffset,
           length: math.max(token.length, 1),
-          diagnosticCode: ParserErrorCode.UNEXPECTED_TOKEN,
+          diagnosticCode: ParserErrorCode.unexpectedToken,
           arguments: [token.lexeme],
         );
         throw FormatterException([error]);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: ^8.1.0
+  analyzer: ^8.2.0
   args: ^2.0.0
   collection: ^1.19.0
   package_config: ^2.1.0


### PR DESCRIPTION
In https://dart-review.googlesource.com/c/sdk/+/444921, all analyzer error constants were renamed to camelCase, but
ParserErrorCode.UNEXPECTED_TOKEN was left in place (and deprecated) since it is used by dart_style.

This change updates dart_style to use the new camelCase declaration.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
