### PR TITLE
Remove uses of internal analyzer implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.4-wip
+
+* Remove dependencies on analyzer internal implementation.
+
 ## 3.1.3
 
 * No longer format imports with configurations and a prefix in the wrong order.

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '3.1.3';
+const dartStyleVersion = '3.1.4';
 
 /// Global options parsed from the command line that affect how the formatter
 /// produces and uses its outputs.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.1.3
+version: 3.1.4-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
In the very rare case that a user called formatStatement() and gave the formatter something longer than a single statement, we need to throw a FormatException but don't actually have a diagnostic from the analyzer to use.

To deal with that, it used to import some internal implementation libraries in order to conjure up a diagnostic. Instead, this has a local implementation of the necessary public analyzer classes.

This will avoid dart_style being broken with analyzer 9.0.0 when that internal code changes.
