### PR TITLE
Test that private named initializing formals can be formatted.

### DIFF
--- a/test/tall/declaration/constructor_parameter.unit
+++ b/test/tall/declaration/constructor_parameter.unit
@@ -91,3 +91,23 @@ class A {
 class A {
   A(covariant this.foo);
 }
+>>> Private named initializing formal.
+class A {
+  A({this._x, required this._y, int? this._z});
+
+  int? _x;
+  int? _y;
+  int? _z;
+}
+<<<
+class A {
+  A({
+    this._x,
+    required this._y,
+    int? this._z,
+  });
+
+  int? _x;
+  int? _y;
+  int? _z;
+}


### PR DESCRIPTION
This covers half of #1772, but I'll leave that open until primary constructors are implemented too so that I can ensure that we can format declaring field parameters as well.

It looks like the parser already allows private named parameters (the error is reported later in semantic analysis) so it's working without any formatter changes.