### PR TITLE
Fix package resolution error to include file path (Fixes #1797)

### DIFF
--- a/lib/src/analysis_options/analysis_options_file.dart
+++ b/lib/src/analysis_options/analysis_options_file.dart
@@ -85,13 +85,14 @@ Future<AnalysisOptions> readAnalysisOptions(
           include = filePath;
         } else {
           throw PackageResolutionException(
-            'Failed to resolve package URI "$include" in include.',
+            'Failed to resolve package URI "$include" in include at '
+            '"$optionsPath".',
           );
         }
       } else {
         throw PackageResolutionException(
-          'Couldn\'t resolve package URI "$include" in include because '
-          'no package resolver was provided.',
+          'Couldn\'t resolve package URI "$include" in include at '
+          '"$optionsPath" because no package resolver was provided.',
         );
       }
     }

--- a/test/analysis_options/analysis_options_file_test.dart
+++ b/test/analysis_options/analysis_options_file_test.dart
@@ -223,7 +223,16 @@ void main() {
           TestFileSystemPath('options.yaml'),
           resolvePackageUri: failingResolver,
         ),
-        throwsA(isA<PackageResolutionException>()),
+        throwsA(
+          isA<PackageResolutionException>().having(
+            (error) => error.toString(),
+            'message',
+            allOf(
+              contains('package:foo/options.yaml'),
+              contains('include at "options.yaml"'),
+            ),
+          ),
+        ),
       );
     });
   });


### PR DESCRIPTION
Fixes #1797

When `analysis_options.yaml` fails to resolve a package URI in an `include`, the current error message does not indicate which file triggered the error. This makes debugging difficult in mono-repos with multiple analysis option files.

This PR adds the file path (`optionsPath`) to the `PackageResolutionException` message.

**Changes:**
- Updated `readAnalysisOptions` to include `$optionsPath` in exception messages.
- Updated `analysis_options_file_test.dart` to verify the path is present in the error string.

**Output:**
- Before: `Failed to resolve package URI "..." in include.`
- After: `Failed to resolve package URI "..." in include at "path/to/analysis_options.yaml".`

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
