### PR TITLE
Fix IOFileSystemPath printing during package resolution exceptions

### DIFF
--- a/lib/src/analysis_options/io_file_system.dart
+++ b/lib/src/analysis_options/io_file_system.dart
@@ -48,4 +48,7 @@ final class IOFileSystemPath implements FileSystemPath {
   final String path;
 
   IOFileSystemPath._(this.path);
+
+  @override
+  String toString() => path;
 }

--- a/lib/src/analysis_options/io_file_system.dart
+++ b/lib/src/analysis_options/io_file_system.dart
@@ -27,7 +27,7 @@ final class IOFileSystem implements FileSystem {
   ) async {
     // Make [path] absolute (if not already) so that we can walk outside of the
     // literal path string passed.
-    var result = p.dirname(p.absolute(path.path));
+    var result = p.dirname(p.normalize(p.absolute(path.path)));
 
     // If the parent directory is the same as [path], we must be at the root.
     if (result == path.path) return null;

--- a/lib/src/config_cache.dart
+++ b/lib/src/config_cache.dart
@@ -148,7 +148,7 @@ final class ConfigCache {
       // Report the error, but use the default settings and keep going.
       stderr.writeln(
         'Warning: Package resolution error when reading '
-        '"analysis_options.yaml" file:\n$exception',
+        '"analysis_options.yaml" file for "${file.path}":\n$exception',
       );
     }
 

--- a/test/analysis_options/io_file_system_test.dart
+++ b/test/analysis_options/io_file_system_test.dart
@@ -93,6 +93,13 @@ void main() {
       expect(await parent(p.join('dir', 'sub')), p.absolute(p.join('dir')));
     });
 
+    test('normalizes path before getting parent', () async {
+      expect(
+        await parent(p.join('.', 'dir', 'sub')),
+        p.normalize(p.absolute('dir')),
+      );
+    });
+
     test('returns null at the root directory (POSIX)', () async {
       var rootPath = p.style == p.Style.posix ? '/' : 'C:\\';
       expect(await parent(rootPath), null);

--- a/test/analysis_options/io_file_system_test.dart
+++ b/test/analysis_options/io_file_system_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dart_style/src/analysis_options/analysis_options_file.dart';
 import 'package:dart_style/src/analysis_options/file_system.dart';
 import 'package:dart_style/src/analysis_options/io_file_system.dart';
 import 'package:path/path.dart' as p;
@@ -138,6 +139,33 @@ void main() {
           await fs.makePath(p.join(d.sandbox, 'dir', 'sub', 'another.txt')),
         ),
         'more',
+      );
+    });
+  });
+
+  group('readAnalysisOptions()', () {
+    test('reports path correctly in exception', () async {
+      await d.dir('dir', [
+        d.file('options.yaml', 'include: package:foo/options.yaml'),
+      ]).create();
+
+      var fs = IOFileSystem();
+      var path = await fs.makePath(p.join(d.sandbox, 'dir', 'options.yaml'));
+
+      Future<String?> failingResolver(Uri uri) async => null;
+
+      expect(
+        readAnalysisOptions(fs, path, resolvePackageUri: failingResolver),
+        throwsA(
+          isA<PackageResolutionException>().having(
+            (error) => error.toString(),
+            'message',
+            allOf(
+              contains('package:foo/options.yaml'),
+              contains('include at "${path.path}"'),
+            ),
+          ),
+        ),
       );
     });
   });

--- a/test/cli/page_width_test.dart
+++ b/test/cli/page_width_test.dart
@@ -142,10 +142,12 @@ void main() {
       'Warning: Package resolution error when reading '
       '"analysis_options.yaml" file for "$expectedPath":',
     );
+
+    var path = p.join(d.sandbox, 'dir', 'foo', 'analysis_options.yaml');
     expect(
       await process.stderr.next,
       'Failed to resolve package URI "package:not_bar/analysis_options.yaml" '
-      'in include at "${p.join(d.sandbox, 'dir', 'foo', 'analysis_options.yaml')}".',
+      'in include at "$path".',
     );
 
     await process.shouldExit(0);

--- a/test/cli/page_width_test.dart
+++ b/test/cli/page_width_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
@@ -134,6 +135,19 @@ void main() {
     ]).create();
 
     var process = await runFormatterOnDir();
+
+    var expectedPath = p.join('.', 'dir', 'foo', 'main.dart');
+    expect(
+      await process.stderr.next,
+      'Warning: Package resolution error when reading '
+      '"analysis_options.yaml" file for "$expectedPath":',
+    );
+    expect(
+      await process.stderr.next,
+      'Failed to resolve package URI "package:not_bar/analysis_options.yaml" '
+      'in include at "${p.join(d.sandbox, 'dir', 'foo', 'analysis_options.yaml')}".',
+    );
+
     await process.shouldExit(0);
 
     // Should format the file at 80.


### PR DESCRIPTION
The `IOFileSystemPath` object lacked a `toString()` method, leading to `Instance of 'IOFileSystemPath'` being rendered in error strings. When `PackageResolutionException` was thrown encountering package resolution errors while reading analysis options, the path output was masked.

This change adds `toString()` to `IOFileSystemPath` to output the correct underlying file system `.path`. A test is also added to `io_file_system_test.dart` preventing regressions.
