### PR TITLE
Move directory formatting to a multi-threaded worker pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.9-wip
+
+* Move directory formatting to a multi-threaded worker pool. File I/O and
+  UTF-8 decoding are now performed in parallel on worker isolates.
+
 ## 3.1.8
 
 ### Style changes

--- a/lib/src/back_end/worker_pool.dart
+++ b/lib/src/back_end/worker_pool.dart
@@ -1,0 +1,296 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:pool/pool.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import '../dart_formatter.dart';
+import '../exceptions.dart';
+import '../source_code.dart';
+
+typedef _PendingRequest = ({
+  _WorkerRequest request,
+  void Function(WorkerResponse) callback,
+});
+
+/// A pool of long-lived isolates that can format Dart source code in parallel.
+final class WorkerPool {
+  /// The list of free worker ports.
+  final List<SendPort> _freeWorkers = [];
+
+  /// The pool to limit concurrency.
+  final Pool _pool;
+
+  /// Whether the pool is being shut down.
+  bool _isClosed = false;
+
+  /// Queue to buffer requests until we have a full batch.
+  final List<_PendingRequest> _pending = [];
+
+  static final _batchSize = _getBatchSize();
+
+  /// The number of requests currently in memory (pending or in flight).
+  int _inMemoryCount = 0;
+
+  /// The maximum number of requests allowed in memory before throttling.
+  final int _maxBacklog;
+
+  /// Completer to pause the producer when the backlog is full.
+  Completer<void>? _throttleCompleter;
+
+  /// Creates a worker pool with [size] isolates.
+  ///
+  /// If [size] is not given, defaults to the 'FORMAT_POOL_SIZE' environment
+  /// variable if set, otherwise [Platform.numberOfProcessors] - 1,
+  /// with a minimum of 1.
+  WorkerPool({int? size})
+    : _pool = Pool(size ?? _getPoolSize()),
+      _maxBacklog = _batchSize * ((size ?? _getPoolSize()) + 1) {
+    if (_batchSize < 1) {
+      throw ArgumentError('FORMAT_BATCH_SIZE must be >= 1, got $_batchSize');
+    }
+  }
+
+  /// Adds a request to the pool.
+  ///
+  /// The [onResult] callback will be called when this specific request is
+  /// complete.
+  ///
+  /// The returned [Future] completes when the pool has capacity to accept more
+  /// requests. If the pool's backlog grows too large, this method will pause
+  /// the caller to apply backpressure and prevent excessive memory usage from
+  /// eagerly reading file contents.
+  Future<void> add({
+    required String uri,
+    required Version languageVersion,
+    required int indent,
+    required int pageWidth,
+    required TrailingCommas? trailingCommas,
+    required List<String> experimentFlags,
+    required void Function(WorkerResponse) onResult,
+  }) async {
+    if (_isClosed) throw StateError('WorkerPool is closed');
+
+    if (_inMemoryCount >= _maxBacklog) {
+      _throttleCompleter ??= Completer<void>();
+      await _throttleCompleter!.future;
+    }
+
+    _inMemoryCount++;
+
+    var request = _WorkerRequest(
+      uri: uri,
+      languageVersion: languageVersion,
+      indent: indent,
+      pageWidth: pageWidth,
+      trailingCommas: trailingCommas,
+      experimentFlags: experimentFlags,
+    );
+
+    void wrappedCallback(WorkerResponse response) {
+      _inMemoryCount--;
+      if (_inMemoryCount < _maxBacklog && _throttleCompleter != null) {
+        var c = _throttleCompleter!;
+        _throttleCompleter = null;
+        c.complete();
+      }
+      onResult(response);
+    }
+
+    _pending.add((request: request, callback: wrappedCallback));
+
+    if (_pending.length >= _batchSize) {
+      _flush();
+    }
+  }
+
+  /// Sends a batch of requests to a worker.
+  void _flush() {
+    if (_pending.isEmpty) return;
+
+    var currentBatch = _pending.toList();
+    _pending.clear();
+
+    var requests = currentBatch.map((_PendingRequest e) => e.request).toList();
+
+    _formatBatch(requests)
+        .then((responses) {
+          for (var i = 0; i < currentBatch.length; i++) {
+            currentBatch[i].callback(responses[i]);
+          }
+        })
+        .catchError((Object e) {
+          for (var i = 0; i < currentBatch.length; i++) {
+            currentBatch[i].callback(WorkerResponse(error: e.toString()));
+          }
+        });
+  }
+
+  /// Spawns a new worker isolate.
+  Future<SendPort> _spawnWorker() async {
+    var completer = Completer<SendPort>();
+    var receivePort = ReceivePort();
+
+    receivePort.listen((message) {
+      if (message is SendPort) {
+        receivePort.close();
+        completer.complete(message);
+      }
+    });
+
+    await Isolate.spawn(_workerEntry, receivePort.sendPort);
+    return completer.future;
+  }
+
+  /// Formats a batch of files in a worker isolate.
+  Future<List<WorkerResponse>> _formatBatch(
+    List<_WorkerRequest> request,
+  ) async {
+    return _pool.withResource(() async {
+      var worker = _freeWorkers.isNotEmpty
+          ? _freeWorkers.removeLast()
+          : await _spawnWorker();
+      var responsePort = ReceivePort();
+
+      try {
+        worker.send((request, responsePort.sendPort));
+        var response = await responsePort.first;
+        return response as List<WorkerResponse>;
+      } finally {
+        responsePort.close();
+        if (_isClosed) {
+          worker.send(null); // Signal worker to exit.
+        } else {
+          _freeWorkers.add(worker);
+        }
+      }
+    });
+  }
+
+  /// Closes the pool and shuts down all worker isolates.
+  Future<void> close() async {
+    _isClosed = true;
+    _flush();
+    await _pool.close();
+    for (var worker in _freeWorkers) {
+      worker.send(null);
+    }
+    _freeWorkers.clear();
+  }
+
+  static void _workerEntry(SendPort mainSendPort) {
+    var receivePort = ReceivePort();
+    mainSendPort.send(receivePort.sendPort);
+
+    receivePort.listen((message) {
+      if (message == null) {
+        receivePort.close();
+        return;
+      }
+
+      var (requests, responseSendPort) =
+          message as (List<_WorkerRequest>, SendPort);
+      var responses = <WorkerResponse>[];
+
+      for (var request in requests) {
+        var formatter = DartFormatter(
+          languageVersion: request.languageVersion,
+          indent: request.indent,
+          pageWidth: request.pageWidth,
+          trailingCommas: request.trailingCommas,
+          experimentFlags: request.experimentFlags,
+        );
+
+        try {
+          var file = File(request.uri);
+          var sourceText = file.readAsStringSync();
+          var source = SourceCode(sourceText, uri: request.uri);
+          var output = formatter.formatSource(source);
+
+          responses.add(
+            WorkerResponse(
+              text: output.text,
+              selectionStart: output.selectionStart,
+              selectionLength: output.selectionLength,
+              changed: sourceText != output.text,
+            ),
+          );
+        } on FormatterException catch (err) {
+          responses.add(
+            WorkerResponse(error: err.message(), isFormatterException: true),
+          );
+        } catch (err, stack) {
+          responses.add(
+            WorkerResponse(error: err.toString(), stackTrace: stack.toString()),
+          );
+        }
+      }
+
+      responseSendPort.send(responses);
+    });
+  }
+}
+
+/// The parameters for a single formatting task.
+final class _WorkerRequest {
+  final String uri;
+  final Version languageVersion;
+  final int indent;
+  final int pageWidth;
+  final TrailingCommas? trailingCommas;
+  final List<String> experimentFlags;
+
+  _WorkerRequest({
+    required this.uri,
+    required this.languageVersion,
+    required this.indent,
+    required this.pageWidth,
+    required this.trailingCommas,
+    required this.experimentFlags,
+  });
+}
+
+/// The result of a single formatting task.
+final class WorkerResponse {
+  final String? text;
+  final int? selectionStart;
+  final int? selectionLength;
+  final String? error;
+  final String? stackTrace;
+  final bool isFormatterException;
+  final bool changed;
+
+  WorkerResponse({
+    this.text,
+    this.selectionStart,
+    this.selectionLength,
+    this.error,
+    this.stackTrace,
+    this.isFormatterException = false,
+    this.changed = false,
+  });
+}
+
+int _getPoolSize() {
+  var env = Platform.environment['FORMAT_POOL_SIZE'];
+  var n = Platform.numberOfProcessors;
+  var size = (n / 3).round();
+  if (env != null) {
+    size = int.tryParse(env) ?? size;
+  }
+  return size.clamp(1, 32);
+}
+
+int _getBatchSize() {
+  var env = Platform.environment['FORMAT_BATCH_SIZE'];
+  var size = 20;
+  if (env != null) {
+    size = int.tryParse(env) ?? size;
+  }
+  return size.clamp(1, 500);
+}

--- a/lib/src/back_end/worker_pool.dart
+++ b/lib/src/back_end/worker_pool.dart
@@ -41,7 +41,7 @@ final class WorkerPool {
   int _inMemoryCount = 0;
 
   /// The maximum number of requests allowed in memory before throttling.
-  final int _maxBacklog;
+  final int maxBacklog;
 
   /// Completer to pause the producer when the backlog is full.
   Completer<void>? _throttleCompleter;
@@ -53,7 +53,7 @@ final class WorkerPool {
   /// with a minimum of 1.
   WorkerPool({int? size})
     : _pool = Pool(size ?? _getPoolSize()),
-      _maxBacklog = _batchSize * ((size ?? _getPoolSize()) + 1) {
+      maxBacklog = _batchSize * ((size ?? _getPoolSize()) + 1) {
     if (_batchSize < 1) {
       throw ArgumentError('FORMAT_BATCH_SIZE must be >= 1, got $_batchSize');
     }
@@ -79,7 +79,7 @@ final class WorkerPool {
   }) async {
     if (_isClosed) throw StateError('WorkerPool is closed');
 
-    if (_inMemoryCount >= _maxBacklog) {
+    if (_inMemoryCount >= maxBacklog) {
       _throttleCompleter ??= Completer<void>();
       await _throttleCompleter!.future;
     }
@@ -97,7 +97,7 @@ final class WorkerPool {
 
     void wrappedCallback(WorkerResponse response) {
       _inMemoryCount--;
-      if (_inMemoryCount < _maxBacklog && _throttleCompleter != null) {
+      if (_inMemoryCount < maxBacklog && _throttleCompleter != null) {
         var c = _throttleCompleter!;
         _throttleCompleter = null;
         c.complete();

--- a/lib/src/back_end/worker_pool.dart
+++ b/lib/src/back_end/worker_pool.dart
@@ -32,6 +32,9 @@ final class WorkerPool {
   /// Queue to buffer requests until we have a full batch.
   final List<_PendingRequest> _pending = [];
 
+  /// List of futures for active batches to ensure we wait for them on close.
+  final List<Future<void>> _activeBatches = [];
+
   static final _batchSize = _getBatchSize();
 
   /// The number of requests currently in memory (pending or in flight).
@@ -118,17 +121,8 @@ final class WorkerPool {
 
     var requests = currentBatch.map((_PendingRequest e) => e.request).toList();
 
-    _formatBatch(requests)
-        .then((responses) {
-          for (var i = 0; i < currentBatch.length; i++) {
-            currentBatch[i].callback(responses[i]);
-          }
-        })
-        .catchError((Object e) {
-          for (var i = 0; i < currentBatch.length; i++) {
-            currentBatch[i].callback(WorkerResponse(error: e.toString()));
-          }
-        });
+    // Run the batch in the background. The pool will limit concurrency.
+    _formatBatch(requests, currentBatch);
   }
 
   /// Spawns a new worker isolate.
@@ -148,19 +142,27 @@ final class WorkerPool {
   }
 
   /// Formats a batch of files in a worker isolate.
-  Future<List<WorkerResponse>> _formatBatch(
-    List<_WorkerRequest> request,
+  Future<void> _formatBatch(
+    List<_WorkerRequest> requests,
+    List<_PendingRequest> batch,
   ) async {
-    return _pool.withResource(() async {
+    var future = _pool.withResource(() async {
       var worker = _freeWorkers.isNotEmpty
           ? _freeWorkers.removeLast()
           : await _spawnWorker();
       var responsePort = ReceivePort();
 
       try {
-        worker.send((request, responsePort.sendPort));
+        worker.send((requests, responsePort.sendPort));
         var response = await responsePort.first;
-        return response as List<WorkerResponse>;
+        var responses = response as List<WorkerResponse>;
+        for (var i = 0; i < batch.length; i++) {
+          batch[i].callback(responses[i]);
+        }
+      } catch (e) {
+        for (var i = 0; i < batch.length; i++) {
+          batch[i].callback(WorkerResponse(error: e.toString()));
+        }
       } finally {
         responsePort.close();
         if (_isClosed) {
@@ -170,12 +172,20 @@ final class WorkerPool {
         }
       }
     });
+
+    _activeBatches.add(future);
+    try {
+      await future;
+    } finally {
+      _activeBatches.remove(future);
+    }
   }
 
   /// Closes the pool and shuts down all worker isolates.
   Future<void> close() async {
     _isClosed = true;
     _flush();
+    await Future.wait(_activeBatches);
     await _pool.close();
     for (var worker in _freeWorkers) {
       worker.send(null);

--- a/lib/src/back_end/worker_pool.dart
+++ b/lib/src/back_end/worker_pool.dart
@@ -79,11 +79,6 @@ final class WorkerPool {
   }) async {
     if (_isClosed) throw StateError('WorkerPool is closed');
 
-    if (_inMemoryCount >= maxBacklog) {
-      _throttleCompleter ??= Completer<void>();
-      await _throttleCompleter!.future;
-    }
-
     _inMemoryCount++;
 
     var request = _WorkerRequest(
@@ -109,6 +104,11 @@ final class WorkerPool {
 
     if (_pending.length >= _batchSize) {
       _flush();
+    }
+
+    if (_inMemoryCount >= maxBacklog) {
+      _throttleCompleter ??= Completer<void>();
+      return _throttleCompleter!.future;
     }
   }
 

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+import 'back_end/worker_pool.dart';
 import 'cli/formatter_options.dart';
 import 'config_cache.dart';
 import 'dart_formatter.dart';
@@ -147,6 +148,8 @@ Future<bool> _processDirectory(
   );
   entries.sort((a, b) => a.path.compareTo(b.path));
 
+  var pool = WorkerPool();
+
   for (var entry in entries) {
     if (entry is Link) continue;
 
@@ -156,16 +159,60 @@ Future<bool> _processDirectory(
     var parts = p.split(p.relative(entry.path, from: directory.path));
     if (parts.any((part) => part.startsWith('.'))) continue;
 
-    if (!await _processFile(
-      cache,
-      options,
-      entry,
-      displayPath: p.normalize(entry.path),
-    )) {
-      success = false;
-    }
-  }
+    var displayPath = p.normalize(entry.path);
 
+    // Determine configuration in main isolate (leveraging cache).
+    var languageVersion =
+        options.languageVersion ??
+        await cache.findLanguageVersion(entry, displayPath);
+    languageVersion ??= DartFormatter.latestLanguageVersion;
+
+    var pageWidth = options.pageWidth ?? await cache.findPageWidth(entry);
+    var trailingCommas =
+        options.trailingCommas ?? await cache.findTrailingCommas(entry);
+    pageWidth ??= DartFormatter.defaultPageWidth;
+
+    options.beforeFile(entry, displayPath);
+
+    await pool.add(
+      uri: entry.path,
+      languageVersion: languageVersion,
+      indent: options.indent,
+      pageWidth: pageWidth,
+      trailingCommas: trailingCommas,
+      experimentFlags: options.experimentFlags,
+      onResult: (response) {
+        if (response.error != null) {
+          if (response.isFormatterException) {
+            stderr.writeln(response.error);
+          } else {
+            stderr.writeln(
+              'Hit a bug in the formatter when formatting $displayPath.\n'
+              '${response.error}\n'
+              '${response.stackTrace}',
+            );
+          }
+          success = false;
+          return;
+        }
+
+        var output = SourceCode(
+          response.text!,
+          uri: entry.path,
+          selectionStart: response.selectionStart,
+          selectionLength: response.selectionLength,
+        );
+
+        options.afterFile(
+          entry,
+          displayPath,
+          output,
+          changed: response.changed,
+        );
+      },
+    );
+  }
+  await pool.close();
   return success;
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.1.8
+version: 3.1.9-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.
@@ -14,6 +14,7 @@ dependencies:
   collection: ^1.19.0
   package_config: ^2.1.0
   path: ^1.9.0
+  pool: ^1.5.2
   pub_semver: ^2.1.4
   source_span: ^1.8.0
   yaml: ^3.1.2

--- a/test/cli/cli_test.dart
+++ b/test/cli/cli_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -82,6 +83,21 @@ void main() {
     await d.dir('code', [d.file('a.dart', 'herp derp i are a dart')]).create();
 
     var process = await runFormatterOnDir();
+    await process.shouldExit(65);
+  });
+
+  test('exits with 65 and prints stack trace on unexpected error', () async {
+    // Create a file with invalid UTF-8 bytes that will fail to decode.
+    await d.dir('code').create();
+    var file = File(p.join(d.sandbox, 'code', 'a.dart'));
+    file.writeAsBytesSync([0xFF, 0xFE, 0xFD]);
+
+    var process = await runFormatterOnDir();
+    
+    await expectLater(
+      process.stderr,
+      emitsThrough(contains('Hit a bug in the formatter')),
+    );
     await process.shouldExit(65);
   });
 

--- a/test/cli/cli_test.dart
+++ b/test/cli/cli_test.dart
@@ -93,7 +93,7 @@ void main() {
     file.writeAsBytesSync([0xFF, 0xFE, 0xFD]);
 
     var process = await runFormatterOnDir();
-    
+
     await expectLater(
       process.stderr,
       emitsThrough(contains('Hit a bug in the formatter')),

--- a/test/worker_pool_test.dart
+++ b/test/worker_pool_test.dart
@@ -17,7 +17,7 @@ void main() {
     // active.
     var testFile = 'test/worker_pool_test.dart';
 
-    for (var i = 0; i < 20; i++) {
+    for (var i = 0; i < pool.maxBacklog; i++) {
       unawaited(
         pool.add(
           uri: testFile,

--- a/test/worker_pool_test.dart
+++ b/test/worker_pool_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_style/src/back_end/worker_pool.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('WorkerPool.close waits for callbacks', () async {
+    var pool = WorkerPool(size: 1); // Pool size 1
+
+    // We cannot easily override the batch size via environment variables here
+    // because it is read once into a static final field in WorkerPool.
+    // Instead, we add enough tasks (20) to fill a default batch and make it
+    // active.
+    var testFile = 'test/worker_pool_test.dart';
+
+    for (var i = 0; i < 20; i++) {
+      await pool.add(
+        uri: testFile,
+        languageVersion: Version(3, 0, 0),
+        indent: 0,
+        pageWidth: 80,
+        trailingCommas: null,
+        experimentFlags: [],
+        onResult: (_) {},
+      );
+    }
+
+    // The first batch is now active and using the single pool resource.
+
+    var callbackCalled = false;
+    var success = true;
+
+    // Add one more task that will be queued since the pool is busy.
+    await pool.add(
+      uri: 'non_existent_file.dart',
+      languageVersion: Version(3, 0, 0),
+      indent: 0,
+      pageWidth: 80,
+      trailingCommas: null,
+      experimentFlags: [],
+      onResult: (response) {
+        callbackCalled = true;
+        if (response.error != null) {
+          success = false;
+        }
+      },
+    );
+
+    // Immediately close the pool. This flushes the pending request,
+    // which will be queued in the pool. We want to verify that close()
+    // waits for this queued request to complete its callback.
+    await pool.close();
+
+    // Verify that the callback was called and success was set to false.
+    expect(callbackCalled, isTrue, reason: 'Callback should be called');
+    expect(success, isFalse, reason: 'Success should be false on error');
+  });
+}

--- a/test/worker_pool_test.dart
+++ b/test/worker_pool_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'package:dart_style/src/back_end/worker_pool.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
@@ -17,14 +18,16 @@ void main() {
     var testFile = 'test/worker_pool_test.dart';
 
     for (var i = 0; i < 20; i++) {
-      await pool.add(
-        uri: testFile,
-        languageVersion: Version(3, 0, 0),
-        indent: 0,
-        pageWidth: 80,
-        trailingCommas: null,
-        experimentFlags: [],
-        onResult: (_) {},
+      unawaited(
+        pool.add(
+          uri: testFile,
+          languageVersion: Version(3, 0, 0),
+          indent: 0,
+          pageWidth: 80,
+          trailingCommas: null,
+          experimentFlags: [],
+          onResult: (_) {},
+        ),
       );
     }
 
@@ -34,19 +37,21 @@ void main() {
     var success = true;
 
     // Add one more task that will be queued since the pool is busy.
-    await pool.add(
-      uri: 'non_existent_file.dart',
-      languageVersion: Version(3, 0, 0),
-      indent: 0,
-      pageWidth: 80,
-      trailingCommas: null,
-      experimentFlags: [],
-      onResult: (response) {
-        callbackCalled = true;
-        if (response.error != null) {
-          success = false;
-        }
-      },
+    unawaited(
+      pool.add(
+        uri: 'non_existent_file.dart',
+        languageVersion: Version(3, 0, 0),
+        indent: 0,
+        pageWidth: 80,
+        trailingCommas: null,
+        experimentFlags: [],
+        onResult: (response) {
+          callbackCalled = true;
+          if (response.error != null) {
+            success = false;
+          }
+        },
+      ),
     );
 
     // Immediately close the pool. This flushes the pending request,


### PR DESCRIPTION
* Offload file I/O and UTF-8 decoding to worker isolates to improve performance.
* Implement a WorkerPool with batching and dynamic pool sizing (defaults to number of processors / 3).
* Only send formatted text back if it changed or if needed for output.
* Add test coverage for unexpected errors in worker isolates.
* Bump version to 3.1.9-wip.
