### PR TITLE
Add script to remove experiments from tests when they have launched.

### DIFF
--- a/lib/src/testing/test_file.dart
+++ b/lib/src/testing/test_file.dart
@@ -15,8 +15,8 @@ final _indentPattern = RegExp(r'\(indent (\d+)\)');
 final _experimentPattern = RegExp(r'\(experiment ([a-z-]+)\)');
 final _preserveTrailingCommasPattern = r'(trailing_commas preserve)';
 // Only supports two-digit hex numbers.
-final _unicodeUnescapePattern = RegExp(r'×([0-9a-fA-F]{2})');
-final _unicodeEscapePattern = RegExp('[\x0a\x0c\x0d]');
+final _unicodeUnescapePattern = RegExp(r'×([0-9a-fA-F]{2,4})');
+final _unicodeEscapePattern = RegExp('[\x0a\x0c\x0d\x80-\uFFFF]');
 
 /// Matches an output header line with an optional version and description.
 /// Examples:
@@ -162,7 +162,7 @@ final class TestFile {
       var versionedOutputs = <Version, TestEntry>{};
       while (i < lines.length && lines[i].startsWith('<<<')) {
         var match = _outputPattern.firstMatch(readLine())!;
-        var outputDescription = match[3]!.trim();
+        var outputDescription = match[3]!;
         Version? outputVersion;
         if (match[1] case var majorVersion?) {
           outputVersion = Version(
@@ -546,6 +546,9 @@ String escapeUnicode(String input) {
     assert(match.end == match.start + 1);
     var codePoint = input.codeUnitAt(match.start);
     assert(codePoint < 0x100); // Two digits is enough.
-    return '×${codePoint.toRadixString(16).padLeft(2, '0')}';
+    var hexDigits = codePoint
+        .toRadixString(16)
+        .padLeft(codePoint < 0x100 ? 2 : 4, '0');
+    return '×$hexDigits';
   });
 }

--- a/lib/src/testing/test_file.dart
+++ b/lib/src/testing/test_file.dart
@@ -18,12 +18,12 @@ final _unicodeUnescapePattern = RegExp(r'×([0-9a-fA-F]{2,4})');
 
 /// Matches an output header line with an optional version and description.
 /// Examples:
-/// ```plaintext
-/// >>>
-/// >>> Only description.
-/// >>> 1.2
-/// >>> 1.2 Version and description.
-/// ```
+///
+///     <<<
+///     <<< Only description.
+///     <<< 1.2
+///     <<< 1.2 Version and description.
+///
 final _outputPattern = RegExp(r'<<<(?: (\d+)\.(\d+))?(.*)');
 
 /// Get the absolute local file path to the dart_style package's root directory.
@@ -32,12 +32,14 @@ Future<String> findPackageDirectory() async {
     Uri.parse('package:dart_style/src/testing/test_file.dart'),
   ))?.toFilePath();
 
+  if (libraryPath != null) {
+    // Assume path is `PACKAGE_DIR/lib/src/testing/test_file.dart`.
+    return p.normalize(p.dirname(p.dirname(p.dirname(p.dirname(libraryPath)))));
+  }
   // Fallback, if we can't resolve the package URI because we're running in an
   // AOT snapshot, just assume we're running from the root directory of the
   // package.
-  libraryPath ??= 'lib/src/testing/test_file.dart';
-
-  return p.normalize(p.join(p.dirname(libraryPath), '../../..'));
+  return p.current;
 }
 
 /// Get the absolute local file path to the package's "test" directory.
@@ -364,10 +366,10 @@ sealed class FormatTest {
     return 'line $line: ${input.description}';
   }
 
-  void writeTo(StringSink output) {
-    output.write('>>>');
-    options.writeTo(output, prefix: ' ');
-    input.writeTo(output);
+  void writeTo(StringSink target) {
+    target.write('>>>');
+    options.writeTo(target, prefix: ' ');
+    input.writeTo(target);
     // Outputs are written by subclasses.
   }
 }
@@ -382,10 +384,10 @@ final class UnversionedFormatTest extends FormatTest {
   UnversionedFormatTest(super.line, super.options, super.input, this.output);
 
   @override
-  void writeTo(StringSink output) {
-    super.writeTo(output);
-    output.write('<<<');
-    this.output.writeTo(output);
+  void writeTo(StringSink target) {
+    super.writeTo(target);
+    target.write('<<<');
+    output.writeTo(target);
   }
 }
 
@@ -407,15 +409,15 @@ final class VersionedFormatTest extends FormatTest {
   VersionedFormatTest(super.line, super.options, super.input, this.outputs);
 
   @override
-  void writeTo(StringSink output) {
-    super.writeTo(output);
+  void writeTo(StringSink target) {
+    super.writeTo(target);
     outputs.forEach((version, entry) {
-      output
+      target
         ..write('<<< ')
         ..write(version.major)
         ..write('.')
         ..write(version.minor);
-      entry.writeTo(output);
+      entry.writeTo(target);
     });
   }
 }
@@ -452,7 +454,8 @@ final class TestEntry {
       output.writeln(comment);
     }
     output.write(source);
-    if (!code.text.endsWith('\n')) output.writeln(); // Can that happen?
+    // TODO(rnystrom): Can that happen?
+    if (!code.text.endsWith('\n')) output.writeln();
   }
 }
 
@@ -474,7 +477,7 @@ final class TestOptions {
   ///
   /// Returns whether anything was written.
   bool writeTo(StringSink output, {String prefix = ''}) {
-    var change = false;
+    var wroteOutput = false;
     if (leadingIndent != null && leadingIndent != 0) {
       output
         ..write(prefix)
@@ -482,7 +485,7 @@ final class TestOptions {
         ..write(leadingIndent)
         ..write(')');
       prefix = '';
-      change = true;
+      wroteOutput = true;
     }
     for (var experiment in experimentFlags) {
       output
@@ -491,15 +494,15 @@ final class TestOptions {
         ..write(experiment)
         ..write(')');
       prefix = '';
-      change = true;
+      wroteOutput = true;
     }
     if (trailingCommas == TrailingCommas.preserve) {
       output
         ..write(prefix)
         ..write('(trailing_commas preserve)');
-      change = true;
+      wroteOutput = true;
     }
-    return change;
+    return wroteOutput;
   }
 }
 
@@ -526,9 +529,12 @@ SourceCode _parseTestSource(
   return _extractSelection(sourceText, isCompilationUnit: isCompilationUnit);
 }
 
+/// Extracts marked selection from source string.
+///
 /// Given a source string that contains ‹ and › to indicate a selection, returns
 /// a [SourceCode] with the text (with the selection markers removed) and the
 /// correct selection range.
+///
 /// Only recognizes the first `‹...›` range.
 SourceCode _extractSelection(String source, {bool isCompilationUnit = false}) {
   int? selectionStart;
@@ -553,11 +559,18 @@ SourceCode _extractSelection(String source, {bool isCompilationUnit = false}) {
   );
 }
 
-/// Turn the special Unicode escape marker syntax used in the tests into real
-/// Unicode characters.
+/// Converts special Unicode escape markers to their corresponding code unit.
 ///
-/// This does not use Dart's own string escape sequences so that we don't
-/// accidentally modify the Dart code being formatted.
+/// The test source can contain special code-unit markers, to visually
+/// represent unprintable characters. This uses the non-ASCII `×` (U+0097)
+/// character followed by 2-4 hexadecimal digits.
+///
+/// The syntax is separate from Dart syntax to allow these code-point
+/// escapes to occur in a Dart program that contains Dart escapes like
+/// `\x97` in a string literal.
+///
+/// Unescaping these escapes replaces the `×` and following hex digits
+/// with the Unicode code point denoted by the hex numeral.
 String _unescapeUnicode(String input) =>
     input.replaceAllMapped(_unicodeUnescapePattern, (match) {
       var codePoint = int.parse(match[1]!, radix: 16);

--- a/tool/update_sdk.dart
+++ b/tool/update_sdk.dart
@@ -233,6 +233,10 @@ class Updater {
 
   /// Updates the minium SDK constraint in `pubspec.yaml` to [targetVersion].
   ///
+  /// Assumes a standard `sdk: ^...` format for the SDK constraint,
+  /// and normal two-space indentation of the YAML file,
+  /// with nothing else on the line, including comments.
+  ///
   /// If the existing version is greater than the requested version, no change
   /// is needed.
   ///

--- a/tool/update_sdk.dart
+++ b/tool/update_sdk.dart
@@ -38,7 +38,6 @@ void main(List<String> args) {
     ) = _parseArguments(
       args,
     );
-    verbose = 9;
     var stylePackageDir = _findStylePackageDir();
     if (verbose > 0) {
       stdout.writeln('dart_style root: ${stylePackageDir.path}');
@@ -227,7 +226,7 @@ class Updater {
     files.flushChanges();
     if (updatedPubspecVersion && !dryRun) {
       stdout.writeln(
-        'Updated PubSpec version. Run `dart pub get` and `dart format`.',
+        'Updated pubspec version. Run `dart pub get` and `dart format`.',
       );
     }
   }

--- a/tool/update_sdk.dart
+++ b/tool/update_sdk.dart
@@ -1,0 +1,495 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Script to update the SDK dependency to the newest version,
+/// and to remove references to experiments that have been released.
+library;
+
+import 'dart:convert' show LineSplitter;
+import 'dart:io';
+import 'dart:io' as io show exit;
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart' as y;
+
+// Command line can contain:
+//
+// - Explicit version: `3.10`, which is used as version in pubspec.yaml.
+// - Directory of SDK, may be relative to CWD.
+// - `-n` for dry-run.
+void main(List<String> args) {
+  try {
+    var flagErrors = false;
+    // General use of verbosity levels:
+    // 0: No extra output.
+    // 1+: Say what is done
+    // 2+: Also say when no change is made.
+    var verbose = 0;
+    var dryRun = false;
+    var nonFlagArgs = <String>[];
+    for (var arg in args) {
+      if (arg.startsWith('-')) {
+        for (var i = 1; i < arg.length; i++) {
+          switch (arg[i]) {
+            case 'n':
+              dryRun = true;
+            case 'v':
+              verbose++;
+            case var char:
+              stderr.writeln('Invalid flag: "$char"');
+              flagErrors = true;
+          }
+        }
+      } else {
+        nonFlagArgs.add(arg);
+      }
+    }
+    if (flagErrors) {
+      stderr.writeln(usage);
+      exit(1);
+    }
+    if (verbose > 1) {
+      stdout.writeln('Verbosity: $verbose');
+    }
+    if (verbose > 0) {
+      if (dryRun || verbose > 1) stdout.writeln('Dry-run: $dryRun');
+    }
+
+    var stylePackageDir = _findStylePackageDir();
+    if (verbose > 0) {
+      stdout.writeln('dart_style root: ${stylePackageDir.path}');
+    }
+    if (findExperimentsFile(nonFlagArgs) case var experimentsFile?) {
+      // A version number on the command line will be "current version",
+      // otherwise use the maximal version of released experiments in the
+      // experiments file.
+      Version? version;
+      var experiments = _parseExperiments(experimentsFile);
+      for (var arg in nonFlagArgs) {
+        if (Version.tryParse(arg) case var explicitVersion?) {
+          version = explicitVersion;
+          if (verbose > 0) {
+            stdout.writeln('SDK version from command line: $version');
+          }
+          break;
+        }
+      }
+      if (version == null) {
+        version = experiments.values.nonNulls.reduce(Version.max);
+        if (verbose > 0) {
+          stdout.writeln('SDK version from experiments: $version');
+        }
+      }
+
+      Updater(
+        stylePackageDir,
+        version,
+        experiments,
+        verbose: verbose,
+        dryRun: dryRun,
+      ).run();
+    } else {
+      stderr.writeln('Cannot find experiments file.');
+      stderr.writeln(usage);
+      exit(1);
+    }
+  } catch (e) {
+    if (e case (:int exitCode)) {
+      stdout.flush().then((_) {
+        stderr.flush().then((_) {
+          io.exit(exitCode);
+        });
+      });
+    }
+  }
+}
+
+class Updater {
+  final Directory root;
+  final Version currentVersion;
+  final int verbose;
+  final Map<String, Version?> experiments;
+  final FileCache files;
+  Updater(
+    this.root,
+    this.currentVersion,
+    this.experiments, {
+    this.verbose = 0,
+    bool dryRun = false,
+  }) : files = FileCache(verbose: verbose, dryRun: dryRun);
+  void run() {
+    _updatePubspec();
+    _updateTests();
+    files.flushSaves();
+  }
+
+  bool _updatePubspec() {
+    var file = File(p.join(root.path, 'pubspec.yaml'));
+    var pubspecText = files.load(file);
+    var versionRE = RegExp(
+      r'(?<=^environment:\n  sdk: \^)([\w\-.+]+)(?=[ \t]*$)',
+      multiLine: true,
+    );
+    var change = false;
+    Version? unchangedVersion;
+    pubspecText = pubspecText.replaceFirstMapped(versionRE, (m) {
+      var versionText = m[0]!;
+      var existingVersion = Version.parse(versionText);
+      if (existingVersion < currentVersion) {
+        change = true;
+        return '$currentVersion.0';
+      }
+      unchangedVersion = existingVersion;
+      return versionText; // No change.
+    });
+    if (change) {
+      if (verbose > 0) {
+        stdout.writeln('Updated pubspec.yaml SDK to $currentVersion');
+      }
+      files.save(file, pubspecText);
+      return true;
+    }
+    if (unchangedVersion == null) {
+      throw UnsupportedError('Cannot find SDK version in pubspec.yaml');
+    }
+    if (verbose > 1) {
+      stdout.writeln('Pubspec SDK version unchanged: $unchangedVersion');
+    }
+    return false;
+  }
+
+  void _updateTests() {
+    var testDirectory = Directory(p.join(root.path, 'test'));
+    for (var file in testDirectory.listSync(recursive: true)) {
+      if (file is File && file.path.endsWith('.stmt')) {
+        if (_updateTest(file) && verbose > 0) {
+          stdout.writeln('Updated test: ${file.path}');
+        }
+      }
+    }
+  }
+
+  // Matches an `(experiment exp-name)` entry, plus a single prior space.
+  // Captures:
+  // - name: The exp-name
+  static final _experimentRE = RegExp(r' ?\(experiment (?<name>[\w\-]+)\)');
+  
+  /// Matches a language version on a format test output line.
+  static final _languageVersionRE = RegExp(r'(?<=^<<< )\d+\.\d+\b');
+
+  bool _updateTest(File testFile) {
+    var source = files.load(testFile);
+    if (!source.contains('(experiment ')) return false;
+    // Experiments can be written in two places:
+    // - at top, after first line, as a lone of `(experiment exp-name)`
+    //   in which case it applies to every test.
+    // - on individual test as `>>> (experiment exp-name) Test name`
+    //   where it only applies to that test.
+    //
+    // Language version can occur after first part of source
+    // - `<<< 3.8 optional description`
+
+    var output = <String>[];
+    // Set when an enabled experiment is removed from the header,
+    // and the feature requires this version.
+    // Is the *minimum language version* allowed for tests in the file.
+    Version? globalVersion;
+    // Set when an enabled experiment is removed from a single test.
+    // Cleared when the next test starts.
+    Version? localVersion;
+    var inHeader = true;
+    var change = false;
+    for (var line in LineSplitter.split(source)) {
+      if (line.startsWith('>>>')) {
+        inHeader = false;
+        localVersion = null;
+      }
+      if (line.startsWith('<<<')) {
+        if (_languageVersionRE.firstMatch(line) case var m?) {
+          var minVersion = localVersion ?? globalVersion;
+          if (minVersion != null) {
+            var lineVersion = Version.parse(m[0]!);
+            if (lineVersion < minVersion) {
+              change = true;
+              line = line.replaceRange(m.start, m.end, minVersion.toString());
+            }
+          }
+        } else {
+          // If we have a minimum version imposed by a removed experiment,
+          // put it on any output that doesn't have a version.
+          var minVersion = localVersion ?? globalVersion;
+          if (minVersion != null) {
+            line = line.replaceRange(3, 3, ' $minVersion');
+            change = true;
+          }
+        }
+      } else if (line.isNotEmpty) {
+        line = line.replaceAllMapped(_experimentRE, (m) {
+          m as RegExpMatch;
+          var experimentName = m.namedGroup('name')!;
+          var release = experiments[experimentName];
+          if (release == null || release > currentVersion) {
+            // Not released yet.
+            if (!experiments.containsKey(experimentName)) {
+              stderr.writeln(
+                'Unrecognized experiment name "$experimentName"'
+                ' in ${testFile.path}',
+              );
+            }
+            return m[0]!; // Keep experiment.
+          }
+          // Remove the experiment entry, the experiment is released.
+          // Ensure language level, if specified, is high enough to enable
+          // the feature without a flag.
+          var currentMinVersion = localVersion ?? globalVersion;
+          if (currentMinVersion == null || release > currentMinVersion) {
+            if (inHeader) {
+              globalVersion = release;
+            } else {
+              localVersion = release;
+            }
+          }
+          change = true;
+          return '';
+        });
+        // Top-level experiment lines only,
+        if (line.isEmpty) continue;
+      }
+      output.add(line);
+    }
+    if (change) {
+      if (output.isNotEmpty && output.last.isNotEmpty) {
+        output.add(''); // Make sure to have final newline.
+      }
+      files.save(testFile, output.join('\n'));
+      return true;
+    }
+    return false;
+  }
+}
+
+// --------------------------------------------------------------------
+// Parse the `experimental_features.yaml` file to find experiments
+// and their 'enabled' version.
+Map<String, Version?> _parseExperiments(File experimentsFile) {
+  var result = <String, Version?>{};
+  var yaml =
+      y.loadYaml(
+            experimentsFile.readAsStringSync(),
+            sourceUrl: experimentsFile.uri,
+          )
+          as y.YamlMap;
+  var features = yaml['features'] as y.YamlMap;
+  for (var MapEntry(key: name as String, value: info as y.YamlMap)
+      in features.entries) {
+    Version? version;
+    if (info['enabledIn'] case String enabledString) {
+      version = Version.tryParse(enabledString);
+    }
+    result[name] = version;
+  }
+  return result;
+}
+
+// --------------------------------------------------------------------
+// File system abstraction which caches changes, so they can be written
+// atomically at the end.
+
+class FileCache {
+  final int verbose;
+  final bool dryRun;
+  final Map<File, ({String content, bool changed})> _cache = {};
+
+  FileCache({this.verbose = 0, this.dryRun = false});
+
+  String load(File path) {
+    if (verbose > 0) {
+      var fromString =
+          verbose > 1
+              ? ' from ${_cache.containsKey(path) ? 'cache' : 'disk'}'
+              : '';
+      stdout.writeln('Reading ${path.path}$fromString.');
+    }
+
+    return (_cache[path] ??= (content: path.readAsStringSync(), changed: false))
+        .content;
+  }
+
+  void save(File path, String content) {
+    var existing = _cache[path];
+    if (verbose == 1) stdout.writeln('Saving ${path.path}.');
+    if (existing != null) {
+      if (existing.content == content) {
+        if (verbose > 2) stdout.writeln('Saving ${path.path} with no changes');
+        return;
+      }
+      if (verbose > 2) stdout.writeln('Save updates ${path.path}');
+    } else if (verbose > 2) {
+      stdout.writeln('Save ${path.path}, not in cache');
+    }
+    _cache[path] = (content: content, changed: true);
+  }
+
+  void flushSaves() {
+    var count = 0;
+    var prefix = dryRun ? 'Dry-run: ' : '';
+    _cache.updateAll((file, value) {
+      if (!value.changed) return value;
+      var content = value.content;
+      if (!dryRun) file.writeAsStringSync(content);
+      if (verbose > 1) {
+        stdout.writeln('${prefix}Flushing updated ${file.path}');
+      }
+      count++;
+      return (content: content, changed: false);
+    });
+    if (verbose > 0) {
+      if (count > 0) {
+        stdout.writeln(
+          '${prefix}Flushed $count changed file${_plural(count)}.',
+        );
+      } else if (verbose > 1) {
+        stdout.writeln('${prefix}Flushing file cache with no changed files.');
+      }
+    }
+  }
+}
+
+// --------------------------------------------------------------------
+// Find the root directory of the `dart_style` package.
+
+Directory _findStylePackageDir() {
+  var cwd = Directory.current;
+  if (_isStylePackageDir(cwd)) return cwd;
+  var scriptDir = p.dirname(p.absolute(p.fromUri(Platform.script)));
+  var scriptParentDir = Directory(p.dirname(scriptDir));
+  if (_isStylePackageDir(scriptParentDir)) return scriptParentDir;
+  var cursor = p.absolute(cwd.path);
+  while (true) {
+    var parentPath = p.dirname(cursor);
+    if (cursor == parentPath) break;
+    cursor = parentPath;
+    var directory = Directory(cursor);
+    if (_isStylePackageDir(directory)) return directory;
+  }
+  throw UnsupportedError(
+    "Couldn't find package root. Run from inside package.",
+  );
+}
+
+bool _isStylePackageDir(Directory directory) {
+  var pubspec = File(p.join(directory.path, 'pubspec.yaml'));
+  return pubspec.existsSync() &&
+      LineSplitter.split(pubspec.readAsStringSync()).first ==
+          'name: dart_style';
+}
+
+// --------------------------------------------------------------------
+// Find version and experiments file in SDK.
+
+File? findExperimentsFile(List<String> args) {
+  // Check if argument is SDK directory.
+  if (args.isNotEmpty) {
+    for (var arg in args) {
+      var directory = Directory(p.absolute(arg));
+      if (directory.existsSync()) {
+        if (_experimentsInSdkDirectory(directory) case var file?) {
+          return file;
+        }
+      }
+    }
+  }
+  // Try relative to `dart` executable.
+  var cursor = Platform.resolvedExecutable;
+  if (p.basenameWithoutExtension(cursor) == 'dart') {
+    while (true) {
+      var parent = p.dirname(cursor);
+      if (parent == cursor) break;
+      cursor = parent;
+      var directory = Directory(cursor);
+      if (_experimentsInSdkDirectory(directory) case var file?) {
+        return file;
+      }
+    }
+  }
+  return null;
+}
+
+File? _experimentsInSdkDirectory(Directory directory) {
+  var experimentsFile = File(
+    p.join(directory.path, 'tools', 'experimental_features.yaml'),
+  );
+  if (experimentsFile.existsSync()) return experimentsFile;
+  return null;
+}
+
+class Version implements Comparable<Version> {
+  final int major, minor;
+  Version(this.major, this.minor);
+
+  static Version max(Version v1, Version v2) => v1.compareTo(v2) >= 0 ? v1 : v2;
+
+  static Version min(Version v1, Version v2) => v1.compareTo(v2) <= 0 ? v1 : v2;
+
+  static Version parse(String version) =>
+      tryParse(version) ??
+      (throw FormatException('Not a version string', version));
+
+  static Version? tryParse(String version) {
+    var majorEnd = version.indexOf('.');
+    if (majorEnd < 0) return null;
+    var minorEnd = version.indexOf('.', majorEnd + 1);
+    if (minorEnd < 0) minorEnd = version.length; // Accept `3.5`.
+    var major = int.tryParse(version.substring(0, majorEnd));
+    if (major == null) return null;
+    var minor = int.tryParse(version.substring(majorEnd + 1, minorEnd));
+    if (minor == null) return null;
+    return Version(major, minor);
+  }
+
+  @override
+  int compareTo(Version other) {
+    var delta = major.compareTo(other.major);
+    if (delta == 0) delta = minor.compareTo(other.minor);
+    return delta;
+  }
+
+  @override
+  int get hashCode => Object.hash(major, minor);
+  @override
+  bool operator ==(Object other) =>
+      other is Version && major == other.major && minor == other.minor;
+  @override
+  String toString() => '$major.$minor';
+
+  bool operator <(Version other) =>
+      major < other.major || major == other.major && minor < other.minor;
+  bool operator <=(Version other) =>
+      major < other.major || major == other.major && minor <= other.minor;
+  bool operator >(Version other) => other < this;
+  bool operator >=(Version other) => other <= this;
+}
+
+/// Trailing `'s'` if number is not `1`.
+String _plural(int number) => number == 1 ? '' : 's';
+
+final String usage = '''
+dart tool/update_sdk.dart [-v] [-n] [VERSION] [SDKDIR]
+
+Run from inside dart_style directory to be sure to be able to find it.
+Uses path to `dart` executable to look for SDK directory.
+
+VERSION  SemVer or `major.minor` version.
+         If provided, use that as SDK version in pubspec.yaml.
+SDKDIR   Path to SDK repository containing experimental_features.yaml file.
+         Will be searched for if not provided.
+
+-v       Verbosity. Can be used multiple times.
+-n       Dryrun. If set, does not write changed files back. 
+''';
+
+void exit(int value) {
+  // ignore: only_throw_errors
+  throw (exitCode: value);
+}

--- a/tool/update_sdk.dart
+++ b/tool/update_sdk.dart
@@ -26,7 +26,9 @@ void main(List<String> args) {
       bool dryRun,
       File? experimentsFile,
       Version? targetVersion,
-    ) = _parseArguments(args);
+    ) = _parseArguments(
+      args,
+    );
 
     var stylePackageDir = _findStylePackageDir();
     if (verbose > 0) {
@@ -147,6 +149,7 @@ class Updater {
   final Directory root;
   final Version currentVersion;
   final int verbose;
+  final bool dryRun;
   final Map<String, Version?> experiments;
   final FileEditor files;
   Updater(
@@ -154,13 +157,18 @@ class Updater {
     this.currentVersion,
     this.experiments, {
     this.verbose = 0,
-    bool dryRun = false,
+    this.dryRun = false,
   }) : files = FileEditor(verbose: verbose - 1, dryRun: dryRun);
 
   void run() {
-    _updatePubspec();
+    var updatedPubspecVersion = _updatePubspec();
     _updateTests();
     files.flushChanges();
+    if (updatedPubspecVersion && !dryRun) {
+      stdout.writeln(
+        'Updated PubSpec version. Run `dart pub get` and `dart format`.',
+      );
+    }
   }
 
   bool _updatePubspec() {

--- a/tool/update_sdk.dart
+++ b/tool/update_sdk.dart
@@ -30,12 +30,7 @@ import 'package:yaml/yaml.dart' as y;
 
 void main(List<String> args) {
   try {
-    var (
-      int verbose,
-      bool dryRun,
-      File? experimentsFile,
-      Version? targetVersion,
-    ) = _parseArguments(
+    var (verbose, dryRun, experimentsFile, targetVersion) = _parseArguments(
       args,
     );
     var stylePackageDir = _findStylePackageDir();
@@ -105,15 +100,13 @@ void main(List<String> args) {
       verbose: verbose,
       dryRun: dryRun,
     ).run();
-  } catch (e) {
+  } on ExitException catch (e) {
     // Flush output before actually exiting.
-    if (e case (:int exitCode)) {
-      stdout.flush().then((_) {
-        stderr.flush().then((_) {
-          io.exit(exitCode);
-        });
+    stdout.flush().then((_) {
+      stderr.flush().then((_) {
+        io.exit(e.exitCode);
       });
-    }
+    });
   }
 }
 
@@ -438,7 +431,6 @@ class Updater {
   File experimentsFile,
   Version? targetVersion,
 ) {
-  var result = <String, Version?>{};
   var yaml =
       y.loadYaml(
             experimentsFile.readAsStringSync(),
@@ -462,6 +454,7 @@ class Updater {
     );
   }
   var features = yaml['features'] as y.YamlMap;
+  var result = <String, Version?>{};
   for (var MapEntry(key: name as String, value: info as y.YamlMap)
       in features.entries) {
     Version? version;
@@ -600,7 +593,7 @@ Directory _findStylePackageDir() {
   var scriptParentDir = Directory(p.dirname(scriptDir));
   if (_isStylePackageDir(scriptParentDir)) return scriptParentDir;
   // Check ancestor directories of current directory,
-  // if run from, fx, inside `<pkgRoot>/tool/`.
+  // if run from, for example, inside `<pkgRoot>/tool/`.
   var cursor = p.absolute(cwd.path);
   while (true) {
     var parentPath = p.dirname(cursor);
@@ -738,6 +731,11 @@ PATH     Path to "experimental_features.yaml" or to an SDK repository containing
 
 /// Caught by [main] to flush output before actually exiting.
 Never exit(int value) {
-  // ignore: only_throw_errors
-  throw (exitCode: value);
+  throw ExitException(exitCode);
+}
+
+/// Thrown by [exit] and caught my [main] to ensure clean-up.
+class ExitException implements Exception {
+  final int exitCode;
+  ExitException(this.exitCode);
 }


### PR DESCRIPTION
Re: https://github.com/dart-lang/dart_style/pull/1779#issuecomment-3460959291

I made a script to remove experiments from tests, and update the min-SDK version.

I haven't figured out how to find the matching analyzer package and update that in pubspec as well.
May need to run `dart pub upgrade` after running this script, or manually updating the analyzer package
to a version that supports the new language version without experiment flags.