### PR TITLE
Require analyzer ^13.0.0, with breaking changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.9
+
+* Require `analyzer: ^13.0.0`.
+
 ## 3.1.8
 
 ### Style changes

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -12,6 +12,8 @@ extension AstNodeExtensions on AstNode {
   BlockFormat get blockFormatType => switch (this) {
     AdjacentStrings(indentStrings: true) => BlockFormat.indentedAdjacentStrings,
     AdjacentStrings() => BlockFormat.unindentedAdjacentStrings,
+    NamedArgument(:var argumentExpression) =>
+      argumentExpression.blockFormatType,
     Expression(:var blockFormatType) => blockFormatType,
     _ => BlockFormat.none,
   };
@@ -29,9 +31,6 @@ extension AstNodeExtensions on AstNode {
       // metadata.
       AnnotatedNode(metadata: [var annotation, ...]) => annotation.beginToken,
       AnnotatedNode(firstTokenAfterCommentAndMetadata: var token) => token,
-
-      // The inner [NormalFormalParameter] is an [AnnotatedNode].
-      DefaultFormalParameter(:var parameter) => parameter.firstNonCommentToken,
 
       // The inner [PatternVariableDeclaration] is an [AnnotatedNode].
       PatternVariableDeclarationStatement(:var declaration) =>
@@ -214,9 +213,6 @@ extension ExpressionExtensions on Expression {
   /// category it belongs to.
   BlockFormat get blockFormatType {
     return switch (this) {
-      // Unwrap named expressions to get the real expression inside.
-      NamedExpression(:var expression) => expression.blockFormatType,
-
       // Allow the target of a single-section cascade to be block formatted.
       CascadeExpression(:var target, :var cascadeSections)
           when cascadeSections.length == 1 && target.canBlockSplit =>
@@ -276,7 +272,7 @@ extension ExpressionExtensions on Expression {
   /// Whether this is an argument in an argument list with a trailing comma.
   bool get isTrailingCommaArgument {
     var parent = this.parent;
-    if (parent is NamedExpression) parent = parent.parent;
+    if (parent is NamedArgument) parent = parent.parent;
 
     return parent is ArgumentList && parent.arguments.hasCommaAfter;
   }
@@ -479,7 +475,8 @@ extension AdjacentStringsExtensions on AdjacentStrings {
 
       // Don't indent when following `:`.
       MapLiteralEntry(:var value) when value == this => false,
-      NamedExpression() => false,
+      NamedArgument() => false,
+      RecordLiteralNamedField() => false,
 
       // Don't indent when the body of a `=>` function.
       ExpressionFunctionBody() => false,
@@ -487,7 +484,7 @@ extension AdjacentStringsExtensions on AdjacentStrings {
     };
   }
 
-  bool _hasOtherStringArgument(List<Expression> arguments) => arguments.any(
+  bool _hasOtherStringArgument(Iterable<Argument> arguments) => arguments.any(
     (argument) => argument != this && argument is StringLiteral,
   );
 }

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '3.1.8';
+const dartStyleVersion = '3.1.9';
 
 /// Global options parsed from the command line that affect how the formatter
 /// produces and uses its outputs.

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -578,13 +578,6 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
   }
 
   @override
-  void visitDefaultFormalParameter(DefaultFormalParameter node) {
-    // Visit the inner parameter. It will then access its parent to extract the
-    // default value.
-    pieces.visit(node.parameter);
-  }
-
-  @override
   void visitDoStatement(DoStatement node) {
     pieces.token(node.doKeyword);
     pieces.space();
@@ -772,7 +765,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitFieldFormalParameter(FieldFormalParameter node) {
-    if (node.parameters case var parameters?) {
+    if (node.functionTypedSuffix case var functionTypedSuffix?) {
       // A function-typed field formal like:
       //
       //     C(this.fn(parameter));
@@ -781,15 +774,15 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
         fieldKeyword: node.thisKeyword,
         period: node.period,
         node.name,
-        node.typeParameters,
-        parameters,
-        node.question,
+        functionTypedSuffix.typeParameters,
+        functionTypedSuffix.formalParameters,
+        functionTypedSuffix.question,
         parameter: node,
       );
     } else {
       writeFormalParameter(
         node,
-        mutableKeyword: node.keyword,
+        mutableKeyword: node.constFinalOrVarKeyword,
         fieldKeyword: node.thisKeyword,
         period: node.period,
         node.type,
@@ -802,7 +795,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
   void visitFormalParameterList(FormalParameterList node) {
     // Find the first non-mandatory parameter (if there are any).
     var firstOptional = node.parameters.indexWhere(
-      (p) => p is DefaultFormalParameter,
+      (p) => p.isNamed || p.isOptionalPositional,
     );
 
     // If the parameter list is completely empty, write the brackets inline so
@@ -959,18 +952,6 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
       pieces.visit(node.parameters);
       pieces.token(node.semicolon);
     });
-  }
-
-  @override
-  void visitFunctionTypedFormalParameter(FunctionTypedFormalParameter node) {
-    writeFunctionType(
-      parameter: node,
-      node.returnType,
-      node.name,
-      node.typeParameters,
-      node.parameters,
-      node.question,
-    );
   }
 
   @override
@@ -1290,8 +1271,13 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitLabel(Label node) {
-    pieces.visit(node.label);
+    pieces.token(node.name);
     pieces.token(node.colon);
+  }
+
+  @override
+  void visitLabelReference(LabelReference node) {
+    pieces.token(node.name);
   }
 
   @override
@@ -1490,11 +1476,11 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
   }
 
   @override
-  void visitNamedExpression(NamedExpression node) {
-    writeAssignment(
-      node.name.label,
-      node.name.colon,
-      node.expression,
+  void visitNamedArgument(NamedArgument node) {
+    writeTokenAssignment(
+      node.name,
+      node.colon,
+      node.argumentExpression,
       rightHandSideContext: NodeContext.namedExpression,
     );
   }
@@ -1751,6 +1737,16 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
   }
 
   @override
+  void visitRecordLiteralNamedField(RecordLiteralNamedField node) {
+    writeTokenAssignment(
+      node.name,
+      node.colon,
+      node.fieldExpression,
+      rightHandSideContext: NodeContext.namedExpression,
+    );
+  }
+
+  @override
   void visitRecordPattern(RecordPattern node) {
     writeRecord(node.leftParenthesis, node.fields, node.rightParenthesis);
   }
@@ -1872,13 +1868,24 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
   }
 
   @override
-  void visitSimpleFormalParameter(SimpleFormalParameter node) {
-    writeFormalParameter(
-      node,
-      node.type,
-      node.name,
-      mutableKeyword: node.keyword,
-    );
+  void visitRegularFormalParameter(RegularFormalParameter node) {
+    if (node.functionTypedSuffix case var functionTypedSuffix?) {
+      writeFunctionType(
+        node.type,
+        node.name!,
+        functionTypedSuffix.typeParameters,
+        functionTypedSuffix.formalParameters,
+        functionTypedSuffix.question,
+        parameter: node,
+      );
+    } else {
+      writeFormalParameter(
+        node,
+        node.type,
+        node.name,
+        mutableKeyword: node.constFinalOrVarKeyword,
+      );
+    }
   }
 
   @override
@@ -1927,7 +1934,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitSuperFormalParameter(SuperFormalParameter node) {
-    if (node.parameters case var parameters?) {
+    if (node.functionTypedSuffix case var functionTypedSuffix?) {
       // A function-typed super parameter like:
       //
       //     C(super.fn(parameter));
@@ -1936,15 +1943,15 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
         fieldKeyword: node.superKeyword,
         period: node.period,
         node.name,
-        node.typeParameters,
-        parameters,
-        node.question,
+        functionTypedSuffix.typeParameters,
+        functionTypedSuffix.formalParameters,
+        functionTypedSuffix.question,
         parameter: node,
       );
     } else {
       writeFormalParameter(
         node,
-        mutableKeyword: node.keyword,
+        mutableKeyword: node.constFinalOrVarKeyword,
         fieldKeyword: node.superKeyword,
         period: node.period,
         node.type,

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -492,7 +492,7 @@ final class DelimitedListBuilder {
     if (candidateIndex == -1) return;
 
     // The block argument must be positional.
-    if (arguments[candidateIndex] is NamedExpression) return;
+    if (arguments[candidateIndex] is NamedArgument) return;
 
     // Only allow up to one trailing argument after the block argument. This
     // handles the common `tags` and `timeout` named arguments in `test()` and
@@ -514,7 +514,7 @@ final class DelimitedListBuilder {
     //     });
     if (candidateIndex == 1 &&
         arguments[1].blockFormatType == BlockFormat.function &&
-        arguments[0] is! NamedExpression) {
+        arguments[0] is! NamedArgument) {
       var firstArgumentFormatType = arguments[0].blockFormatType;
       if (firstArgumentFormatType
           case BlockFormat.unindentedAdjacentStrings ||

--- a/lib/src/front_end/expression_contents.dart
+++ b/lib/src/front_end/expression_contents.dart
@@ -49,15 +49,15 @@ class ExpressionContents {
   final List<_Contents> _stack = [_Contents(_Type.otherCall)];
 
   /// Begins tracking an argument list.
-  void beginCall(List<AstNode> arguments) {
+  void beginCall(List<Argument> arguments) {
     var type = _Type.otherCall;
 
     // Count the non-trivial named arguments in this call.
     var namedArguments = 0;
     for (var argument in arguments) {
-      if (argument is NamedExpression) {
+      if (argument is NamedArgument) {
         type = _Type.callWithNamedArgument;
-        if (!_isTrivial(argument.expression)) namedArguments++;
+        if (!_isTrivial(argument.argumentExpression)) namedArguments++;
       }
     }
 
@@ -66,7 +66,7 @@ class ExpressionContents {
 
   /// Ends the most recently begun call and returns `true` if its argument list
   /// should eagerly split.
-  bool endCall(List<Expression> arguments) {
+  bool endCall(List<Argument> arguments) {
     var contents = _end();
 
     // If there are "too many" named arguments in this call and the calls it

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -1475,6 +1475,10 @@ mixin PieceFactory {
   }
 
   /// Writes an assignment-like construct with a token on the left-hand side.
+  ///
+  /// This is used instead of [writeAssignment] when the left-hand side is a
+  /// [Token] (like the name of a named argument or record field) rather than
+  /// a full [AstNode].
   void writeTokenAssignment(
     Token leftHandSide,
     Token operator,

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -127,7 +127,7 @@ mixin PieceFactory {
   /// Writes a [ListPiece] for an argument list.
   void writeArguments(
     Token leftBracket,
-    List<Expression> arguments,
+    List<Argument> arguments,
     Token rightBracket,
   ) {
     // In 3.7, we don't support preserving trailing commas or eager splitting.
@@ -244,7 +244,7 @@ mixin PieceFactory {
   }
 
   /// Writes a piece for a `break` or `continue` statement.
-  void writeBreak(Token keyword, SimpleIdentifier? label, Token semicolon) {
+  void writeBreak(Token keyword, LabelReference? label, Token semicolon) {
     pieces.token(keyword);
     pieces.visit(label, spaceBefore: true);
     pieces.token(semicolon);
@@ -655,14 +655,9 @@ mixin PieceFactory {
     Token? fieldKeyword,
     Token? period,
   }) {
-    // If the parameter has a default value, the parameter node will be wrapped
-    // in a DefaultFormalParameter node containing the default.
     (Token separator, Expression value)? defaultValueRecord;
-    if (node.parent case DefaultFormalParameter(
-      :var separator?,
-      :var defaultValue?,
-    )) {
-      defaultValueRecord = (separator, defaultValue);
+    if (node.defaultClause case var defaultClause?) {
+      defaultValueRecord = (defaultClause.separator, defaultClause.value);
     }
 
     writeParameter(
@@ -830,7 +825,7 @@ mixin PieceFactory {
       var modifiers = [
         parameter?.requiredKeyword,
         parameter?.covariantKeyword,
-        if (parameter case FunctionTypedFormalParameter(:var keyword)) keyword,
+        parameter?.constFinalOrVarKeyword,
       ];
 
       void write() {
@@ -850,18 +845,15 @@ mixin PieceFactory {
         pieces.token(question);
       }
 
-      // If the type is a function-typed parameter with a default value, then
-      // grab the default value from the parent node and attach it to the
-      // function.
-      if (parameter?.parent case DefaultFormalParameter(
-        :var separator?,
-        :var defaultValue?,
-      )) {
+      if (parameter?.defaultClause case var defaultClause?) {
         var function = pieces.build(() {
           writeFunctionAndReturnType(modifiers, returnType, write);
         });
 
-        writeDefaultValue(function, (separator, defaultValue));
+        writeDefaultValue(function, (
+          defaultClause.separator,
+          defaultClause.value,
+        ));
       } else {
         writeFunctionAndReturnType(modifiers, returnType, write);
       }
@@ -1383,7 +1375,7 @@ mixin PieceFactory {
       //       ;
       //     }
       [PatternField(name: _?)] => const ListStyle(commas: Commas.trailing),
-      [NamedExpression()] => const ListStyle(commas: Commas.trailing),
+      [RecordLiteralNamedField()] => const ListStyle(commas: Commas.trailing),
 
       // Record types or patterns with a single positional field always have a
       // trailing comma to disambiguate from parenthesized expressions or
@@ -1469,6 +1461,58 @@ mixin PieceFactory {
 
     var leftPiece = pieces.build(() {
       pieces.visit(leftHandSide, context: leftHandSideContext);
+      if (operator.type != TokenType.COLON) pieces.space();
+      pieces.token(operator);
+    });
+
+    var rightPiece = nodePiece(
+      rightHandSide,
+      commaAfter: includeComma,
+      context: rightHandSideContext,
+    );
+
+    pieces.add(AssignPiece(leftPiece, rightPiece));
+  }
+
+  /// Writes an assignment-like construct with a token on the left-hand side.
+  void writeTokenAssignment(
+    Token leftHandSide,
+    Token operator,
+    AstNode rightHandSide, {
+    bool includeComma = false,
+    NodeContext rightHandSideContext = NodeContext.none,
+  }) {
+    if (style.is3Dot7) {
+      var canBlockSplitRight = switch (rightHandSide) {
+        Expression() => rightHandSide.canBlockSplit,
+        DartPattern() => rightHandSide.canBlockSplit,
+        _ => false,
+      };
+
+      var operatorPiece = pieces.build(() {
+        if (operator.type != TokenType.COLON) pieces.space();
+        pieces.token(operator);
+      });
+
+      var rightPiece = nodePiece(
+        rightHandSide,
+        commaAfter: includeComma,
+        context: NodeContext.assignment,
+      );
+
+      pieces.add(
+        AssignPiece3Dot7(
+          operatorPiece,
+          rightPiece,
+          left: tokenPiece(leftHandSide),
+          canBlockSplitRight: canBlockSplitRight,
+        ),
+      );
+      return;
+    }
+
+    var leftPiece = pieces.build(() {
+      pieces.token(leftHandSide);
       if (operator.type != TokenType.COLON) pieces.space();
       pieces.token(operator);
     });

--- a/lib/src/short/argument_list_visitor.dart
+++ b/lib/src/short/argument_list_visitor.dart
@@ -27,7 +27,7 @@ final class ArgumentListVisitor {
 
   /// All of the arguments, positional, named, and functions, in the argument
   /// list.
-  final List<Expression> _allArguments;
+  final List<Argument> _allArguments;
 
   /// The normal arguments preceding any block function arguments.
   final ArgumentSublist _arguments;
@@ -35,7 +35,7 @@ final class ArgumentListVisitor {
   /// The contiguous list of block function arguments, if any.
   ///
   /// Otherwise, this is `null`.
-  final List<Expression>? _functions;
+  final List<Argument>? _functions;
 
   /// If there are block function arguments, this is the arguments after them.
   ///
@@ -44,7 +44,7 @@ final class ArgumentListVisitor {
 
   /// Returns `true` if there is only a single positional argument.
   bool get _isSingle =>
-      _allArguments.length == 1 && _allArguments.single is! NamedExpression;
+      _allArguments.length == 1 && _allArguments.single is! NamedArgument;
 
   /// Whether this argument list has any arguments that should be formatted as
   /// blocks.
@@ -68,7 +68,7 @@ final class ArgumentListVisitor {
     SourceVisitor visitor,
     Token leftParenthesis,
     Token rightParenthesis,
-    List<Expression> arguments,
+    List<Argument> arguments,
   ) {
     var functionRange = _contiguousFunctions(arguments);
 
@@ -166,7 +166,7 @@ final class ArgumentListVisitor {
   /// should receive special formatting.
   ///
   /// Returns a list of (start, end] indexes if found, otherwise returns `null`.
-  static List<int>? _contiguousFunctions(List<Expression> arguments) {
+  static List<int>? _contiguousFunctions(List<Argument> arguments) {
     int? functionsStart;
     var functionsEnd = -1;
 
@@ -215,9 +215,9 @@ final class ArgumentListVisitor {
     // styles, it looks cleaner to treat them all like normal expressions so
     // that the named arguments line up.
     if (_isAllNamed(arguments.sublist(functionsStart, functionsEnd))) {
-      bool isNamedArrow(Expression expression) {
-        if (expression is! NamedExpression) return false;
-        expression = expression.expression;
+      bool isNamedArrow(Argument argument) {
+        if (argument is! NamedArgument) return false;
+        var expression = argument.argumentExpression;
 
         return expression is FunctionExpression &&
             expression.body is ExpressionFunctionBody;
@@ -236,13 +236,13 @@ final class ArgumentListVisitor {
   }
 
   /// Returns `true` if every expression in [arguments] is named.
-  static bool _isAllNamed(List<Expression> arguments) =>
-      arguments.every((argument) => argument is NamedExpression);
+  static bool _isAllNamed(List<Argument> arguments) =>
+      arguments.every((argument) => argument is NamedArgument);
 
-  /// Returns `true` if [expression] is a [FunctionExpression] with a non-empty
+  /// Returns `true` if [argument] is a [FunctionExpression] with a non-empty
   /// block body.
-  static bool _isBlockFunction(Expression expression) {
-    if (expression is NamedExpression) expression = expression.expression;
+  static bool _isBlockFunction(Argument argument) {
+    var expression = argument.argumentExpression;
 
     // Allow functions wrapped in dotted method calls like "a.b.c(() { ... })".
     if (expression is MethodInvocation) {
@@ -308,22 +308,22 @@ final class ArgumentListVisitor {
 /// In that case, there will be two of these.
 final class ArgumentSublist {
   /// The full argument list from the AST.
-  final List<Expression> _allArguments;
+  final List<Argument> _allArguments;
 
   /// If all positional arguments occur before all named arguments, then this
   /// contains the positional arguments, in order. Otherwise (there are no
   /// positional arguments or they are interleaved with named ones), this is
   /// empty.
-  final List<Expression> _positional;
+  final List<Argument> _positional;
 
   /// The named arguments, in order. If there are any named arguments that occur
   /// before positional arguments, then all arguments are treated as named and
   /// end up in this list.
-  final List<Expression> _named;
+  final List<Argument> _named;
 
   /// Maps each block argument, excluding functions, to the first token for that
   /// argument.
-  final Map<Expression, Token> _blocks;
+  final Map<Argument, Token> _blocks;
 
   /// The number of leading block arguments, excluding functions.
   ///
@@ -344,14 +344,14 @@ final class ArgumentSublist {
   Chunk? _previousSplit;
 
   factory ArgumentSublist(
-    List<Expression> allArguments,
-    List<Expression> arguments,
+    List<Argument> allArguments,
+    List<Argument> arguments,
   ) {
     var argumentLists = _splitArgumentLists(arguments);
     var positional = argumentLists[0];
     var named = argumentLists[1];
 
-    var blocks = <Expression, Token>{};
+    var blocks = <Argument, Token>{};
     for (var argument in arguments) {
       var bracket = _blockToken(argument);
       if (bracket != null) blocks[argument] = bracket;
@@ -447,7 +447,7 @@ final class ArgumentSublist {
 
   void _visitArguments(
     SourceVisitor visitor,
-    List<Expression> arguments,
+    List<Argument> arguments,
     ArgumentRule rule,
   ) {
     visitor.builder.startRule(rule);
@@ -481,7 +481,7 @@ final class ArgumentSublist {
   void _visitArgument(
     SourceVisitor visitor,
     ArgumentRule rule,
-    Expression argument,
+    Argument argument,
   ) {
     // If we're about to write a block argument, handle it specially.
     var argumentBlock = _blocks[argument];
@@ -503,7 +503,7 @@ final class ArgumentSublist {
       // are formatted like regular values when they appear in argument lists
       // even though they internally get block-like formatting.
       visitor.builder.startBlockArgumentNesting();
-    } else if (argument is! NamedExpression) {
+    } else if (argument is! NamedArgument) {
       // Edge case: Likewise, don't force the argument to split if there is
       // only a single positional one, like:
       //
@@ -512,11 +512,11 @@ final class ArgumentSublist {
       rule.disableSplitOnInnerRules();
     }
 
-    if (argument is NamedExpression) {
+    if (argument is NamedArgument) {
       visitor.visitNamedNode(
-        argument.name.label.token,
-        argument.name.colon,
-        argument.expression,
+        argument.name,
+        argument.colon,
+        argument.argumentExpression,
         rule as NamedRule,
       );
     } else {
@@ -528,7 +528,7 @@ final class ArgumentSublist {
     } else if (_allArguments.length > 1 ||
         _allArguments.first is RecordLiteral) {
       visitor.builder.endBlockArgumentNesting();
-    } else if (argument is! NamedExpression) {
+    } else if (argument is! NamedArgument) {
       rule.enableSplitOnInnerRules();
     }
 
@@ -546,18 +546,16 @@ final class ArgumentSublist {
   /// output.
   ///
   /// Returns a list of two lists: the positional arguments then the named ones.
-  static List<List<Expression>> _splitArgumentLists(
-    List<Expression> arguments,
-  ) {
-    var positional = <Expression>[];
-    var named = <Expression>[];
+  static List<List<Argument>> _splitArgumentLists(List<Argument> arguments) {
+    var positional = <Argument>[];
+    var named = <Argument>[];
     var inNamed = false;
     for (var argument in arguments) {
-      if (argument is NamedExpression) {
+      if (argument is NamedArgument) {
         inNamed = true;
       } else if (inNamed) {
         // Got a positional argument after a named one.
-        return [[], arguments];
+        return [<Argument>[], arguments];
       }
 
       if (inNamed) {
@@ -570,15 +568,13 @@ final class ArgumentSublist {
     return [positional, named];
   }
 
-  /// If [expression] can be formatted as a block, returns the token that opens
+  /// If [argument] can be formatted as a block, returns the token that opens
   /// the block, such as a collection's bracket.
   ///
   /// Block-formatted arguments can get special indentation to make them look
   /// more statement-like.
-  static Token? _blockToken(Expression expression) {
-    if (expression is NamedExpression) {
-      expression = expression.expression;
-    }
+  static Token? _blockToken(Argument argument) {
+    var expression = argument.argumentExpression;
 
     // TODO(rnystrom): Should we step into parenthesized expressions?
 

--- a/lib/src/short/argument_list_visitor.dart
+++ b/lib/src/short/argument_list_visitor.dart
@@ -555,7 +555,7 @@ final class ArgumentSublist {
         inNamed = true;
       } else if (inNamed) {
         // Got a positional argument after a named one.
-        return [<Argument>[], arguments];
+        return [[], arguments];
       }
 
       if (inNamed) {

--- a/lib/src/short/call_chain_visitor.dart
+++ b/lib/src/short/call_chain_visitor.dart
@@ -325,16 +325,12 @@ final class CallChainVisitor {
     // If the argument list has a trailing comma, treat it like a collection.
     if (argument.hasCommaAfter) return false;
 
-    if (argument is NamedExpression) {
-      argument = argument.expression;
-    }
-
     // TODO(rnystrom): This logic is similar (but not identical) to
     // ArgumentListVisitor.hasBlockArguments. They overlap conceptually and
     // both have their own peculiar heuristics. It would be good to unify and
     // rationalize them.
 
-    return _forcesSplit(argument);
+    return _forcesSplit(argument.argumentExpression);
   }
 
   /// Called when a [_MethodSelector] has written its name and is about to

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -174,7 +174,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
       //         "no extra"
       //         "indent";
       shouldNest = false;
-    } else if (parent is NamedExpression || parent is ExpressionFunctionBody) {
+    } else if (parent is NamedArgument || parent is ExpressionFunctionBody) {
       shouldNest = false;
     }
 
@@ -927,25 +927,6 @@ final class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
-  void visitDefaultFormalParameter(DefaultFormalParameter node) {
-    visit(node.parameter);
-    if (node.separator != null) {
-      builder.startSpan();
-      builder.nestExpression();
-
-      // The '=' separator is preceded by a space, ":" is not.
-      if (node.separator!.type == TokenType.EQ) space();
-      token(node.separator);
-
-      soloSplit(_assignmentCost(node.defaultValue!));
-      visit(node.defaultValue);
-
-      builder.unnest();
-      builder.endSpan();
-    }
-  }
-
-  @override
   void visitDoStatement(DoStatement node) {
     builder.nestExpression();
     token(node.doKeyword);
@@ -1213,17 +1194,36 @@ final class SourceVisitor extends ThrowingAstVisitor {
   void visitFieldFormalParameter(FieldFormalParameter node) {
     visitParameterMetadata(node.metadata, () {
       _beginFormalParameter(node);
-      token(node.keyword, after: space);
+      token(node.constFinalOrVarKeyword, after: space);
       visit(node.type);
       _separatorBetweenTypeAndVariable(node.type);
       token(node.thisKeyword);
       token(node.period);
       token(node.name);
-      visit(node.typeParameters);
-      visit(node.parameters);
-      token(node.question);
+      if (node.functionTypedSuffix case var functionTypedSuffix?) {
+        visit(functionTypedSuffix.typeParameters);
+        visit(functionTypedSuffix.formalParameters);
+        token(functionTypedSuffix.question);
+      }
       _endFormalParameter(node);
+      visit(node.defaultClause);
     });
+  }
+
+  @override
+  void visitFormalParameterDefaultClause(FormalParameterDefaultClause node) {
+    builder.startSpan();
+    builder.nestExpression();
+
+    // The '=' separator is preceded by a space, ":" is not.
+    if (node.separator.type == TokenType.EQ) space();
+    token(node.separator);
+
+    soloSplit(_assignmentCost(node.value));
+    visit(node.value);
+
+    builder.unnest();
+    builder.endSpan();
   }
 
   @override
@@ -1251,10 +1251,10 @@ final class SourceVisitor extends ThrowingAstVisitor {
     }
 
     var requiredParams = node.parameters
-        .where((param) => param is! DefaultFormalParameter)
+        .where((param) => !param.isNamed && !param.isOptionalPositional)
         .toList();
     var optionalParams = node.parameters
-        .whereType<DefaultFormalParameter>()
+        .where((param) => param.isNamed || param.isOptionalPositional)
         .toList();
 
     if (nestExpression) builder.nestExpression();
@@ -1578,18 +1578,11 @@ final class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
-  void visitFunctionTypedFormalParameter(FunctionTypedFormalParameter node) {
-    visitParameterMetadata(node.metadata, () {
-      modifier(node.requiredKeyword);
-      modifier(node.covariantKeyword);
-      visit(node.returnType, after: space);
-      // Try to keep the function's parameters with its name.
-      builder.startSpan();
-      token(node.name);
-      _visitParameterSignature(node.typeParameters, node.parameters);
-      token(node.question);
-      builder.endSpan();
-    });
+  void visitFunctionTypedFormalParameterSuffix(
+    FunctionTypedFormalParameterSuffix node,
+  ) {
+    _visitParameterSignature(node.typeParameters, node.formalParameters);
+    token(node.question);
   }
 
   @override
@@ -1939,8 +1932,13 @@ final class SourceVisitor extends ThrowingAstVisitor {
 
   @override
   void visitLabel(Label node) {
-    visit(node.label);
+    token(node.name);
     token(node.colon);
+  }
+
+  @override
+  void visitLabelReference(LabelReference node) {
+    token(node.name);
   }
 
   @override
@@ -2149,8 +2147,14 @@ final class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
-  void visitNamedExpression(NamedExpression node) {
-    visitNamedNode(node.name.label.token, node.name.colon, node.expression);
+  @override
+  void visitNamedArgument(NamedArgument node, [NamedRule? rule]) {
+    visitNamedNode(
+      node.name,
+      node.colon,
+      node.argumentExpression,
+      rule,
+    );
   }
 
   @override
@@ -2430,6 +2434,11 @@ final class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
+  void visitRecordLiteralNamedField(RecordLiteralNamedField node) {
+    visitNamedNode(node.name, node.colon, node.fieldExpression);
+  }
+
+  @override
   void visitRecordPattern(RecordPattern node) {
     _visitCollectionLiteral(
       node.leftParenthesis,
@@ -2592,17 +2601,34 @@ final class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
-  void visitSimpleFormalParameter(SimpleFormalParameter node) {
+  void visitRegularFormalParameter(RegularFormalParameter node) {
     visitParameterMetadata(node.metadata, () {
-      _beginFormalParameter(node);
+      if (node.functionTypedSuffix case var functionTypedSuffix?) {
+        modifier(node.requiredKeyword);
+        modifier(node.covariantKeyword);
+        visit(node.type, after: space);
+        // Try to keep the function's parameters with its name.
+        builder.startSpan();
+        token(node.name);
+        _visitParameterSignature(
+          functionTypedSuffix.typeParameters,
+          functionTypedSuffix.formalParameters,
+        );
+        token(functionTypedSuffix.question);
+        builder.endSpan();
+        visit(node.defaultClause);
+      } else {
+        _beginFormalParameter(node);
 
-      modifier(node.keyword);
+        modifier(node.constFinalOrVarKeyword);
 
-      visit(node.type);
-      if (node.name != null) _separatorBetweenTypeAndVariable(node.type);
-      token(node.name);
+        visit(node.type);
+        if (node.name != null) _separatorBetweenTypeAndVariable(node.type);
+        token(node.name);
 
-      _endFormalParameter(node);
+        _endFormalParameter(node);
+        visit(node.defaultClause);
+      }
     });
   }
 
@@ -2650,15 +2676,18 @@ final class SourceVisitor extends ThrowingAstVisitor {
   void visitSuperFormalParameter(SuperFormalParameter node) {
     visitParameterMetadata(node.metadata, () {
       _beginFormalParameter(node);
-      token(node.keyword, after: space);
+      token(node.constFinalOrVarKeyword, after: space);
       visit(node.type, after: split);
       token(node.superKeyword);
       token(node.period);
       token(node.name);
-      visit(node.typeParameters);
-      visit(node.parameters);
-      token(node.question);
+      if (node.functionTypedSuffix case var functionTypedSuffix?) {
+        visit(functionTypedSuffix.typeParameters);
+        visit(functionTypedSuffix.formalParameters);
+        token(functionTypedSuffix.question);
+      }
       _endFormalParameter(node);
+      visit(node.defaultClause);
     });
   }
 
@@ -3108,15 +3137,6 @@ final class SourceVisitor extends ThrowingAstVisitor {
   /// the surrounding named argument rule. That way, this can ensure that a
   /// split between the name and argument forces the argument list to split
   /// too.
-  void visitNamedArgument(NamedExpression node, [NamedRule? rule]) {
-    visitNamedNode(
-      node.name.label.token,
-      node.name.colon,
-      node.expression,
-      rule,
-    );
-  }
-
   /// Visits syntax of the form `identifier: <node>`: a named argument or a
   /// named record field.
   void visitNamedNode(
@@ -3646,14 +3666,16 @@ final class SourceVisitor extends ThrowingAstVisitor {
     // there are any).
     FormalParameter? lastRequired;
     for (var i = 0; i < parameters.parameters.length; i++) {
-      if (parameters.parameters[i] is DefaultFormalParameter) {
+      if (parameters.parameters[i].isNamed ||
+          parameters.parameters[i].isOptionalPositional) {
         if (i > 0) lastRequired = parameters.parameters[i - 1];
         break;
       }
     }
 
     // If all parameters are optional, put the "[" or "{" right after "(".
-    if (parameters.parameters.first is DefaultFormalParameter) {
+    if (parameters.parameters.first.isNamed ||
+        parameters.parameters.first.isOptionalPositional) {
       token(parameters.leftDelimiter);
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.1.8
+version: 3.1.9
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  analyzer: ^12.0.0
+  analyzer: ^13.0.0
   args: ^2.5.0
   collection: ^1.19.0
   package_config: ^2.1.0


### PR DESCRIPTION
This change refers to not yet published `analyzer 13.0.0`, because I cannot land corresponding [analyzer CL](https://dart-review.googlesource.com/c/sdk/+/488624) (and then publish) without pulling into the Dart SDK a version of `dart_style` (and `test`, see https://github.com/dart-lang/test/pull/2622) that is compatible with this breaking change version of the analyzer. So, I want to land this PR with a version of `dart_style` that is compatible with `analyzer 13.0.0` (to be), and the pull this git commit into [the CL](https://dart-review.googlesource.com/c/sdk/+/488624).

I tested it locally with
```yaml
dependency_overrides:
  _fe_analyzer_shared:
    path: /Users/scheglov/Source/Dart/sdk.git/sdk/pkg/_fe_analyzer_shared
  analyzer:
    path: /Users/scheglov/Source/Dart/sdk.git/sdk/pkg/analyzer
```
Obviously, GitHub bots will be red until `analyzer 13.0.0` is published.