### PR TITLE
Support primary constructors in short style.

### DIFF
--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -599,13 +599,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
     modifier(node.mixinKeyword);
     token(node.classKeyword);
     space();
-    token(node.namePart.typeName);
-    visit(node.namePart.typeParameters);
-
-    var namePart = node.namePart;
-    if (namePart is PrimaryConstructorDeclaration) {
-      visit(namePart.formalParameters);
-    }
+    visit(node.namePart);
 
     visit(node.extendsClause);
     _visitClauses(node.withClause, node.implementsClause);
@@ -1024,8 +1018,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
     builder.nestExpression();
     token(node.enumKeyword);
     space();
-    token(node.namePart.typeName);
-    visit(node.namePart.typeParameters);
+    visit(node.namePart);
     _visitClauses(node.withClause, node.implementsClause);
     space();
 
@@ -2384,6 +2377,12 @@ final class SourceVisitor extends ThrowingAstVisitor {
     visit(node.typeParameters);
     visit(node.constructorName);
     visit(node.formalParameters);
+  }
+
+  @override
+  void visitNameWithTypeParameters(NameWithTypeParameters node) {
+    token(node.typeName);
+    visit(node.typeParameters);
   }
 
   @override

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -601,15 +601,24 @@ final class SourceVisitor extends ThrowingAstVisitor {
     space();
     token(node.namePart.typeName);
     visit(node.namePart.typeParameters);
+
+    var namePart = node.namePart;
+    if (namePart is PrimaryConstructorDeclaration) {
+      visit(namePart.formalParameters);
+    }
+
     visit(node.extendsClause);
     _visitClauses(node.withClause, node.implementsClause);
     visit(node.nativeClause, before: space);
-    space();
+    if (node.body is! EmptyClassBody) space();
 
     builder.unnest();
-    // TODO(scheglov): support for EmptyBody
-    var body = node.body as BlockClassBody;
-    _visitBody(body.leftBracket, body.members, body.rightBracket);
+    switch (node.body) {
+      case BlockClassBody body:
+        _visitBody(body.leftBracket, body.members, body.rightBracket);
+      case EmptyClassBody body:
+        token(body.semicolon);
+    }
   }
 
   @override
@@ -1166,12 +1175,16 @@ final class SourceVisitor extends ThrowingAstVisitor {
       space();
       visit(onClause.extendedType);
     }
-    space();
+    if (node.body is! EmptyClassBody) space();
+
     builder.unnest();
 
-    // TODO(scheglov): support for EmptyBody
-    var body = node.body as BlockClassBody;
-    _visitBody(body.leftBracket, body.members, body.rightBracket);
+    switch (node.body) {
+      case BlockClassBody body:
+        _visitBody(body.leftBracket, body.members, body.rightBracket);
+      case EmptyClassBody body:
+        token(body.semicolon);
+    }
   }
 
   @override
@@ -1189,11 +1202,14 @@ final class SourceVisitor extends ThrowingAstVisitor {
     visit(node.implementsClause);
     builder.endRule();
 
-    space();
+    if (node.body is! EmptyClassBody) space();
     builder.unnest();
-    // TODO(scheglov): support for EmptyBody
-    var body = node.body as BlockClassBody;
-    _visitBody(body.leftBracket, body.members, body.rightBracket);
+    switch (node.body) {
+      case BlockClassBody body:
+        _visitBody(body.leftBracket, body.members, body.rightBracket);
+      case EmptyClassBody body:
+        token(body.semicolon);
+    }
   }
 
   @override
@@ -2139,13 +2155,16 @@ final class SourceVisitor extends ThrowingAstVisitor {
     visit(node.implementsClause);
     builder.endRule();
 
-    space();
+    if (node.body is! EmptyClassBody) space();
 
     builder.unnest();
 
-    // TODO(scheglov): support for EmptyBody
-    var body = node.body as BlockClassBody;
-    _visitBody(body.leftBracket, body.members, body.rightBracket);
+    switch (node.body) {
+      case BlockClassBody body:
+        _visitBody(body.leftBracket, body.members, body.rightBracket);
+      case EmptyClassBody body:
+        token(body.semicolon);
+    }
   }
 
   @override

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -600,7 +600,6 @@ final class SourceVisitor extends ThrowingAstVisitor {
     token(node.classKeyword);
     space();
     visit(node.namePart);
-
     visit(node.extendsClause);
     _visitClauses(node.withClause, node.implementsClause);
     visit(node.nativeClause, before: space);
@@ -1169,7 +1168,6 @@ final class SourceVisitor extends ThrowingAstVisitor {
       visit(onClause.extendedType);
     }
     if (node.body is! EmptyClassBody) space();
-
     builder.unnest();
 
     switch (node.body) {

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -380,6 +380,59 @@ final class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
+  void visitBlockClassBody(BlockClassBody node) {
+    _visitBody(node.leftBracket, node.members, node.rightBracket);
+  }
+
+  @override
+  void visitBlockEnumBody(BlockEnumBody node) {
+    _beginBody(node.leftBracket, space: true);
+
+    visitCommaSeparatedNodes(node.constants, between: splitOrTwoNewlines);
+
+    // If there is a trailing comma, always force the constants to split.
+    var trailingComma = node.constants.last.commaAfter;
+    if (trailingComma != null) {
+      builder.forceRules();
+    }
+
+    // The ";" after the constants, which may occur after a trailing comma.
+    var afterConstants = node.constants.last.endToken.next!;
+    Token? semicolon;
+    if (afterConstants.type == TokenType.SEMICOLON) {
+      semicolon = node.constants.last.endToken.next!;
+    } else if (trailingComma != null &&
+        trailingComma.next!.type == TokenType.SEMICOLON) {
+      semicolon = afterConstants.next!;
+    }
+
+    if (semicolon != null) {
+      // If there is both a trailing comma and a semicolon, move the semicolon
+      // to the next line. This doesn't look great but it's less bad than being
+      // next to the comma.
+      // TODO(rnystrom): If the formatter starts making non-whitespace changes
+      // like adding/removing trailing commas, then it should fix this too.
+      if (trailingComma != null) newline();
+
+      token(semicolon);
+
+      // Put a blank line between the constants and members.
+      if (node.members.isNotEmpty) twoNewlines();
+    }
+
+    _visitBodyContents(node.members);
+
+    _endBody(
+      node.rightBracket,
+      forceSplit:
+          semicolon != null ||
+          trailingComma != null ||
+          node.members.isNotEmpty ||
+          node.constants.containsLineComments(),
+    );
+  }
+
+  @override
   void visitBlockFunctionBody(BlockFunctionBody node) {
     // Space after the parameter list.
     space();
@@ -603,6 +656,9 @@ final class SourceVisitor extends ThrowingAstVisitor {
     visit(node.extendsClause);
     _visitClauses(node.withClause, node.implementsClause);
     visit(node.nativeClause, before: space);
+    if (node.body is! EmptyClassBody) space();
+    builder.unnest();
+
     visit(node.body);
   }
 
@@ -972,6 +1028,16 @@ final class SourceVisitor extends ThrowingAstVisitor {
   }
 
   @override
+  void visitEmptyClassBody(EmptyClassBody node) {
+    token(node.semicolon);
+  }
+
+  @override
+  void visitEmptyEnumBody(EmptyEnumBody node) {
+    token(node.semicolon);
+  }
+
+  @override
   void visitEmptyFunctionBody(EmptyFunctionBody node) {
     token(node.semicolon);
   }
@@ -1012,59 +1078,10 @@ final class SourceVisitor extends ThrowingAstVisitor {
     visit(node.namePart);
     _visitClauses(node.withClause, node.implementsClause);
 
-    switch (node.body) {
-      case BlockEnumBody body:
-        space();
-        builder.unnest();
+    if (node.body is! EmptyEnumBody) space();
+    builder.unnest();
 
-        _beginBody(body.leftBracket, space: true);
-
-        visitCommaSeparatedNodes(body.constants, between: splitOrTwoNewlines);
-
-        // If there is a trailing comma, always force the constants to split.
-        var trailingComma = body.constants.last.commaAfter;
-        if (trailingComma != null) {
-          builder.forceRules();
-        }
-
-        // The ";" after the constants, which may occur after a trailing comma.
-        var afterConstants = body.constants.last.endToken.next!;
-        Token? semicolon;
-        if (afterConstants.type == TokenType.SEMICOLON) {
-          semicolon = body.constants.last.endToken.next!;
-        } else if (trailingComma != null &&
-            trailingComma.next!.type == TokenType.SEMICOLON) {
-          semicolon = afterConstants.next!;
-        }
-
-        if (semicolon != null) {
-          // If there is both a trailing comma and a semicolon, move the semicolon
-          // to the next line. This doesn't look great but it's less bad than being
-          // next to the comma.
-          // TODO(rnystrom): If the formatter starts making non-whitespace changes
-          // like adding/removing trailing commas, then it should fix this too.
-          if (trailingComma != null) newline();
-
-          token(semicolon);
-
-          // Put a blank line between the constants and members.
-          if (body.members.isNotEmpty) twoNewlines();
-        }
-
-        _visitBodyContents(body.members);
-
-        _endBody(
-          body.rightBracket,
-          forceSplit:
-              semicolon != null ||
-              trailingComma != null ||
-              body.members.isNotEmpty ||
-              body.constants.containsLineComments(),
-        );
-      case EmptyEnumBody body:
-        builder.unnest();
-        token(body.semicolon);
-    }
+    visit(node.body);
   }
 
   @override
@@ -1158,6 +1175,9 @@ final class SourceVisitor extends ThrowingAstVisitor {
       space();
       visit(onClause.extendedType);
     }
+    if (node.body is! EmptyClassBody) space();
+    builder.unnest();
+
     visit(node.body);
   }
 
@@ -1175,6 +1195,9 @@ final class SourceVisitor extends ThrowingAstVisitor {
     builder.startRule(CombinatorRule());
     visit(node.implementsClause);
     builder.endRule();
+
+    if (node.body is! EmptyClassBody) space();
+    builder.unnest();
 
     visit(node.body);
   }
@@ -2122,7 +2145,16 @@ final class SourceVisitor extends ThrowingAstVisitor {
     visit(node.implementsClause);
     builder.endRule();
 
+    if (node.body is! EmptyClassBody) space();
+    builder.unnest();
+
     visit(node.body);
+  }
+
+  @override
+  void visitNameWithTypeParameters(NameWithTypeParameters node) {
+    token(node.typeName);
+    visit(node.typeParameters);
   }
 
   @override
@@ -2342,12 +2374,6 @@ final class SourceVisitor extends ThrowingAstVisitor {
     visit(node.typeParameters);
     visit(node.constructorName);
     visit(node.formalParameters);
-  }
-
-  @override
-  void visitNameWithTypeParameters(NameWithTypeParameters node) {
-    token(node.typeName);
-    visit(node.typeParameters);
   }
 
   @override
@@ -3962,19 +3988,6 @@ final class SourceVisitor extends ThrowingAstVisitor {
     _beginBody(leftBracket);
     _visitBodyContents(nodes);
     _endBody(rightBracket, forceSplit: nodes.isNotEmpty);
-  }
-
-  @override
-  void visitBlockClassBody(BlockClassBody node) {
-    space();
-    builder.unnest();
-    _visitBody(node.leftBracket, node.members, node.rightBracket);
-  }
-
-  @override
-  void visitEmptyClassBody(EmptyClassBody node) {
-    builder.unnest();
-    token(node.semicolon);
   }
 
   static final _lineTerminatorRE = RegExp(r'\r\n?|\n');

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -603,15 +603,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
     visit(node.extendsClause);
     _visitClauses(node.withClause, node.implementsClause);
     visit(node.nativeClause, before: space);
-    if (node.body is! EmptyClassBody) space();
-
-    builder.unnest();
-    switch (node.body) {
-      case BlockClassBody body:
-        _visitBody(body.leftBracket, body.members, body.rightBracket);
-      case EmptyClassBody body:
-        token(body.semicolon);
-    }
+    visit(node.body);
   }
 
   @override
@@ -1019,61 +1011,60 @@ final class SourceVisitor extends ThrowingAstVisitor {
     space();
     visit(node.namePart);
     _visitClauses(node.withClause, node.implementsClause);
-    space();
 
-    builder.unnest();
+    switch (node.body) {
+      case BlockEnumBody body:
+        space();
+        builder.unnest();
 
-    // TODO(scheglov): support for EmptyEnumBody
-    var body = node.body as BlockEnumBody;
-    _beginBody(body.leftBracket, space: true);
+        _beginBody(body.leftBracket, space: true);
 
-    visitCommaSeparatedNodes(body.constants, between: splitOrTwoNewlines);
+        visitCommaSeparatedNodes(body.constants, between: splitOrTwoNewlines);
 
-    // If there is a trailing comma, always force the constants to split.
-    var trailingComma = body.constants.last.commaAfter;
-    if (trailingComma != null) {
-      builder.forceRules();
+        // If there is a trailing comma, always force the constants to split.
+        var trailingComma = body.constants.last.commaAfter;
+        if (trailingComma != null) {
+          builder.forceRules();
+        }
+
+        // The ";" after the constants, which may occur after a trailing comma.
+        var afterConstants = body.constants.last.endToken.next!;
+        Token? semicolon;
+        if (afterConstants.type == TokenType.SEMICOLON) {
+          semicolon = body.constants.last.endToken.next!;
+        } else if (trailingComma != null &&
+            trailingComma.next!.type == TokenType.SEMICOLON) {
+          semicolon = afterConstants.next!;
+        }
+
+        if (semicolon != null) {
+          // If there is both a trailing comma and a semicolon, move the semicolon
+          // to the next line. This doesn't look great but it's less bad than being
+          // next to the comma.
+          // TODO(rnystrom): If the formatter starts making non-whitespace changes
+          // like adding/removing trailing commas, then it should fix this too.
+          if (trailingComma != null) newline();
+
+          token(semicolon);
+
+          // Put a blank line between the constants and members.
+          if (body.members.isNotEmpty) twoNewlines();
+        }
+
+        _visitBodyContents(body.members);
+
+        _endBody(
+          body.rightBracket,
+          forceSplit:
+              semicolon != null ||
+              trailingComma != null ||
+              body.members.isNotEmpty ||
+              body.constants.containsLineComments(),
+        );
+      case EmptyEnumBody body:
+        builder.unnest();
+        token(body.semicolon);
     }
-
-    // The ";" after the constants, which may occur after a trailing comma.
-    var afterConstants = body.constants.last.endToken.next!;
-    Token? semicolon;
-    if (afterConstants.type == TokenType.SEMICOLON) {
-      semicolon = body.constants.last.endToken.next!;
-    } else if (trailingComma != null &&
-        trailingComma.next!.type == TokenType.SEMICOLON) {
-      semicolon = afterConstants.next!;
-    }
-
-    if (semicolon != null) {
-      // If there is both a trailing comma and a semicolon, move the semicolon
-      // to the next line. This doesn't look great but it's less bad than being
-      // next to the comma.
-      // TODO(rnystrom): If the formatter starts making non-whitespace changes
-      // like adding/removing trailing commas, then it should fix this too.
-      if (trailingComma != null) newline();
-
-      token(semicolon);
-
-      // Put a blank line between the constants and members.
-      if (body.members.isNotEmpty) twoNewlines();
-    }
-
-    _visitBodyContents(body.members);
-
-    _endBody(
-      body.rightBracket,
-      forceSplit:
-          semicolon != null ||
-          trailingComma != null ||
-          body.members.isNotEmpty ||
-          // If there is a line comment after an enum constant, it won't
-          // automatically force the enum body to split since the rule for
-          // the constants is the hard rule used by the entire block and its
-          // hardening state doesn't actually change. Instead, look
-          // explicitly for a line comment here.
-          body.constants.containsLineComments(),
-    );
   }
 
   @override
@@ -1167,15 +1158,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
       space();
       visit(onClause.extendedType);
     }
-    if (node.body is! EmptyClassBody) space();
-    builder.unnest();
-
-    switch (node.body) {
-      case BlockClassBody body:
-        _visitBody(body.leftBracket, body.members, body.rightBracket);
-      case EmptyClassBody body:
-        token(body.semicolon);
-    }
+    visit(node.body);
   }
 
   @override
@@ -1193,14 +1176,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
     visit(node.implementsClause);
     builder.endRule();
 
-    if (node.body is! EmptyClassBody) space();
-    builder.unnest();
-    switch (node.body) {
-      case BlockClassBody body:
-        _visitBody(body.leftBracket, body.members, body.rightBracket);
-      case EmptyClassBody body:
-        token(body.semicolon);
-    }
+    visit(node.body);
   }
 
   @override
@@ -2146,16 +2122,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
     visit(node.implementsClause);
     builder.endRule();
 
-    if (node.body is! EmptyClassBody) space();
-
-    builder.unnest();
-
-    switch (node.body) {
-      case BlockClassBody body:
-        _visitBody(body.leftBracket, body.members, body.rightBracket);
-      case EmptyClassBody body:
-        token(body.semicolon);
-    }
+    visit(node.body);
   }
 
   @override
@@ -3995,6 +3962,19 @@ final class SourceVisitor extends ThrowingAstVisitor {
     _beginBody(leftBracket);
     _visitBodyContents(nodes);
     _endBody(rightBracket, forceSplit: nodes.isNotEmpty);
+  }
+
+  @override
+  void visitBlockClassBody(BlockClassBody node) {
+    space();
+    builder.unnest();
+    _visitBody(node.leftBracket, node.members, node.rightBracket);
+  }
+
+  @override
+  void visitEmptyClassBody(EmptyClassBody node) {
+    builder.unnest();
+    token(node.semicolon);
   }
 
   static final _lineTerminatorRE = RegExp(r'\r\n?|\n');

--- a/test/short/splitting/classes.unit
+++ b/test/short/splitting/classes.unit
@@ -134,3 +134,20 @@ class TooLongClassName extends Another {}
 <<<
 class TooLongClassName
     extends Another {}
+>>> (experiment primary-constructors) Long primary constructor parameter list splits
+class LongClassName(final int veryLongParameterName, String anotherLongParameter) {}
+<<<
+class LongClassName(
+    final int veryLongParameterName,
+    String anotherLongParameter) {}
+>>> (experiment primary-constructors) Long const primary constructor splits
+class const LongClassName(final int veryLongParameterName, String anotherLongParameter);
+<<<
+class const LongClassName(
+    final int veryLongParameterName,
+    String anotherLongParameter);
+>>> (experiment primary-constructors) Primary constructor clauses split
+class C(int x, int y) extends LongBaseClass with Mixin {}
+<<<
+class C(int x, int y)
+    extends LongBaseClass with Mixin {}

--- a/test/short/splitting/type_parameters.unit
+++ b/test/short/splitting/type_parameters.unit
@@ -52,3 +52,9 @@ class Foo extends GenericBaseClass<TypeParameter> {}
 <<<
 class Foo extends GenericBaseClass<
     TypeParameter> {}
+>>> (experiment primary-constructors) Split type parameters with primary constructor and empty body
+class LongClassName<FirstTypeParameterIsLong, Second>(int x);
+<<<
+class LongClassName<
+    FirstTypeParameterIsLong,
+    Second>(int x);

--- a/test/short/whitespace/classes.unit
+++ b/test/short/whitespace/classes.unit
@@ -264,3 +264,7 @@ class C(var int x, final String y);
 class C(int x) /* comment */ ;
 <<<
 class C(int x) /* comment */;
+>>> (experiment primary-constructors) Const primary constructor
+class const C(final int x);
+<<<
+class const C(final int x);

--- a/test/short/whitespace/classes.unit
+++ b/test/short/whitespace/classes.unit
@@ -244,3 +244,23 @@ abstract mixin class C12 = Object
     with Mixin;
 abstract base mixin class C13 = Object
     with Mixin;
+>>> (experiment primary-constructors) Primary constructor with empty body
+class C(int x);
+<<<
+class C(int x);
+>>> (experiment primary-constructors) Primary constructor with block body
+class C(int x) {}
+<<<
+class C(int x) {}
+>>> (experiment primary-constructors) Abstract class with primary constructor and empty body
+abstract class C(int x);
+<<<
+abstract class C(int x);
+>>> (experiment primary-constructors) Primary constructor with multiple parameters and modifiers
+class C(var int x, final String y);
+<<<
+class C(var int x, final String y);
+>>> (experiment primary-constructors) Primary constructor with comment before semicolon
+class C(int x) /* comment */ ;
+<<<
+class C(int x) /* comment */;

--- a/test/short/whitespace/enums.unit
+++ b/test/short/whitespace/enums.unit
@@ -312,3 +312,24 @@ enum E {
 
   bar() {}
 }
+>>> (experiment primary-constructors) Enum with primary constructor and single constant
+enum E(final int x) { a(1) }
+<<<
+enum E(final int x) { a(1) }
+>>> (experiment primary-constructors) Enum with primary constructor and multiple constants
+enum E(final int x) { a(1), b(2) }
+<<<
+enum E(final int x) { a(1), b(2) }
+>>> (experiment primary-constructors) Enum with primary constructor and members
+enum E(final int x) { a(1), b(2); void foo() {} }
+<<<
+enum E(final int x) {
+  a(1),
+  b(2);
+
+  void foo() {}
+}
+>>> (experiment primary-constructors) Const enum with primary constructor
+enum const E(final int x) { a(1) }
+<<<
+enum const E(final int x) { a(1) }

--- a/test/short/whitespace/enums.unit
+++ b/test/short/whitespace/enums.unit
@@ -333,3 +333,11 @@ enum E(final int x) {
 enum const E(final int x) { a(1) }
 <<<
 enum const E(final int x) { a(1) }
+>>> (experiment primary-constructors) Enum with semicolon body
+enum E;
+<<<
+enum E;
+>>> (experiment primary-constructors) Enum with primary constructor and semicolon body
+enum E(int x);
+<<<
+enum E(int x);

--- a/test/short/whitespace/extension_types.unit
+++ b/test/short/whitespace/extension_types.unit
@@ -179,3 +179,11 @@ extension type const A<T>.name(int a) {
   int me(int x) => x;
   int operator +(int x) => x;
 }
+>>> (experiment primary-constructors) Extension type with empty body
+extension type E(int x);
+<<<
+extension type E(int x);
+>>> (experiment primary-constructors) Extension type with comment before semicolon
+extension type E(int x) /* comment */ ;
+<<<
+extension type E(int x) /* comment */;

--- a/test/short/whitespace/extensions.unit
+++ b/test/short/whitespace/extensions.unit
@@ -131,3 +131,11 @@ extension A on B {
 extension A on B {
   bar() {}
 }
+>>> (experiment primary-constructors) Extension with empty body
+extension A on B;
+<<<
+extension A on B;
+>>> (experiment primary-constructors) Extension with comment before semicolon
+extension A on B /* comment */ ;
+<<<
+extension A on B /* comment */;

--- a/test/short/whitespace/mixins.unit
+++ b/test/short/whitespace/mixins.unit
@@ -29,3 +29,11 @@ mixin M<A, B> on C implements D {}
 base  mixin M {}
 <<<
 base mixin M {}
+>>> (experiment primary-constructors) Mixin with empty body
+mixin M;
+<<<
+mixin M;
+>>> (experiment primary-constructors) Mixin with comment before semicolon
+mixin M /* comment */ ;
+<<<
+mixin M /* comment */;


### PR DESCRIPTION
A few SDK tests (`pkg/front_end/test/textual_outline/dartdevc/primary_constructors/abstract_class`) are crashing so I'm updating short style to handle primary constructors.

- Formatting of `;` bodies in classes, mixins, extensions, extension types, and enums.
- Refactored some of the visitors. `visitBlockEnumBody` was extracted from the enum declaration visitor. Added `NameWithTypeParameters` so we can visit the `namePart` for primary constructors and regular declarations.