### PR TITLE
Update workflows and SDK constraint to 3.11.

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [3.10.0, dev]
+        sdk: [3.11.0, dev]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
@@ -50,7 +50,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [3.10.0, dev]
+        sdk: [3.11.0, dev]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Note: The following line of code is modified by tool/grind.dart.
-const dartStyleVersion = '3.1.9';
+const dartStyleVersion = '3.1.10';
 
 /// Global options parsed from the command line that affect how the formatter
 /// produces and uses its outputs.

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -2158,12 +2158,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
   @override
   @override
   void visitNamedArgument(NamedArgument node, [NamedRule? rule]) {
-    visitNamedNode(
-      node.name,
-      node.colon,
-      node.argumentExpression,
-      rule,
-    );
+    visitNamedNode(node.name, node.colon, node.argumentExpression, rule);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: dart_style
 # Note: See tool/grind.dart for how to bump the version.
-version: 3.1.9
+version: 3.1.10-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.
 repository: https://github.com/dart-lang/dart_style
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   analyzer: ^13.0.0


### PR DESCRIPTION
Now that dart_style requires analyzer 13.0.0, it doesn't work on older SDKs.
