### PR TITLE
Avoid running tests containing 'final' or 'var' on version 3.13.

### DIFF
--- a/test/tall/function/parameter.unit
+++ b/test/tall/function/parameter.unit
@@ -28,12 +28,13 @@ function(int? callback()    ?  ) {}
 function(int? callback()?) {}
 >>> `var` and `final` keywords on parameters.
 function(var x, final y, final String z) {}
-<<< 3.12
+<<<
 function(
   var x,
   final y,
   final String z,
 ) {}
+<<< 3.13 (unsupported)
 >>> Required old style function typed parameter.
 f({   required    callback()}) {}
 <<<

--- a/test/tall/regression/0000/0095.unit
+++ b/test/tall/regression/0000/0095.unit
@@ -3,7 +3,7 @@
       String message_str, [final String desc = '', final Map examples = const {
   }, String locale, String name, List<String> args, String meaning]) =>
       message_str;
-<<< 3.12
+<<<
   String lookupMessage(
     String message_str, [
     final String desc = '',
@@ -13,6 +13,7 @@
     List<String> args,
     String meaning,
   ]) => message_str;
+<<< 3.13 (unsupported)
 >>> (indent 2) Without final
   String lookupMessage(
       String message_str, [String desc = '', Map examples = const {

--- a/test/tall/regression/0200/0211.unit
+++ b/test/tall/regression/0200/0211.unit
@@ -24,7 +24,7 @@ void defineProperty(var obj, String property, var value) {
       '{value: #, enumerable: false, writable: true, configurable: true})',
       obj, property, value);
 }
-<<< 3.12
+<<<
 void defineProperty(var obj, String property, var value) {
   JS(
     'void',
@@ -35,6 +35,7 @@ void defineProperty(var obj, String property, var value) {
     value,
   );
 }
+<<< 3.13 (unsupported)
 >>> Without var
 void defineProperty(obj, String property, value) {
   JS('void', 'Object.defineProperty(#, #, '

--- a/test/tall/regression/0200/0237.unit
+++ b/test/tall/regression/0200/0237.unit
@@ -7,7 +7,7 @@ class Bar {
       });
   }
 }
-<<< 3.12
+<<<
 class Bar {
   void foo() {
     blah.method(someLongArgument, andAnotherOne, andAThirdOne, andOneMore).then(
@@ -17,6 +17,7 @@ class Bar {
     );
   }
 }
+<<< 3.13 (unsupported)
 >>> Without var
 class Bar {
   void foo() {

--- a/test/tall/regression/1100/1107.unit
+++ b/test/tall/regression/1100/1107.unit
@@ -11,7 +11,7 @@ class SomeClassC extends SomeClassA {
           ),
         );
 }
-<<< 3.12
+<<<
 class SomeClassC extends SomeClassA {
   SomeClassC({required final String property1})
     : super(
@@ -20,6 +20,7 @@ class SomeClassC extends SomeClassA {
         complexProperty: SomeClassB("sdf", "dfg", "fgh"),
       );
 }
+<<< 3.13 (unsupported)
 >>> Without final
 class SomeClassC extends SomeClassA {
   SomeClassC({required String property1})


### PR DESCRIPTION
These are the tests I thought I was fixing in https://github.com/dart-lang/dart_style/pull/1822. I updated them to actually avoid running on 3.13.

`test/tall/declaration/constructor_parameter.unit` was fixed in https://github.com/dart-lang/dart_style/commit/91f85cc453a27cbb0cfa852cf9d673b61bc92eb7

We're updating these tests for the primary constructors flag flip.