### PR TITLE
Format the guard in an if-case to split if the pattern block splits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,28 @@
 
   This change is language versioned and only affects code at 3.13 or higher.
 
+*  In if-case pieces, split the guard if the pattern block-splits (#1596).
+
+  This tends to lead to code where the pattern is kept on one line and the
+  guard splits:
+
+  ```dart
+  // Before:
+  if (expression case SomeClass(
+    property: var x,
+  ) when guardClause(x)) {
+    ...
+  }
+
+  // After:
+  if (expression case SomeClass(property: var x)
+      when guardClause(x)) {
+    ...
+  }
+  ```
+
+  This change is language versioned and only affects code at 3.13 or higher.
+
 * Don't add a blank line before a comment at the end of a compilation unit or
   braced body (#1644).
 

--- a/lib/src/front_end/formatting_style.dart
+++ b/lib/src/front_end/formatting_style.dart
@@ -71,6 +71,10 @@ final class FormattingStyle {
   /// formatted.
   bool get blockFormatTypeTest => _languageVersion >= _version3Dot13;
 
+  /// Whether an if-case pattern can be block-formatted when there is a guard
+  /// clause as well.
+  bool get blockFormatIfCaseWithGuard => _languageVersion < _version3Dot13;
+
   /// Whether there is a trailing comma at the end of the list delimited by
   /// [rightBracket] which should be preserved by this style.
   bool preserveTrailingCommaBefore(Token rightBracket) =>

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -900,27 +900,15 @@ mixin PieceFactory {
 
       var guardPiece = optionalNodePiece(caseClause.guardedPattern.whenClause);
 
-      if (style.blockFormatIfCaseWithGuard) {
-        pieces.add(
-          IfCasePiece3Dot12(
-            expressionPiece,
-            casePiece,
-            guardPiece,
-            canBlockSplitPattern:
-                caseClause.guardedPattern.pattern.canBlockSplit,
-          ),
-        );
-      } else {
-        pieces.add(
-          IfCasePiece(
-            expressionPiece,
-            casePiece,
-            guardPiece,
-            canBlockSplitPattern:
-                caseClause.guardedPattern.pattern.canBlockSplit,
-          ),
-        );
-      }
+      pieces.add(
+        IfCasePiece(
+          expressionPiece,
+          casePiece,
+          guardPiece,
+          canBlockSplitPattern: caseClause.guardedPattern.pattern.canBlockSplit,
+          canBlockFormatPatternWithGuard: style.blockFormatIfCaseWithGuard,
+        ),
+      );
     } else {
       pieces.visit(expression);
     }

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -900,14 +900,27 @@ mixin PieceFactory {
 
       var guardPiece = optionalNodePiece(caseClause.guardedPattern.whenClause);
 
-      pieces.add(
-        IfCasePiece(
-          expressionPiece,
-          casePiece,
-          guardPiece,
-          canBlockSplitPattern: caseClause.guardedPattern.pattern.canBlockSplit,
-        ),
-      );
+      if (style.blockFormatIfCaseWithGuard) {
+        pieces.add(
+          IfCasePiece3Dot12(
+            expressionPiece,
+            casePiece,
+            guardPiece,
+            canBlockSplitPattern:
+                caseClause.guardedPattern.pattern.canBlockSplit,
+          ),
+        );
+      } else {
+        pieces.add(
+          IfCasePiece(
+            expressionPiece,
+            casePiece,
+            guardPiece,
+            canBlockSplitPattern:
+                caseClause.guardedPattern.pattern.canBlockSplit,
+          ),
+        );
+      }
     } else {
       pieces.visit(expression);
     }

--- a/lib/src/piece/case.dart
+++ b/lib/src/piece/case.dart
@@ -80,8 +80,11 @@ final class CaseExpressionPiece extends Piece {
       // in a funny location, but if it happens, allow it.
       _ when child == _arrow => Shape.all,
       _blockSplitBody when child == _body => Shape.onlyBlock,
+
+      // Only allow the pattern to split if there is no guard.
       _beforeBody when child == _pattern => Shape.anyIf(_guard == null),
       _beforeBody when child == _body => Shape.all,
+
       _beforeWhenAndBody => Shape.all,
       _ => Shape.onlyInline,
     };

--- a/lib/src/piece/if_case.dart
+++ b/lib/src/piece/if_case.dart
@@ -57,7 +57,31 @@ final class IfCasePiece extends Piece {
   /// Whether the pattern can be block formatted.
   final bool _canBlockSplitPattern;
 
-  IfCasePiece(
+  factory IfCasePiece(
+    Piece value,
+    Piece pattern,
+    Piece? guard, {
+    required bool canBlockSplitPattern,
+    required bool canBlockFormatPatternWithGuard,
+  }) {
+    if (canBlockFormatPatternWithGuard) {
+      return _IfCasePieceBlockFormatWithGuard(
+        value,
+        pattern,
+        guard,
+        canBlockSplitPattern: canBlockSplitPattern,
+      );
+    } else {
+      return IfCasePiece._(
+        value,
+        pattern,
+        guard,
+        canBlockSplitPattern: canBlockSplitPattern,
+      );
+    }
+  }
+
+  IfCasePiece._(
     this._value,
     this._pattern,
     this._guard, {
@@ -174,13 +198,13 @@ final class IfCasePiece extends Piece {
 ///
 /// The change is language-versioned and this class implements the previous
 /// behavior.
-final class IfCasePiece3Dot12 extends IfCasePiece {
-  IfCasePiece3Dot12(
+final class _IfCasePieceBlockFormatWithGuard extends IfCasePiece {
+  _IfCasePieceBlockFormatWithGuard(
     super.value,
     super.pattern,
     super.guard, {
     required super.canBlockSplitPattern,
-  });
+  }) : super._();
 
   @override
   Set<Shape> allowedChildShapes(State state, Piece child) {

--- a/lib/src/piece/if_case.dart
+++ b/lib/src/piece/if_case.dart
@@ -74,19 +74,27 @@ final class IfCasePiece extends Piece {
   @override
   Set<Shape> allowedChildShapes(State state, Piece child) {
     return switch (state) {
-      // When not splitting before `case` or `when`, we only allow newlines
-      // in block-formatted patterns.
-      State.unsplit when child == _pattern => Shape.anyIf(
-        _canBlockSplitPattern,
-      ),
+      // When not splitting before `case` or `when`, we only allow splitting a
+      // block-formatted pattern if there is no guard.
+      State.unsplit
+          when child == _pattern && _canBlockSplitPattern && _guard == null =>
+        Shape.inlineOrBlock,
 
       // Allow newlines only in the guard if we split before `when`.
       _beforeWhen when child == _guard => Shape.all,
 
-      // Only allow the guard on the same line as the pattern if it doesn't
-      // split.
-      _beforeCase when child != _guard => Shape.all,
+      // If there's no guard, then we can split anywhere in the pattern when
+      // splitting after `case`.
+      _beforeCase when child == _pattern && _guard == null => Shape.all,
+
+      // If there is a guard, then the entire pattern and guard must fit on
+      // one line, but the value expression can split.
+      _beforeCase when child == _value => Shape.all,
+
+      // Once we split at both `case` and `when`, then splits are allowed
+      // everywhere.
       _beforeCaseAndWhen => Shape.all,
+
       _ => Shape.onlyInline,
     };
   }
@@ -122,5 +130,75 @@ final class IfCasePiece extends Piece {
     callback(_value);
     callback(_pattern);
     if (_guard case var guard?) callback(guard);
+  }
+}
+
+/// An [IfCasePiece] for language versions older than 3.13.
+///
+/// In 3.13, we made if-case formatting stricter about block-formatting patterns
+/// in the presence of a guard. Before 3.13, the formatter would allow output
+/// like:
+///
+///     if (expression case [
+///       constant,
+///       another
+///     ] when guardExpression) {
+///      ...
+///     }
+///
+/// Allowing the `when` clause hanging off the block-formatted pattern can make
+/// it hard to see. In 3.13, we force a split before the `when` if the pattern
+/// splits:
+///
+///     if (expression
+///         case [
+///           constant,
+///           another
+///         ]
+///         when guardExpression) {
+///      ...
+///     }
+///
+/// A deliberate consequence of this change is that the formatter will prefer
+/// splitting the guard and keeping the pattern on one line instead of block
+/// splitting the pattern:
+///
+///     // Before:
+///     if (expression case SomeClass(
+///       property: var x,
+///     ) when guardClause(x)) {
+///
+///     // After:
+///     if (expression case SomeClass(property: var x)
+///         when guardClause(x)) {
+///
+/// The change is language-versioned and this class implements the previous
+/// behavior.
+final class IfCasePiece3Dot12 extends IfCasePiece {
+  IfCasePiece3Dot12(
+    super.value,
+    super.pattern,
+    super.guard, {
+    required super.canBlockSplitPattern,
+  });
+
+  @override
+  Set<Shape> allowedChildShapes(State state, Piece child) {
+    return switch (state) {
+      // When not splitting before `case` or `when`, we only allow newlines
+      // in block-formatted patterns.
+      State.unsplit when child == _pattern => Shape.anyIf(
+        _canBlockSplitPattern,
+      ),
+
+      // Allow newlines only in the guard if we split before `when`.
+      IfCasePiece._beforeWhen when child == _guard => Shape.all,
+
+      // Only allow the guard on the same line as the pattern if it doesn't
+      // split.
+      IfCasePiece._beforeCase when child != _guard => Shape.all,
+      IfCasePiece._beforeCaseAndWhen => Shape.all,
+      _ => Shape.onlyInline,
+    };
   }
 }

--- a/lib/src/piece/piece.dart
+++ b/lib/src/piece/piece.dart
@@ -237,6 +237,9 @@ enum Shape {
   /// Prohibits any newlines at all.
   static const Set<Shape> onlyInline = {inline};
 
+  /// The only way it can split is block-style.
+  static const Set<Shape> inlineOrBlock = {inline, block};
+
   /// Allows all shapes if [condition] is `true` or only an inline piece
   /// otherwise.
   ///

--- a/test/tall/pattern/list.stmt
+++ b/test/tall/pattern/list.stmt
@@ -66,7 +66,7 @@ if (obj case [
 }
 >>> Split in type argument, but not in the body.
 if (obj case <Map<VeryLongTypeArgument, VeryLongTypeArgument>>[e]) {;}
-<<<
+<<< 3.7
 if (obj case <
   Map<
     VeryLongTypeArgument,
@@ -75,9 +75,19 @@ if (obj case <
 >[e]) {
   ;
 }
+<<< 3.13
+if (obj
+    case <
+      Map<
+        VeryLongTypeArgument,
+        VeryLongTypeArgument
+      >
+    >[e]) {
+  ;
+}
 >>> Split in type argument and body.
 if (obj case <Map<VeryLongTypeArgument, VeryLongTypeArgument>>[element,VeryLongElementElementElement]) {;}
-<<<
+<<< 3.7
 if (obj case <
   Map<
     VeryLongTypeArgument,
@@ -87,6 +97,19 @@ if (obj case <
   element,
   VeryLongElementElementElement,
 ]) {
+  ;
+}
+<<< 3.13
+if (obj
+    case <
+      Map<
+        VeryLongTypeArgument,
+        VeryLongTypeArgument
+      >
+    >[
+      element,
+      VeryLongElementElementElement,
+    ]) {
   ;
 }
 >>> Split inside element forces list to split.

--- a/test/tall/regression/1500/1596.stmt
+++ b/test/tall/regression/1500/1596.stmt
@@ -1,0 +1,70 @@
+>>>
+if (node.parent case MethodInvocation(:var target) when target is SimpleIdentifier?) {;}
+<<< 3.7
+if (node.parent case MethodInvocation(
+  :var target,
+) when target is SimpleIdentifier?) {
+  ;
+}
+<<< 3.13
+if (node.parent case MethodInvocation(:var target)
+    when target is SimpleIdentifier?) {
+  ;
+}
+>>>
+if (err
+    case DioException(
+          type: DioExceptionType.badCertificate || DioExceptionType.cancel
+        ) ||
+        DioException(
+          type: DioExceptionType.badResponse,
+          response: Response(statusCode: != null && >= 200 && <= 500)
+        ) when Random().nextInt(100) > 10) {
+  return super.onError(err, handler);
+}
+<<< 3.7
+if (err
+    case DioException(
+          type: DioExceptionType.badCertificate || DioExceptionType.cancel,
+        ) ||
+        DioException(
+          type: DioExceptionType.badResponse,
+          response: Response(statusCode: != null && >= 200 && <= 500),
+        ) when Random().nextInt(100) > 10) {
+  return super.onError(err, handler);
+}
+<<< 3.13
+if (err
+    case DioException(
+          type: DioExceptionType.badCertificate || DioExceptionType.cancel,
+        ) ||
+        DioException(
+          type: DioExceptionType.badResponse,
+          response: Response(statusCode: != null && >= 200 && <= 500),
+        )
+    when Random().nextInt(100) > 10) {
+  return super.onError(err, handler);
+}
+>>>
+if (nodeElement.kind
+  case ElementKind.LOCAL_VARIABLE || ElementKind.TOP_LEVEL_VARIABLE
+  when target.kind == ElementKind.FIELD) {
+  // Something
+}
+<<<
+if (nodeElement.kind
+    case ElementKind.LOCAL_VARIABLE || ElementKind.TOP_LEVEL_VARIABLE
+    when target.kind == ElementKind.FIELD) {
+  // Something
+}
+>>>
+if (nodeElement.kind
+    case ElementKind.LOCAL_VARIABLE ||
+        ElementKind.TOP_LEVEL_VARIABLE) {
+  // Something
+}
+<<<
+if (nodeElement.kind
+    case ElementKind.LOCAL_VARIABLE || ElementKind.TOP_LEVEL_VARIABLE) {
+  // Something
+}

--- a/test/tall/statement/if_case.stmt
+++ b/test/tall/statement/if_case.stmt
@@ -151,3 +151,30 @@ if (obj case constant
         anotherOne) {
   ;
 }
+>>> If pattern block-formats, then guard splits.
+if (obj
+    case const [
+      veryLongElement,
+      veryLongElement,
+      veryLongElement,
+    ] when true) {
+  ;
+}
+<<< 3.7
+if (obj case const [
+  veryLongElement,
+  veryLongElement,
+  veryLongElement,
+] when true) {
+  ;
+}
+<<< 3.13
+if (obj
+    case const [
+      veryLongElement,
+      veryLongElement,
+      veryLongElement,
+    ]
+    when true) {
+  ;
+}


### PR DESCRIPTION
The formatter allows block-formatting in if-case patterns, like:

```dart
if (expression case Thing(
  :var property,
  :var another,
)) {
  ...
}
```

It also allows this if there is a guard clause:

```dart
if (expression case Thing(
  :var property,
  :var another,
) when condition) {
  ...
}
```

But, in general, I don't like when code gets buried at the end of a line like that. Also, because we allow this and because block-formatting is usually lower cost than other kinds of splits, it means the formatter prefers this:

```dart
if (expression case Thing(
  :var property,
) when condition) {
  ...
}
```

Instead of:

```dart
if (expression case Thing(:var property)
    when condition) {
  ...
}
```

But I think the latter is strictly better. This PR tweaks the formatting rule so that an if-case can only block-format the pattern if there is no guard clause. That leads it to prefer the latter of the previous two examples.

In practice, this tweak turns out to affect very little code. I ran it on a huge corpus of pub packages and there were [only 32 changes](https://gist.github.com/munificent/6be922e612850e98e849af20c6688ce0). To my eye, those all look like improvements.

Fix #1596.
