### PR TITLE
Fix tests with final and/or var parameters.

### DIFF
--- a/test/tall/declaration/constructor_parameter.unit
+++ b/test/tall/declaration/constructor_parameter.unit
@@ -5,9 +5,27 @@ class Foo {
   Foo.optional([  this . a, int  this  . b   =  123  ]);
   Foo.named({ required   this . a, int  this  . b  = 123  });
 }
-<<<
+<<< 3.12
 class Foo {
   Foo(this.a, int this.b, final this.c);
+  Foo.optional([
+    this.a,
+    int this.b = 123,
+  ]);
+  Foo.named({
+    required this.a,
+    int this.b = 123,
+  });
+}
+>>> Initializing formal without final.
+class Foo {
+  Foo(this  .  a, int  this  .  b,  this  .  c);
+  Foo.optional([  this . a, int  this  . b   =  123  ]);
+  Foo.named({ required   this . a, int  this  . b  = 123  });
+}
+<<<
+class Foo {
+  Foo(this.a, int this.b, this.c);
   Foo.optional([
     this.a,
     int this.b = 123,
@@ -44,13 +62,31 @@ class Foo {
   Foo.optional([  super . a, int  super  . b   =  123  ]);
   Foo.named({ required   super . a, int  super  . b  = 123  });
 }
-<<<
+<<< 3.12
 class Foo {
   Foo(
     super.a,
     int super.b,
     final super.c,
   );
+  Foo.optional([
+    super.a,
+    int super.b = 123,
+  ]);
+  Foo.named({
+    required super.a,
+    int super.b = 123,
+  });
+}
+>>> Super parameter without final.
+class Foo {
+  Foo(super  .  a, int  super  .  b,  super  .  c);
+  Foo.optional([  super . a, int  super  . b   =  123  ]);
+  Foo.named({ required   super . a, int  super  . b  = 123  });
+}
+<<<
+class Foo {
+  Foo(super.a, int super.b, super.c);
   Foo.optional([
     super.a,
     int super.b = 123,

--- a/test/tall/function/parameter.unit
+++ b/test/tall/function/parameter.unit
@@ -28,7 +28,7 @@ function(int? callback()    ?  ) {}
 function(int? callback()?) {}
 >>> `var` and `final` keywords on parameters.
 function(var x, final y, final String z) {}
-<<<
+<<< 3.12
 function(
   var x,
   final y,

--- a/test/tall/regression/0000/0095.unit
+++ b/test/tall/regression/0000/0095.unit
@@ -3,11 +3,26 @@
       String message_str, [final String desc = '', final Map examples = const {
   }, String locale, String name, List<String> args, String meaning]) =>
       message_str;
-<<<
+<<< 3.12
   String lookupMessage(
     String message_str, [
     final String desc = '',
     final Map examples = const {},
+    String locale,
+    String name,
+    List<String> args,
+    String meaning,
+  ]) => message_str;
+>>> (indent 2) Without final
+  String lookupMessage(
+      String message_str, [String desc = '', Map examples = const {
+  }, String locale, String name, List<String> args, String meaning]) =>
+      message_str;
+<<<
+  String lookupMessage(
+    String message_str, [
+    String desc = '',
+    Map examples = const {},
     String locale,
     String name,
     List<String> args,

--- a/test/tall/regression/0200/0211.unit
+++ b/test/tall/regression/0200/0211.unit
@@ -24,8 +24,25 @@ void defineProperty(var obj, String property, var value) {
       '{value: #, enumerable: false, writable: true, configurable: true})',
       obj, property, value);
 }
-<<<
+<<< 3.12
 void defineProperty(var obj, String property, var value) {
+  JS(
+    'void',
+    'Object.defineProperty(#, #, '
+        '{value: #, enumerable: false, writable: true, configurable: true})',
+    obj,
+    property,
+    value,
+  );
+}
+>>> Without var
+void defineProperty(obj, String property, value) {
+  JS('void', 'Object.defineProperty(#, #, '
+      '{value: #, enumerable: false, writable: true, configurable: true})',
+      obj, property, value);
+}
+<<<
+void defineProperty(obj, String property, value) {
   JS(
     'void',
     'Object.defineProperty(#, #, '

--- a/test/tall/regression/0200/0237.unit
+++ b/test/tall/regression/0200/0237.unit
@@ -7,11 +7,30 @@ class Bar {
       });
   }
 }
-<<<
+<<< 3.12
 class Bar {
   void foo() {
     blah.method(someLongArgument, andAnotherOne, andAThirdOne, andOneMore).then(
       (var x) {
+        var y = x * 2;
+      },
+    );
+  }
+}
+>>> Without var
+class Bar {
+  void foo() {
+    blah.method(someLongArgument, andAnotherOne, andAThirdOne, andOneMore)
+      .then((x) {
+        var y = x * 2;
+      });
+  }
+}
+<<<
+class Bar {
+  void foo() {
+    blah.method(someLongArgument, andAnotherOne, andAThirdOne, andOneMore).then(
+      (x) {
         var y = x * 2;
       },
     );

--- a/test/tall/regression/1100/1107.unit
+++ b/test/tall/regression/1100/1107.unit
@@ -11,9 +11,31 @@ class SomeClassC extends SomeClassA {
           ),
         );
 }
-<<<
+<<< 3.12
 class SomeClassC extends SomeClassA {
   SomeClassC({required final String property1})
+    : super(
+        property1: property1,
+        property2: "abc",
+        complexProperty: SomeClassB("sdf", "dfg", "fgh"),
+      );
+}
+>>> Without final
+class SomeClassC extends SomeClassA {
+  SomeClassC({required String property1})
+      : super(
+          property1: property1,
+          property2: "abc",
+          complexProperty: SomeClassB(
+            "sdf",
+            "dfg",
+            "fgh",
+          ),
+        );
+}
+<<<
+class SomeClassC extends SomeClassA {
+  SomeClassC({required String property1})
     : super(
         property1: property1,
         property2: "abc",


### PR DESCRIPTION
Once we enable primary constructors by-default on 3.13, these tests will fail.
This CL pins the version of these tests to 3.12 and also has a copy without var/final for latest.