### PR TITLE
Allow block formatting "as", "is", and "is!" expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,28 @@
 
   This change is language versioned and only affects code at 3.13 or higher.
 
+* Allow `as`, `is`, and `is!` expressions to be block formatted (#1542).
+
+  ```dart
+  // Before:
+  variable =
+      function(
+            argument,
+            argument,
+            argument,
+          )
+          as Type;
+
+  // After:
+  variable = function(
+    argument,
+    argument,
+    argument,
+  ) as Type;
+  ```
+
+  This change is language versioned and only affects code at 3.13 or higher.
+
 * Don't add a blank line before a comment at the end of a compilation unit or
   braced body (#1644).
 

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -19,6 +19,7 @@ import '../piece/leading_comment.dart';
 import '../piece/list.dart';
 import '../piece/piece.dart';
 import '../piece/type_parameter_bound.dart';
+import '../piece/type_test.dart';
 import '../piece/variable.dart';
 import '../profile.dart';
 import '../source_code.dart';
@@ -184,17 +185,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitAsExpression(AsExpression node) {
-    writeInfix(
-      node.expression,
-      node.asOperator,
-      node.type,
-      // Don't use Indent.infix after 3.7 because it will flatten the
-      // indentation if the expression occurs in an assignment.
-      // TODO(rnystrom): We probably do want to format `as` the same as other
-      // binary operators, but the tall style already treats them differently,
-      // so leaving that alone for now.
-      indent: style.is3Dot7 ? Indent.infix : Indent.expression,
-    );
+    writeTypeTest(node.expression, node.asOperator, node.type);
   }
 
   @override
@@ -1256,17 +1247,11 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
 
   @override
   void visitIsExpression(IsExpression node) {
-    writeInfix(
+    writeTypeTest(
       node.expression,
       node.isOperator,
-      operator2: node.notOperator,
+      bang: node.notOperator,
       node.type,
-      // Don't use Indent.infix after 3.7 because it will flatten the
-      // indentation if the expression occurs in an assignment.
-      // TODO(rnystrom): We probably do want to format `as` the same as other
-      // binary operators, but the tall style already treats them differently,
-      // so leaving that alone for now.
-      indent: style.is3Dot7 ? Indent.infix : Indent.expression,
     );
   }
 

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -19,7 +19,6 @@ import '../piece/leading_comment.dart';
 import '../piece/list.dart';
 import '../piece/piece.dart';
 import '../piece/type_parameter_bound.dart';
-import '../piece/type_test.dart';
 import '../piece/variable.dart';
 import '../profile.dart';
 import '../source_code.dart';

--- a/lib/src/front_end/formatting_style.dart
+++ b/lib/src/front_end/formatting_style.dart
@@ -67,6 +67,10 @@ final class FormattingStyle {
   /// Whether parameter lists should be block formatted in things like typedefs.
   bool get blockFormatParameterLists => _languageVersion >= _version3Dot13;
 
+  /// Whether the LHS of an `as`, `is`, or `is!` expression can be block
+  /// formatted.
+  bool get blockFormatTypeTest => _languageVersion >= _version3Dot13;
+
   /// Whether there is a trailing comma at the end of the list delimited by
   /// [rightBracket] which should be preserved by this style.
   bool preserveTrailingCommaBefore(Token rightBracket) =>

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -19,6 +19,7 @@ import '../piece/list.dart';
 import '../piece/piece.dart';
 import '../piece/prefix.dart';
 import '../piece/sequence.dart';
+import '../piece/type_test.dart';
 import '../piece/variable.dart';
 import 'chain_builder.dart';
 import 'comment_writer.dart';
@@ -1421,6 +1422,42 @@ mixin PieceFactory {
       style: const ListStyle(commas: Commas.nonTrailing, splitCost: 3),
       blockShaped: false,
     );
+  }
+
+  /// Writes an `as`, `is`, or `is!` expression.
+  void writeTypeTest(
+    Expression expression,
+    Token keyword,
+    TypeAnnotation type, {
+    Token? bang,
+  }) {
+    if (style.blockFormatTypeTest) {
+      var expressionPiece = nodePiece(expression);
+
+      var operatorPiece = pieces.build(() {
+        pieces.token(keyword);
+        pieces.token(bang);
+      });
+
+      pieces.add(
+        TypeTestPiece(
+          expressionPiece,
+          operatorPiece,
+          nodePiece(type),
+          canBlockSplit: expression.canBlockSplit,
+        ),
+      );
+    } else {
+      writeInfix(
+        expression,
+        keyword,
+        operator2: bang,
+        type,
+        // Don't use Indent.infix after 3.7 because it will flatten the
+        // indentation if the expression occurs in an assignment.
+        indent: style.is3Dot7 ? Indent.infix : Indent.expression,
+      );
+    }
   }
 
   /// Handles the `async`, `sync*`, or `async*` modifiers on a function body.

--- a/lib/src/piece/type_test.dart
+++ b/lib/src/piece/type_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import '../back_end/code_writer.dart';
+import 'piece.dart';
+
+/// A piece for an `as` or `is` expression.
+final class TypeTestPiece extends Piece {
+  /// Allow the expression to block split.
+  ///
+  /// Unlike most pieces that allow block splitting, the cost here isn't zero
+  /// because we would prefer to split at `=` if it lets the entire type test
+  /// expression fit on one line:
+  ///
+  ///     variable =
+  ///         function(argument) as Type;
+  static const State _blockSplitExpression = State(1);
+
+  /// The expression being tested or cast.
+  final Piece _expression;
+
+  /// The `as`, `is`, or `is!` operator.
+  final Piece _operator;
+
+  /// The type being tested against or cast to.
+  final Piece _type;
+
+  /// Whether the expression can be block formatted.
+  final bool _canBlockSplit;
+
+  TypeTestPiece(
+    this._expression,
+    this._operator,
+    this._type, {
+    bool canBlockSplit = false,
+  }) : _canBlockSplit = canBlockSplit;
+
+  @override
+  List<State> get additionalStates => [
+    if (_canBlockSplit) _blockSplitExpression,
+    State.split,
+  ];
+
+  @override
+  void format(CodeWriter writer, State state) {
+    if (state == State.split) writer.pushIndent(Indent.expression);
+
+    writer.format(_expression);
+    writer.splitIf(state == State.split);
+    writer.format(_operator);
+    writer.space();
+    writer.format(_type);
+
+    if (state == State.split) writer.popIndent();
+  }
+
+  @override
+  void forEachChild(void Function(Piece piece) callback) {
+    callback(_expression);
+    callback(_operator);
+    callback(_type);
+  }
+
+  @override
+  Set<Shape> allowedChildShapes(State state, Piece child) => switch (state) {
+    State.unsplit => Shape.onlyInline,
+    _blockSplitExpression when child == _expression => Shape.onlyBlock,
+    _ => Shape.all,
+  };
+}

--- a/lib/src/piece/type_test.dart
+++ b/lib/src/piece/type_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../back_end/code_writer.dart';

--- a/test/tall/expression/type_test.stmt
+++ b/test/tall/expression/type_test.stmt
@@ -44,3 +44,96 @@ variable = veryLongExpression as VeryLongTypeName;
 variable =
     veryLongExpression
         as VeryLongTypeName;
+>>> Allow block splitting `as` expressions.
+variable = function(argument, argument, argument) as Type;
+<<< 3.7
+variable =
+    function(
+          argument,
+          argument,
+          argument,
+        )
+        as Type;
+<<< 3.13
+variable = function(
+  argument,
+  argument,
+  argument,
+) as Type;
+>>> Allow block splitting `is` expressions.
+variable = function(argument, argument, argument) is Type;
+<<< 3.7
+variable =
+    function(
+          argument,
+          argument,
+          argument,
+        )
+        is Type;
+<<< 3.13
+variable = function(
+  argument,
+  argument,
+  argument,
+) is Type;
+>>> Allow block splitting `is!` expressions.
+variable = function(argument, argument, argument) is! Type;
+<<< 3.7
+variable =
+    function(
+          argument,
+          argument,
+          argument,
+        )
+        is! Type;
+<<< 3.13
+variable = function(
+  argument,
+  argument,
+  argument,
+) is! Type;
+>>> Prefer to split at `=` if the expression fits on one line.
+variable = f(argument, argument) as Type;
+<<< 3.7
+variable =
+    f(argument, argument) as Type;
+<<< 3.13
+variable =
+    f(argument, argument) as Type;
+>>> Prefer to block split versus splitting at the operator.
+variable = f(argument, argument) as VeryLongType;
+<<< 3.7
+variable =
+    f(argument, argument)
+        as VeryLongType;
+<<< 3.13
+variable = f(
+  argument,
+  argument,
+) as VeryLongType;
+>>> Don't block split if the type splits.
+variable = function(argument, argument, argument)
+as VeryLongGenericType<TypeArgument, TypeArgument, TypeArgument>;
+<<< 3.7
+variable =
+    function(
+          argument,
+          argument,
+          argument,
+        )
+        as VeryLongGenericType<
+          TypeArgument,
+          TypeArgument,
+          TypeArgument
+        >;
+<<< 3.13
+variable =
+    function(
+      argument,
+      argument,
+      argument,
+    ) as VeryLongGenericType<
+      TypeArgument,
+      TypeArgument,
+      TypeArgument
+    >;

--- a/test/tall/regression/1500/1526.stmt
+++ b/test/tall/regression/1500/1526.stmt
@@ -44,10 +44,14 @@
   final content = json.decode(
     await rootBundle.loadString('assets/configurations.json'),
   ) as Map<String, Object?>;
-<<<
+<<< 3.7
   final content =
       json.decode(await rootBundle.loadString('assets/configurations.json'))
           as Map<String, Object?>;
+<<< 3.13
+  final content = json.decode(
+    await rootBundle.loadString('assets/configurations.json'),
+  ) as Map<String, Object?>;
 >>> (indent 4)
     final results =
         annotationsOf(element, throwOnUnresolved: throwOnUnresolved);

--- a/test/tall/regression/1500/1542.stmt
+++ b/test/tall/regression/1500/1542.stmt
@@ -1,0 +1,57 @@
+>>> (indent 4)
+    final buildConfig =
+        BuildConfig.build(
+              outputDirectory: outputDirectory,
+              packageName: await _packageName(),
+              packageRoot: Directory.current.uri,
+              buildMode: buildMode ?? BuildMode.release,
+              targetArchitecture: targetArchitecture ?? Architecture.current,
+              targetOS: targetOS ?? OS.current,
+              linkModePreference:
+                  linkModePreference ?? LinkModePreference.dynamic,
+              linkingEnabled: linkingEnabled ?? true,
+              cCompiler: cCompiler,
+              supportedAssetTypes: supportedAssetTypes,
+              targetAndroidNdkApi: targetAndroidNdkApi,
+              targetIOSSdk: targetIOSSdk,
+              targetIOSVersion: targetIOSVersion,
+              targetMacOSVersion: targetMacOSVersion,
+            )
+            as BuildConfigImpl;
+<<< 3.7
+    final buildConfig =
+        BuildConfig.build(
+              outputDirectory: outputDirectory,
+              packageName: await _packageName(),
+              packageRoot: Directory.current.uri,
+              buildMode: buildMode ?? BuildMode.release,
+              targetArchitecture: targetArchitecture ?? Architecture.current,
+              targetOS: targetOS ?? OS.current,
+              linkModePreference:
+                  linkModePreference ?? LinkModePreference.dynamic,
+              linkingEnabled: linkingEnabled ?? true,
+              cCompiler: cCompiler,
+              supportedAssetTypes: supportedAssetTypes,
+              targetAndroidNdkApi: targetAndroidNdkApi,
+              targetIOSSdk: targetIOSSdk,
+              targetIOSVersion: targetIOSVersion,
+              targetMacOSVersion: targetMacOSVersion,
+            )
+            as BuildConfigImpl;
+<<< 3.13
+    final buildConfig = BuildConfig.build(
+      outputDirectory: outputDirectory,
+      packageName: await _packageName(),
+      packageRoot: Directory.current.uri,
+      buildMode: buildMode ?? BuildMode.release,
+      targetArchitecture: targetArchitecture ?? Architecture.current,
+      targetOS: targetOS ?? OS.current,
+      linkModePreference: linkModePreference ?? LinkModePreference.dynamic,
+      linkingEnabled: linkingEnabled ?? true,
+      cCompiler: cCompiler,
+      supportedAssetTypes: supportedAssetTypes,
+      targetAndroidNdkApi: targetAndroidNdkApi,
+      targetIOSSdk: targetIOSSdk,
+      targetIOSVersion: targetIOSVersion,
+      targetMacOSVersion: targetMacOSVersion,
+    ) as BuildConfigImpl;


### PR DESCRIPTION
Type test expressions are in a funny spot. They aren't formatted consistently with other binary operators. But they also don't allow block-formatting. The end result is weird formatting in contexts where block-formatting is possible:

```dart
      // A block-formatted expression:
      final buildConfig = await BuildConfig.build(
        outputDirectory: outputDirectory,
        packageName: await _packageName(),
        packageRoot: Directory.current.uri,
      );

      // A binary operator:
      final buildConfig =
          BuildConfig.build(
            outputDirectory: outputDirectory,
            packageName: await _packageName(),
            packageRoot: Directory.current.uri,
          ) +
          someLongExpression;

      // A type test today:
      final buildConfig =
          BuildConfig.build(
                outputDirectory: outputDirectory,
                packageName: await _packageName(),
                packageRoot: Directory.current.uri,
              )
              as BuildConfigImpl;
```

Daco requested that the formatter allow them to be block-formatted, like:

```dart
final buildConfig = BuildConfig.build(
  outputDirectory: outputDirectory,
  packageName: await _packageName(),
  packageRoot: Directory.current.uri,
) as BuildConfigImpl;
```

That's what this PR does. You can see the overall effect on a random corpus of code [here](https://gist.github.com/munificent/07f1dd403bd3e055e64042719853703b).

Fix #1542.