### PR TITLE
Prefer to split call chains for single-element targets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@
 
 ### Style changes
 
+* Prefer to split call chains for single-element targets (#1732).
+
+  When formatting a method call chain whose target can also split, the formatter
+  must decide whether to split the target or the call chain (or both). For
+  example:
+
+  ```dart
+  // Split target:
+  function(
+    argument,
+  ).method().another();
+
+  // Or split chain:
+  function(argument)
+    .method()
+    .another();
+  ```
+
+  We've tried various heuristics for this over the years but most make some code
+  look better while making other code look worse. This version introduces a
+  relatively simple rule that seems to work well in practice: If the call chain
+  target has only one element or argument, then prefer to split the call chain
+  and keep the target together. So in the above example, if prefers the second
+  output.
+
 * Support block-formatting parameter lists (#1693). The formatter supports
   "block-formatting" for most bracket-delimited constructs in the language. This
   is what enables a multi-line list literal in an assignment to look like this:

--- a/benchmark/case/large.expect
+++ b/benchmark/case/large.expect
@@ -1003,9 +1003,8 @@ class Traverser {
   /// can have a bunch of dependencies back onto the root package as long as
   /// they all agree with each other.
   Dependency _getRequired(String name) {
-    return _getDependencies(
-      name,
-    ).firstWhere((dep) => !dep.dep.isRoot, orElse: () => null);
+    return _getDependencies(name)
+        .firstWhere((dep) => !dep.dep.isRoot, orElse: () => null);
   }
 
   /// Gets the combined [VersionConstraint] currently being placed on package

--- a/lib/src/ast_extensions.dart
+++ b/lib/src/ast_extensions.dart
@@ -269,6 +269,35 @@ extension ExpressionExtensions on Expression {
     };
   }
 
+  /// Whether this expression is a call or collection literal with a single
+  /// argument or element.
+  bool get hasSingleElement {
+    var expression = this;
+    while (true) {
+      if (expression is ParenthesizedExpression) {
+        expression = expression.expression;
+      } else if (expression is AwaitExpression) {
+        expression = expression.expression;
+      } else if (expression is PostfixExpression) {
+        expression = expression.operand;
+      } else {
+        break;
+      }
+    }
+
+    return switch (expression) {
+      MethodInvocation(:var argumentList) ||
+      InstanceCreationExpression(:var argumentList) ||
+      FunctionExpressionInvocation(
+        :var argumentList,
+      ) => argumentList.arguments.length == 1,
+      ListLiteral(:var elements) ||
+      SetOrMapLiteral(:var elements) => elements.length == 1,
+      RecordLiteral(:var fields) => fields.length == 1,
+      _ => false,
+    };
+  }
+
   /// Whether this is an argument in an argument list with a trailing comma.
   bool get isTrailingCommaArgument {
     var parent = this.parent;

--- a/lib/src/front_end/chain_builder.dart
+++ b/lib/src/front_end/chain_builder.dart
@@ -65,7 +65,11 @@ final class ChainBuilder {
   ///       argument,
   ///     )
   ///         .method();
-  late final bool _allowSplitInTarget;
+  bool _allowSplitInTarget = false;
+
+  /// Whether the target of the chain is a call or collection with a single
+  /// argument or element (and we are in a style that treats that specially).
+  bool _isSingleElementTarget = false;
 
   /// The dotted property accesses and method calls following the target.
   final List<ChainCall> _calls = [];
@@ -132,6 +136,7 @@ final class ChainBuilder {
       indent: Indent.cascade,
       blockCallIndex: blockCallIndex,
       allowSplitInTarget: _allowSplitInTarget,
+      singleElementTarget: _isSingleElementTarget,
       is3Dot7: _visitor.style.is3Dot7,
     );
 
@@ -234,21 +239,18 @@ final class ChainBuilder {
       leadingProperties: leadingProperties,
       blockCallIndex: blockCallIndex,
       allowSplitInTarget: _allowSplitInTarget,
+      singleElementTarget: _isSingleElementTarget,
       is3Dot7: _visitor.style.is3Dot7,
     );
   }
 
   /// Given [expression], which is the expression for some call chain, traverses
-  /// the selectors to fill in the list of [_calls].
-  ///
-  /// Otherwise, it's a method chain, and this recursively calls itself for the
-  /// targets to unzip and flatten the nested selector expressions. Then it
-  /// initializes [_target] with the innermost subexpression that isn't a part
-  /// of the call chain. For example, given:
+  /// the selectors to fill in the list of [_calls] and initialize [_target].
+  /// For example, given:
   ///
   ///     foo.bar()!.baz[0][1].bang()
   ///
-  /// This returns `foo` and fills [_calls] with:
+  /// This initializes [_target] to `foo` and fills [_calls] with:
   ///
   ///     .bar()!
   ///     .baz[0][1]
@@ -314,8 +316,8 @@ final class ChainBuilder {
         _calls.add(ChainCall(piece, CallType.property));
 
       // Postfix expressions.
-      case FunctionExpressionInvocation():
-        _unwrapPostfix(expression.function, (target) {
+      case FunctionExpressionInvocation(:var function):
+        _unwrapPostfix(expression, function, (target) {
           return _visitor.pieces.build(() {
             _visitor.pieces.add(target);
             _visitor.pieces.visit(expression.typeArguments);
@@ -329,7 +331,7 @@ final class ChainBuilder {
         // with an index expression like:
         //
         //     object..[index].chain();
-        _unwrapPostfix(target, (target) {
+        _unwrapPostfix(expression, target, (target) {
           return _visitor.pieces.build(() {
             _visitor.pieces.add(target);
             _visitor.writeIndexExpression(expression);
@@ -337,7 +339,7 @@ final class ChainBuilder {
         });
 
       case PostfixExpression() when expression.operator.type == TokenType.BANG:
-        _unwrapPostfix(expression.operand, (target) {
+        _unwrapPostfix(expression, expression.operand, (target) {
           return _visitor.pieces.build(() {
             _visitor.pieces.add(target);
             _visitor.pieces.token(expression.operator);
@@ -356,27 +358,56 @@ final class ChainBuilder {
   /// If [cascadeTarget] is `true`, then this is the target of a cascade
   /// expression. Otherwise, it's the target of a call chain.
   void _visitTarget(Expression target, {bool cascadeTarget = false}) {
-    _allowSplitInTarget = target.canBlockSplit;
+    _initializeTargetProperties(target);
     _target = _visitor.nodePiece(
       target,
       context: cascadeTarget ? NodeContext.cascadeTarget : NodeContext.none,
     );
   }
 
+  /// When [expression] is some kind of postfix expression containing
+  /// [postfixPart], attempts to apply the postfix expression to the preceding
+  /// call in the call chain contained by [expression].
+  ///
+  /// If [expression] doesn't have any more call chain selectors preceding
+  /// [postfixPart], then [expression] and [postfixPart] all become the
+  /// [_target] of the call chain. Otherwise, [postfixPart] is added as a
+  /// postfix operation to the preceding call in the call chain and we recurse
+  /// in to find the inner target.
   void _unwrapPostfix(
-    Expression operand,
+    Expression expression,
+    Expression postfixPart,
     Piece Function(Piece target) createPostfix,
   ) {
-    _unwrapCall(operand);
+    _unwrapCall(postfixPart);
 
     // If we don't have a preceding call to hang the postfix expression off of,
     // make it part of the target expression. For example:
     //
     //     (list + another)!
     if (_calls.isEmpty) {
+      // Prior to 3.13, ChainBuilder didn't recalculate [_allowSplitInTarget]
+      // when unwrapping a postfix expression that ends up being part of the
+      // target. Because of this, a function expression invocation would have
+      // [_allowSplitInTarget] set to `false` (because the inner function
+      // expression itself can't block split) even when the argument list ends
+      // up part of the target. For compatibility, this if statement preserves
+      // that behavior on older versions.
+      if (_visitor.style.avoidSplittingSingleElementCallChainTargets) {
+        _initializeTargetProperties(expression);
+      }
+
       _target = createPostfix(_target);
     } else {
       _calls.last.wrapPostfix(createPostfix);
     }
+  }
+
+  void _initializeTargetProperties(Expression target) {
+    _allowSplitInTarget = target.canBlockSplit;
+
+    _isSingleElementTarget =
+        _visitor.style.avoidSplittingSingleElementCallChainTargets &&
+        target.hasSingleElement;
   }
 }

--- a/lib/src/front_end/chain_builder.dart
+++ b/lib/src/front_end/chain_builder.dart
@@ -69,7 +69,7 @@ final class ChainBuilder {
 
   /// Whether the target of the chain is a call or collection with a single
   /// argument or element (and we are in a style that treats that specially).
-  bool _isSingleElementTarget = false;
+  bool _hasSingleElementTarget = false;
 
   /// The dotted property accesses and method calls following the target.
   final List<ChainCall> _calls = [];
@@ -136,7 +136,7 @@ final class ChainBuilder {
       indent: Indent.cascade,
       blockCallIndex: blockCallIndex,
       allowSplitInTarget: _allowSplitInTarget,
-      singleElementTarget: _isSingleElementTarget,
+      hasSingleElementTarget: _hasSingleElementTarget,
       is3Dot7: _visitor.style.is3Dot7,
     );
 
@@ -239,7 +239,7 @@ final class ChainBuilder {
       leadingProperties: leadingProperties,
       blockCallIndex: blockCallIndex,
       allowSplitInTarget: _allowSplitInTarget,
-      singleElementTarget: _isSingleElementTarget,
+      hasSingleElementTarget: _hasSingleElementTarget,
       is3Dot7: _visitor.style.is3Dot7,
     );
   }
@@ -406,7 +406,7 @@ final class ChainBuilder {
   void _initializeTargetProperties(Expression target) {
     _allowSplitInTarget = target.canBlockSplit;
 
-    _isSingleElementTarget =
+    _hasSingleElementTarget =
         _visitor.style.avoidSplittingSingleElementCallChainTargets &&
         target.hasSingleElement;
   }

--- a/lib/src/front_end/formatting_style.dart
+++ b/lib/src/front_end/formatting_style.dart
@@ -56,6 +56,12 @@ final class FormattingStyle {
       _formatter.trailingCommas == TrailingCommas.preserve &&
       _languageVersion >= _version3Dot10;
 
+  /// Whether the formatter should penalize splitting in the target of a call
+  /// chain if the target is an argument list with only one argument or a
+  /// collection literal with only one element.
+  bool get avoidSplittingSingleElementCallChainTargets =>
+      _languageVersion >= _version3Dot13;
+
   /// Whether mixin declarations and extension types with brace bodies should
   /// always get a blank line above and below them.
   ///

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -305,31 +305,36 @@ final class _ChainPiece extends ChainPiece {
 
   @override
   int stateCost(State state) {
-    if (state == State.split) {
-      // When the target is a single-element argument list or collection, try
-      // to avoid splitting it. Prefers:
-      //
-      //     function(argument)
-      //         .method();
-      //
-      // Over:
-      //
-      //     function(
-      //       argument,
-      //     ).method();
-      if (_hasSingleElementTarget) return 0;
+    // When the target is a single-element argument list or collection, try
+    // to avoid splitting it. Prefers:
+    //
+    //     function(argument)
+    //         .method();
+    //
+    // Over:
+    //
+    //     function(
+    //       argument,
+    //     ).method();
+    if (_hasSingleElementTarget &&
+        (state == ChainPiece._splitAfterProperties || state == State.split)) {
+      return 0;
+    }
 
-      // If the chain is only properties, try to keep them together. Prefers:
-      //
-      //     variable =
-      //         target.property.another;
-      //
-      // Over:
-      //
-      //     variable = target
-      //         .property
-      //         .another;
-      if (!_isCascade && _leadingProperties == _calls.length) return 2;
+    // If the chain is only properties, try to keep them together. Prefers:
+    //
+    //     variable =
+    //         target.property.another;
+    //
+    // Over:
+    //
+    //     variable = target
+    //         .property
+    //         .another;
+    if (!_isCascade &&
+        _leadingProperties == _calls.length &&
+        state == State.split) {
+      return 2;
     }
 
     return super.stateCost(state);

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -132,6 +132,7 @@ abstract base class ChainPiece extends Piece {
     int blockCallIndex = -1,
     Indent indent = Indent.expression,
     required bool allowSplitInTarget,
+    required bool singleElementTarget,
     required bool is3Dot7,
   }) {
     if (is3Dot7) {
@@ -151,6 +152,7 @@ abstract base class ChainPiece extends Piece {
         cascade: cascade,
         leadingProperties: leadingProperties,
         blockCallIndex: blockCallIndex,
+        singleElementTarget: singleElementTarget,
         indent: indent,
       );
     }
@@ -194,7 +196,7 @@ abstract base class ChainPiece extends Piece {
     //       element1,
     //       element2,
     //     ]..cascade();
-    if (state == State.split) return _isCascade ? 0 : 1;
+    if (state == State.split && _isCascade) return 0;
 
     return super.stateCost(state);
   }
@@ -282,6 +284,11 @@ abstract base class ChainPiece extends Piece {
 
 /// A [ChainPiece] subclass for 3.8 and later style.
 final class _ChainPiece extends ChainPiece {
+  /// Whether the target of the chain is a call or collection with a single
+  /// argument or element and we're at a version where those should be formatted
+  /// specially.
+  final bool _hasSingleElementTarget;
+
   /// Creates a new ChainPiece.
   ///
   /// Instead of calling this directly, prefer using [ChainBuilder].
@@ -291,25 +298,38 @@ final class _ChainPiece extends ChainPiece {
     required super.cascade,
     super.leadingProperties,
     super.blockCallIndex,
+    required bool singleElementTarget,
     super.indent,
-  }) : super._();
+  }) : _hasSingleElementTarget = singleElementTarget,
+       super._();
 
   @override
   int stateCost(State state) {
-    // If the chain is only properties, try to keep them together. Prefers:
-    //
-    //     variable =
-    //         target.property.another;
-    //
-    // Over:
-    //
-    //     variable = target
-    //         .property
-    //         .another;
-    if (state == State.split &&
-        !_isCascade &&
-        _leadingProperties == _calls.length) {
-      return 2;
+    if (state == State.split) {
+      // When the target is a single-element argument list or collection, try
+      // to avoid splitting it. Prefers:
+      //
+      //     function(argument)
+      //         .method();
+      //
+      // Over:
+      //
+      //     function(
+      //       argument,
+      //     ).method();
+      if (_hasSingleElementTarget) return 0;
+
+      // If the chain is only properties, try to keep them together. Prefers:
+      //
+      //     variable =
+      //         target.property.another;
+      //
+      // Over:
+      //
+      //     variable = target
+      //         .property
+      //         .another;
+      if (!_isCascade && _leadingProperties == _calls.length) return 2;
     }
 
     return super.stateCost(state);

--- a/lib/src/piece/chain.dart
+++ b/lib/src/piece/chain.dart
@@ -132,7 +132,7 @@ abstract base class ChainPiece extends Piece {
     int blockCallIndex = -1,
     Indent indent = Indent.expression,
     required bool allowSplitInTarget,
-    required bool singleElementTarget,
+    required bool hasSingleElementTarget,
     required bool is3Dot7,
   }) {
     if (is3Dot7) {
@@ -152,7 +152,7 @@ abstract base class ChainPiece extends Piece {
         cascade: cascade,
         leadingProperties: leadingProperties,
         blockCallIndex: blockCallIndex,
-        singleElementTarget: singleElementTarget,
+        hasSingleElementTarget: hasSingleElementTarget,
         indent: indent,
       );
     }
@@ -298,9 +298,9 @@ final class _ChainPiece extends ChainPiece {
     required super.cascade,
     super.leadingProperties,
     super.blockCallIndex,
-    required bool singleElementTarget,
+    required bool hasSingleElementTarget,
     super.indent,
-  }) : _hasSingleElementTarget = singleElementTarget,
+  }) : _hasSingleElementTarget = hasSingleElementTarget,
        super._();
 
   @override

--- a/test/tall/invocation/chain.stmt
+++ b/test/tall/invocation/chain.stmt
@@ -139,6 +139,10 @@ function({key: value}).method().method();
 function({
   key: value,
 }).method().method();
+<<< 3.13
+function({key: value})
+    .method()
+    .method();
 >>> Split chain and target.
 function([longElement1, longElement2, longElement3]).method().method().method().method().method();
 <<< 3.7

--- a/test/tall/invocation/chain_single_element_target.stmt
+++ b/test/tall/invocation/chain_single_element_target.stmt
@@ -1,0 +1,173 @@
+40 columns                              |
+### Prefer splitting the chain over a single-element target.
+>>> Function call with one argument splits the chain.
+function(veryLongArgument).veryLongMethod();
+<<< 3.7
+function(
+  veryLongArgument,
+).veryLongMethod();
+<<< 3.13
+function(veryLongArgument)
+    .veryLongMethod();
+>>> Function call with two arguments splits the target.
+function(argument, second).veryLongMethod();
+<<< 3.7
+function(
+  argument,
+  second,
+).veryLongMethod();
+>>> Instance creation with one argument splits the chain.
+new Thing(veryLongArgument).veryLongMethod();
+<<< 3.7
+new Thing(
+  veryLongArgument,
+).veryLongMethod();
+<<< 3.13
+new Thing(veryLongArgument)
+    .veryLongMethod();
+>>> Instance creation with two arguments splits the target.
+new Thing(argument, second).veryLongMethod();
+<<< 3.7
+new Thing(
+  argument,
+  second,
+).veryLongMethod();
+>>> Function expression call with one argument splits the chain.
+(function)(veryLongArgument).veryLongMethod();
+<<< 3.7
+(function)(veryLongArgument)
+    .veryLongMethod();
+<<< 3.8
+(function)(
+  veryLongArgument,
+).veryLongMethod();
+<<< 3.13
+(function)(veryLongArgument)
+    .veryLongMethod();
+>>> Function expression call with two arguments splits the target.
+(function)(argument, second).veryLongMethod();
+<<< 3.7
+(function)(argument, second)
+    .veryLongMethod();
+<<< 3.8
+(function)(
+  argument,
+  second,
+).veryLongMethod();
+>>> List literal with one element splits the chain.
+<TypeArgument>[veryLongArgument].veryLongMethod();
+<<< 3.7
+<TypeArgument>[
+  veryLongArgument,
+].veryLongMethod();
+<<< 3.13
+<TypeArgument>[veryLongArgument]
+    .veryLongMethod();
+>>> List literal with two elements splits the target.
+<TypeArgument>[argument, second].veryLongMethod();
+<<< 3.7
+<TypeArgument>[
+  argument,
+  second,
+].veryLongMethod();
+>>> Map literal with one entry splits the chain.
+<int, String>{longKey: veryLongValue}.veryLongMethod();
+<<< 3.7
+<int, String>{
+  longKey: veryLongValue,
+}.veryLongMethod();
+<<< 3.13
+<int, String>{longKey: veryLongValue}
+    .veryLongMethod();
+>>> Map literal with two entries splits the target.
+<int, String>{key: value, another: another}.veryLongMethod();
+<<< 3.7
+<int, String>{
+  key: value,
+  another: another,
+}.veryLongMethod();
+>>> Set literal with one element splits the chain.
+<TypeArgument>{veryLongArgument}.veryLongMethod();
+<<< 3.7
+<TypeArgument>{
+  veryLongArgument,
+}.veryLongMethod();
+<<< 3.13
+<TypeArgument>{veryLongArgument}
+    .veryLongMethod();
+>>> Set literal with two elements splits the target.
+<TypeArgument>{argument, second}.veryLongMethod();
+<<< 3.7
+<TypeArgument>{
+  argument,
+  second,
+}.veryLongMethod();
+>>> Record literal with one field splits the chain.
+(longField: veryLongArgument).veryLongMethod();
+<<< 3.7
+(
+  longField: veryLongArgument,
+).veryLongMethod();
+<<< 3.13
+(longField: veryLongArgument)
+    .veryLongMethod();
+>>> Record literal with two fields splits the target.
+(field: argument, second).veryLongMethod();
+<<< 3.7
+(
+  field: argument,
+  second,
+).veryLongMethod();
+>>> Wrapping the target in parentheses still applies the single-argument rule.
+(((function(veryLongArgument)))).veryLongMethod();
+<<< 3.7
+(((function(
+  veryLongArgument,
+)))).veryLongMethod();
+<<< 3.13
+(((function(veryLongArgument))))
+    .veryLongMethod();
+>>> Wrapping the target in await still applies the single-argument rule.
+(await function(veryLongArgument)).veryLongMethod();
+<<< 3.7
+(await function(
+  veryLongArgument,
+)).veryLongMethod();
+<<< 3.13
+(await function(veryLongArgument))
+    .veryLongMethod();
+>>> A target with a postfix `!` still applies the single-argument rule.
+function(veryLongArgument)!.veryLongMethod();
+<<< 3.7
+function(
+  veryLongArgument,
+)!.veryLongMethod();
+<<< 3.13
+function(veryLongArgument)!
+    .veryLongMethod();
+>>> Cascades prefer to split regardless of arity.
+function(veryLongArgument)..veryLongMethod();
+<<< 3.7
+function(veryLongArgument)
+  ..veryLongMethod();
+>>> Function call with two arguments splits the target.
+function(argument, second)..veryLongMethod();
+<<< 3.7
+function(argument, second)
+  ..veryLongMethod();
+>>> The single-argument rule applies when the chain is all properties.
+function(veryLongArgument).veryLongProperty;
+<<< 3.7
+function(
+  veryLongArgument,
+).veryLongProperty;
+<<< 3.13
+function(veryLongArgument)
+    .veryLongProperty;
+>>> The single-argument rule applies when the chain is all properties.
+function(argument, second).veryLongProperty;
+<<< 3.7
+function(
+  argument,
+  second,
+).veryLongProperty;

--- a/test/tall/invocation/chain_single_element_target.stmt
+++ b/test/tall/invocation/chain_single_element_target.stmt
@@ -171,3 +171,19 @@ function(
   argument,
   second,
 ).veryLongProperty;
+>>> Apply the single-argument rule to call chains with unsplit properties.
+function(veryLongArgument).prop.erty.someCall();
+<<< 3.7
+function(
+  veryLongArgument,
+).prop.erty.someCall();
+<<< 3.13
+function(veryLongArgument).prop.erty
+    .someCall();
+>>> The single-argument rule applies when the chain is all properties.
+function(argument, second).prop.erty.someCall();
+<<< 3.7
+function(
+  argument,
+  second,
+).prop.erty.someCall();

--- a/test/tall/regression/0000/0055.unit
+++ b/test/tall/regression/0000/0055.unit
@@ -13,6 +13,10 @@
   bool isSdkDir(String dirname) => new File(
     path.join(dirname, 'lib', '_internal', 'libraries.dart'),
   ).existsSync();
+<<< 3.13
+  bool isSdkDir(String dirname) =>
+      new File(path.join(dirname, 'lib', '_internal', 'libraries.dart'))
+          .existsSync();
 >>> (indent 6)
       bool isSdkDir(String dirname) =>
           new File(path.join(dirname, 'lib', '_internal', 'libraries.dart'))
@@ -26,6 +30,10 @@
       bool isSdkDir(String dirname) => new File(
         path.join(dirname, 'lib', '_internal', 'libraries.dart'),
       ).existsSync();
+<<< 3.13
+      bool isSdkDir(String dirname) =>
+          new File(path.join(dirname, 'lib', '_internal', 'libraries.dart'))
+              .existsSync();
 >>> (indent 12)
             bool isSdkDir(String dirname) =>
                 new File(path.join(dirname, 'lib', '_internal', 'libraries.dart'))

--- a/test/tall/regression/0000/0070.stmt
+++ b/test/tall/regression/0000/0070.stmt
@@ -9,8 +9,10 @@
         path.join(dirname, 'lib', '_internal', 'libraries.dart'),
       ).existsSync();
 <<< 3.8
-### TODO(rnystrom): Would look better if the constructor arguments didn't split
-### and we split at `.` instead.
   bool isSdkDir(String dirname) => new File(
     path.join(dirname, 'lib', '_internal', 'libraries.dart'),
   ).existsSync();
+<<< 3.13
+  bool isSdkDir(String dirname) =>
+      new File(path.join(dirname, 'lib', '_internal', 'libraries.dart'))
+          .existsSync();

--- a/test/tall/regression/0200/0206.stmt
+++ b/test/tall/regression/0200/0206.stmt
@@ -3,7 +3,9 @@ when(mockLoader.loadData(expectedRequestMetricInitialDateCTR))
     .thenReturn(
          _buildMinimalResponseFuture(MetricType.CTR, metricRequest));
 <<< 3.7
-### TODO(rnystrom): I think it would look better to split the method chain.
 when(
   mockLoader.loadData(expectedRequestMetricInitialDateCTR),
 ).thenReturn(_buildMinimalResponseFuture(MetricType.CTR, metricRequest));
+<<< 3.13
+when(mockLoader.loadData(expectedRequestMetricInitialDateCTR))
+    .thenReturn(_buildMinimalResponseFuture(MetricType.CTR, metricRequest));

--- a/test/tall/regression/0200/0211.unit
+++ b/test/tall/regression/0200/0211.unit
@@ -97,3 +97,8 @@ void defineProperty(obj, String property, value) {
       _class._jsConstructor,
     ].addAll(typeArguments.map((t) => t._asRuntimeType()));
   }
+<<< 3.13
+  _asRuntimeType() {
+    return [_class._jsConstructor]
+        .addAll(typeArguments.map((t) => t._asRuntimeType()));
+  }

--- a/test/tall/regression/0400/0413.unit
+++ b/test/tall/regression/0400/0413.unit
@@ -9,3 +9,8 @@ List get bindings => [
     const StaticFilePath(),
   ).toValue(_staticFilePath.isEmpty ? _libRoot : _staticFilePath),
 ];
+<<< 3.13
+List get bindings => [
+  bind(const StaticFilePath())
+      .toValue(_staticFilePath.isEmpty ? _libRoot : _staticFilePath),
+];

--- a/test/tall/regression/0600/0679.unit
+++ b/test/tall/regression/0600/0679.unit
@@ -24,3 +24,15 @@ class UnitConverterApp extends StatelessWidget {
     );
   }
 }
+<<< 3.13
+class UnitConverterApp extends StatelessWidget {
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(
+        textTheme: Theme.of(context)
+            .textTheme
+            .apply(bodyColor: Colors.black, displayColor: Colors.grey[600]),
+      ),
+    );
+  }
+}

--- a/test/tall/regression/0600/0679.unit
+++ b/test/tall/regression/0600/0679.unit
@@ -29,8 +29,7 @@ class UnitConverterApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(
-        textTheme: Theme.of(context)
-            .textTheme
+        textTheme: Theme.of(context).textTheme
             .apply(bodyColor: Colors.black, displayColor: Colors.grey[600]),
       ),
     );

--- a/test/tall/regression/0700/0765.stmt
+++ b/test/tall/regression/0700/0765.stmt
@@ -69,3 +69,15 @@ Stream<dynamic> refreshEpic(
     return Observable.just(RefreshSuccessAction()).delay(Duration(seconds: 2));
   });
 }
+<<< 3.13
+Stream<dynamic> refreshEpic(
+  Stream<dynamic> actions,
+  EpicStore<AppState> store,
+) {
+  return Observable(actions)
+      .ofType(TypeToken<RefreshAction>())
+      .switchMap((action) {
+        return Observable.just(RefreshSuccessAction())
+            .delay(Duration(seconds: 2));
+      });
+}

--- a/test/tall/regression/0800/0855.unit
+++ b/test/tall/regression/0800/0855.unit
@@ -95,3 +95,39 @@ Method _main() => Method(
       refer('exitCode', 'dart:io').assign(refer('result')).statement,
     ]),
 );
+<<< 3.13
+Method _main() => Method(
+  (b) => b
+    ..name = 'main'
+    ..modifier = MethodModifier.async
+    ..requiredParameters.add(
+      Parameter(
+        (b) => b
+          ..name = 'args'
+          ..type = TypeReference(
+            (b) => b
+              ..symbol = 'List'
+              ..types.add(refer('String')),
+          ),
+      ),
+    )
+    ..optionalParameters.add(
+      Parameter(
+        (b) => b
+          ..name = 'sendPort'
+          ..type = refer('SendPort', 'dart:isolate'),
+      ),
+    )
+    ..body = Block.of([
+      refer('run', 'package:build_runner/build_runner.dart')
+          .call([refer('args'), refer('_builders')])
+          .awaited
+          .assignVar('result')
+          .statement,
+      refer('sendPort')
+          .nullSafeProperty('send')
+          .call([refer('result')])
+          .statement,
+      refer('exitCode', 'dart:io').assign(refer('result')).statement,
+    ]),
+);

--- a/test/tall/regression/0800/0881.unit
+++ b/test/tall/regression/0800/0881.unit
@@ -108,6 +108,46 @@ void main() async {
     });
   });
 }
+<<< 3.13
+void main() async {
+  group('my group', () {
+    setUp(() async {
+      final requestHandler = FakeRequestHandler()
+        ..when(withServiceName(Ng2ProtoFooBarBazService.serviceName))
+            .thenRespond(
+              FooBarBazListResponse()
+                ..entities.add(
+                  FooBarBaz()
+                    ..fooBarBazEntityId = entityId
+                    ..name = 'Test entity'
+                    ..baseFooBarBazId = baseFooBarBazId
+                    ..entityFooBarBazId = entityFooBarBazId,
+                ),
+            )
+        ..when(
+          allOf(
+            withServiceName(Ng2ProtoFooBarBazService.serviceName),
+            hasFooBarBazId(baseFooBarBazId),
+          ),
+        ).thenRespond(FooBarBazListResponse()..entities.add(baseFooBarBaz))
+        ..when(
+          allOf(
+            withServiceName(Ng2ProtoFooBarBazService.serviceName),
+            hasFooBarBazId(entityFooBarBazId),
+          ),
+        ).thenRespond(FooBarBazListResponse()..entities.add(entityFooBarBaz))
+        ..when(
+          allOf(
+            withServiceName(Ng2ProtoFooBarBazService.serviceName),
+            hasFooBarBazIds(Set.from([baseFooBarBazId, entityFooBarBazId])),
+          ),
+        ).thenRespond(
+          FooBarBazListResponse()
+            ..entities.addAll([baseFooBarBaz, entityFooBarBaz]),
+        );
+    });
+  });
+}
 >>>
 aaaa() {
   {

--- a/test/tall/regression/1400/1429.stmt
+++ b/test/tall/regression/1400/1429.stmt
@@ -69,6 +69,11 @@ main() {
     PdfDocumentHelper.getHelper(
       _helper.crossTable!.document!,
     ).catalog.beginSaveList ??= <SavePdfPrimitiveCallback>[];
+<<< 3.13
+    PdfDocumentHelper.getHelper(_helper.crossTable!.document!)
+            .catalog
+            .beginSaveList ??=
+        <SavePdfPrimitiveCallback>[];
 >>> (indent 12)
             PdfSecurityHelper.getHelper(
                   _helper._security!,
@@ -82,6 +87,11 @@ main() {
             PdfSecurityHelper.getHelper(
               _helper._security!,
             ).encryptor.encryptOnlyAttachment = false;
+<<< 3.13
+            PdfSecurityHelper.getHelper(_helper._security!)
+                    .encryptor
+                    .encryptOnlyAttachment =
+                false;
 >>> (indent 6)
       PdfGridHelper.getHelper(
             PdfGridRowHelper.getHelper(_helper.row!).grid,
@@ -94,6 +104,10 @@ main() {
       PdfGridHelper.getHelper(
         PdfGridRowHelper.getHelper(_helper.row!).grid,
       ).hasColumnSpan = true;
+<<< 3.13
+      PdfGridHelper.getHelper(PdfGridRowHelper.getHelper(_helper.row!).grid)
+              .hasColumnSpan =
+          true;
 >>> (indent 2)
   Widget build(BuildContext context) => CompositionRoot(
     configureOverrides: configureOverrides,

--- a/test/tall/regression/1700/1732.stmt
+++ b/test/tall/regression/1700/1732.stmt
@@ -1,0 +1,22 @@
+>>> (indent 24)
+                        GoRouter.of(
+                          context,
+                        ).go('/play/session/${level.number}');
+<<< 3.8
+                        GoRouter.of(
+                          context,
+                        ).go('/play/session/${level.number}');
+<<< 3.13
+                        GoRouter.of(context)
+                            .go('/play/session/${level.number}');
+>>> (indent 2)
+  when(
+    mockApi.fetchUser(id: '123', includeMetadata: true),
+  ).thenAnswer((_) async => 'Test User');
+<<< 3.8
+  when(
+    mockApi.fetchUser(id: '123', includeMetadata: true),
+  ).thenAnswer((_) async => 'Test User');
+<<< 3.13
+  when(mockApi.fetchUser(id: '123', includeMetadata: true))
+      .thenAnswer((_) async => 'Test User');


### PR DESCRIPTION
One of the most challenging parts of formatting Dart code well is dealing with method call chains on targets that can themselves split. The formatter needs to decide whether to split the target and avoid splitting the call chain or vice versa. For example:

```dart
// Split target:
function(
  argument,
).method().another();

// Or split chain:
function(argument)
  .method()
  .another();
```

Heuristics for that choice that look great on some callsites often make others look worse. I've toyed with many variations over the years.

This adds a fairly simple rule based on the examples in (#1732): If the target of a call chain only has *one* element or argument, then prefer to split the call chain and keep the target together. So in the above example, if prefers the second output. If `function()` had multiple arguments, it would prefer the first.

An intuitive argument in favor of this rule is that when we split a comma-separated argument or element list, what feels most intuitive to readers is splitting *between* the elements. Then as a secondary effect, we also split around the delimiting brackets to. If there is only one element, then there's no way to split between them, only around them. That doesn't look as good, so this style change avoids that.

Pragmatically, I think the results of the new rule look good. You can see a diff of running this on a random assortment of pub packages [here](https://gist.github.com/munificent/7d39fa6cd7667e8b9d9458638753e4f3).

This is a larger change than most these days. I ran it on a large corpus of files from Pub:

```
Affected / total files : 3,511 / 93,664 (~3.7%)
Affected / total lines : 35,770 / 22,424,287 (0.13%)
```

For affected lines, I'm ignoring additions and counting only the number of deleted lines from running `git diff --stat`. Since the formatter is always replacing a chunk of lines with another, I think that's a good way to measure the number of original lines which are impacted.

Fix #1732
