### PR TITLE
Support block-formatting parameter lists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,53 @@
+## 3.1.10
+
+### Style changes
+
+* Support block-formatting parameter lists (#1693). The formatter supports
+  "block-formatting" for most bracket-delimited constructs in the language. This
+  is what enables a multi-line list literal in an assignment to look like this:
+
+  ```dart
+  variable = [
+    some,
+    list,
+    elements,
+  ];
+  ```
+
+  Instead of:
+
+  ```dart
+  variable =
+      [
+        some,
+        list,
+        elements,
+      ];
+  ```
+
+  This style applies to most language constructs, but function parameter lists
+  were omitted. Now they are not. This rarely shows up in real code, except for
+  typedefs for large function types:
+
+  ```dart
+  // Before:
+  typedef DataViewBuilder<T> =
+      Widget Function(
+        BuildContext context,
+        PagingState<int, T> state,
+        NextPageCallback fetchNextPage,
+      );
+
+  // After:
+  typedef DataViewBuilder<T> = Widget Function(
+    BuildContext context,
+    PagingState<int, T> state,
+    NextPageCallback fetchNextPage,
+  );
+  ```
+
+  This change is language versioned and only affects code at 3.13 or higher.
+
 ## 3.1.9
 
 * Require `analyzer: ^13.0.0`.

--- a/benchmark/case/curry_2.expect
+++ b/benchmark/case/curry_2.expect
@@ -1,16 +1,15 @@
 typedef Map1<T1, R> = R Function(T1 arg1);
 
-typedef Map8<T1, T2, T3, T4, T5, T6, T7, T8, R> =
-    R Function(
-      T1 arg1,
-      T2 arg2,
-      T3 arg3,
-      T4 arg4,
-      T5 arg5,
-      T6 arg6,
-      T7 arg7,
-      T8 arg8,
-    );
+typedef Map8<T1, T2, T3, T4, T5, T6, T7, T8, R> = R Function(
+  T1 arg1,
+  T2 arg2,
+  T3 arg3,
+  T4 arg4,
+  T5 arg5,
+  T6 arg6,
+  T7 arg7,
+  T8 arg8,
+);
 
 extension Curry8<T1, T2, T3, T4, T5, T6, T7, T8, R>
     on Map8<T1, T2, T3, T4, T5, T6, T7, T8, R> {

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -838,7 +838,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
         forceSplit: style.preserveTrailingCommaBefore(
           node.rightDelimiter ?? node.rightParenthesis,
         ),
-        blockShaped: node.parent is PrimaryConstructorDeclaration,
+        blockShaped: style.blockFormatParameterLists,
       ),
     );
   }

--- a/lib/src/front_end/formatting_style.dart
+++ b/lib/src/front_end/formatting_style.dart
@@ -15,6 +15,10 @@ import '../dart_formatter.dart';
 /// code whose language version is older than a style change will retain the
 /// older style.
 final class FormattingStyle {
+  static final _version3Dot7 = Version(3, 7, 0);
+  static final _version3Dot10 = Version(3, 10, 0);
+  static final _version3Dot13 = Version(3, 13, 0);
+
   /// The [DartFormatter] the style was created from.
   final DartFormatter _formatter;
 
@@ -41,7 +45,7 @@ final class FormattingStyle {
 
   /// Whether the code being formatted is at language version 3.7 and doesn't
   /// include the sweeping style changes in 3.8.
-  bool get is3Dot7 => _languageVersion == Version(3, 7, 0);
+  bool get is3Dot7 => _languageVersion == _version3Dot7;
 
   /// Whether a trailing comma should be preserved after for-loop updaters.
   bool get preserveTrailingCommaAfterForUpdaters =>
@@ -50,7 +54,7 @@ final class FormattingStyle {
   /// Whether a trailing comma should be preserved after enum values.
   bool get preserveTrailingCommaAfterEnumValues =>
       _formatter.trailingCommas == TrailingCommas.preserve &&
-      _languageVersion >= Version(3, 10, 0);
+      _languageVersion >= _version3Dot10;
 
   /// Whether mixin declarations and extension types with brace bodies should
   /// always get a blank line above and below them.
@@ -58,7 +62,10 @@ final class FormattingStyle {
   /// They always should have, but they were overlooked. We already do this for
   /// classes, enums, and extensions.
   bool get blankLineAroundMixinAndExtensionTypes =>
-      _languageVersion >= Version(3, 13, 0);
+      _languageVersion >= _version3Dot13;
+
+  /// Whether parameter lists should be block formatted in things like typedefs.
+  bool get blockFormatParameterLists => _languageVersion >= _version3Dot13;
 
   /// Whether there is a trailing comma at the end of the list delimited by
   /// [rightBracket] which should be preserved by this style.

--- a/test/tall/declaration/typedef.unit
+++ b/test/tall/declaration/typedef.unit
@@ -9,15 +9,20 @@ typedef  F  =  A  Function  <  A  ,  B  >  (  A  a  ,  B  b  )  ;
 typedef F = A Function<A, B>(A a, B b);
 >>> Split in function type parameter list.
 typedef   SomeFunc=ReturnType  Function(int param,   double other);
-<<<
+<<< 3.7
 typedef SomeFunc =
     ReturnType Function(
       int param,
       double other,
     );
+<<< 3.13
+typedef SomeFunc = ReturnType Function(
+  int param,
+  double other,
+);
 >>> Nested function type.
 typedef SomeFunc = Function(int first, Function(int first, bool second, String third) second, String third);
-<<<
+<<< 3.7
 typedef SomeFunc =
     Function(
       int first,
@@ -28,6 +33,28 @@ typedef SomeFunc =
       )
       second,
       String third,
+    );
+<<< 3.13
+typedef SomeFunc = Function(
+  int first,
+  Function(
+    int first,
+    bool second,
+    String third,
+  )
+  second,
+  String third,
+);
+>>> Split after `=` if return type doesn't fit.
+typedef SomeFunc = LongReturnType Function(
+  int param,
+  double other,
+);
+<<<
+typedef SomeFunc =
+    LongReturnType Function(
+      int param,
+      double other,
     );
 >>> Generic typedef.
 typedef  Foo  <  A  ,  B  >  =  Function  (  A  a  ,  B  b  )  ;
@@ -65,7 +92,7 @@ typedef G =
     );
 >>> Split typedef type parameters and function parameters.
 typedef LongfunctionType<First, Second, Third, Fourth, Fifth, Sixth> = Function<Seventh>(First first, Second second, Third third, Fourth fourth);
-<<<
+<<< 3.7
 typedef LongfunctionType<
   First,
   Second,
@@ -80,6 +107,20 @@ typedef LongfunctionType<
       Third third,
       Fourth fourth,
     );
+<<< 3.13
+typedef LongfunctionType<
+  First,
+  Second,
+  Third,
+  Fourth,
+  Fifth,
+  Sixth
+> = Function<Seventh>(
+  First first,
+  Second second,
+  Third third,
+  Fourth fourth,
+);
 >>> Split typedef type parameters.
 typedef LongfunctionType<First, Second, Third, Fourth, Fifth, Sixth> = Type;
 <<<

--- a/test/tall/function/default_value.unit
+++ b/test/tall/function/default_value.unit
@@ -52,13 +52,20 @@ f([callback() = constantFunction]) {}
 f([callback() = constantFunction]) {}
 >>> Split in function typed parameter parameter list with default value.
 f([callback(SomeLongType longParameter, AnotherType anotherParameter) = constantFunction]) {}
-<<<
+<<< 3.7
 f([
   callback(
         SomeLongType longParameter,
         AnotherType anotherParameter,
       ) =
       constantFunction,
+]) {}
+<<< 3.13
+f([
+  callback(
+    SomeLongType longParameter,
+    AnotherType anotherParameter,
+  ) = constantFunction,
 ]) {}
 >>> Split in function typed parameter default value.
 f([callback(SomeType parameter) = const CallableClass(someLongConstantArgument, anotherConstantArgument)]) {}

--- a/test/tall/preserve_trailing_commas/parameter.unit
+++ b/test/tall/preserve_trailing_commas/parameter.unit
@@ -34,11 +34,15 @@ function(
 }) {}
 >>> Trailing comma in function expression parameter list forces split.
 var f = (int i,) {};
-<<<
+<<< 3.7
 var f =
     (
       int i,
     ) {};
+<<< 3.13
+var f = (
+  int i,
+) {};
 >>> Trailing comma in old style function typed parameter list forces split.
 bool doStuff(void f(int i,)) {}
 <<<

--- a/test/tall/regression/1500/1521.unit
+++ b/test/tall/regression/1500/1521.unit
@@ -14,7 +14,7 @@ extension Curry8<T1, T2, T3, T4, T5, T6, T7, T8, R>
           (T5 arg5) => (T6 arg6) => (T7 arg7) =>
               (T8 arg8) => this(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
 }
-<<<
+<<< 3.7
 typedef Map1<T1, R> = R Function(T1 arg1);
 
 typedef Map8<T1, T2, T3, T4, T5, T6, T7, T8, R> =
@@ -28,6 +28,45 @@ typedef Map8<T1, T2, T3, T4, T5, T6, T7, T8, R> =
       T7 arg7,
       T8 arg8,
     );
+
+extension Curry8<T1, T2, T3, T4, T5, T6, T7, T8, R>
+    on Map8<T1, T2, T3, T4, T5, T6, T7, T8, R> {
+  Map1<
+    T1,
+    Map1<T2, Map1<T3, Map1<T4, Map1<T5, Map1<T6, Map1<T7, Map1<T8, R>>>>>>>
+  >
+  get curry =>
+      (T1 arg1) =>
+          (T2 arg2) =>
+              (T3 arg3) =>
+                  (T4 arg4) =>
+                      (T5 arg5) =>
+                          (T6 arg6) =>
+                              (T7 arg7) =>
+                                  (T8 arg8) => this(
+                                    arg1,
+                                    arg2,
+                                    arg3,
+                                    arg4,
+                                    arg5,
+                                    arg6,
+                                    arg7,
+                                    arg8,
+                                  );
+}
+<<< 3.13
+typedef Map1<T1, R> = R Function(T1 arg1);
+
+typedef Map8<T1, T2, T3, T4, T5, T6, T7, T8, R> = R Function(
+  T1 arg1,
+  T2 arg2,
+  T3 arg3,
+  T4 arg4,
+  T5 arg5,
+  T6 arg6,
+  T7 arg7,
+  T8 arg8,
+);
 
 extension Curry8<T1, T2, T3, T4, T5, T6, T7, T8, R>
     on Map8<T1, T2, T3, T4, T5, T6, T7, T8, R> {

--- a/test/tall/variable/local.stmt
+++ b/test/tall/variable/local.stmt
@@ -240,12 +240,18 @@ var variableName =
     ) {
       body;
     };
->>> Don't use block-like splitting for expression-bodied function expressions.
+>>> Block-like splitting for expression-bodied function expressions.
 var variableName = (parameter, parameter, parameter) => body;
-<<<
+<<< 3.7
 var variableName =
     (parameter, parameter, parameter) =>
         body;
+<<< 3.13
+var variableName = (
+  parameter,
+  parameter,
+  parameter,
+) => body;
 >>> Use block-like splitting for parenthesized expressions whose inner does.
 var variableName = ([element, element, element]);
 <<<


### PR DESCRIPTION
When I first designed the tall style, as the name implies, I erred on the side of taller, simpler formatting. I knew some things should be block formatted. (No one wants their `test(() { ... })` calls to split after the first `(`.) But it wasn't clear if every bracketed syntax should be.

Initially the answer was yes for argument lists and collection literals. Then a user requested we include record type annotations. Then another user pointed out that block-formatting record types in typedefs but not function types is inconsistent. So here, I go ahead and block format parameter lists too.

This change doesn't affect a ton of code in the wild because type annotations don't often occur in contexts where block formatting comes into play. Block formatting is mainly for the RHS of `=` and `:` and you don't usually have function types or function declarations there. But you can have a function type on the right of `=` in a typedef, and you can have function *expressions* on the right of `=`, especially in default values.

Still, this change effects enough that I figured it was safest to language-version it.

Fix #1693.
