### PR TITLE
Separate imports into sections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,33 @@
 
   This change is language versioned and only affects code at 3.13 or higher.
 
-*  In if-case pieces, split the guard if the pattern block-splits (#1596).
+* Separate imports into sections (#1120). Following the guidelines in
+  ["Effective Dart"][sections], the formatter inserts a blank line between
+  "dart:", "package:", and other imports:
+
+  ```dart
+  // Before:
+  import 'dart:io';
+  import 'dart:math';
+  import 'package:args/args.dart';
+  import 'package:test/test.dart';
+  import 'my_library.dart';
+
+  // After:
+  import 'dart:io';
+  import 'dart:math';
+
+  import 'package:args/args.dart';
+  import 'package:test/test.dart';
+
+  import 'my_library.dart';
+  ```
+
+  This change is language versioned and only affects code at 3.13 or higher.
+
+[sections]: https://dart.dev/effective-dart/style#ordering
+
+* In if-case pieces, split the guard if the pattern block-splits (#1596).
 
   This tends to lead to code where the pattern is kept on one line and the
   guard splits:

--- a/example/format.dart
+++ b/example/format.dart
@@ -19,12 +19,15 @@ void main(List<String> args) {
   debug.traceSolverDequeing = true;
   debug.traceSolverShowCode = true;
 
-  _formatStmt('''
-  1 + 2;
-  ''');
+  // _formatStmt('''
+  // 1 + 2;
+  // ''');
 
   _formatUnit('''
-  class C {}
+  import 'dart:io';
+  // import 'dart:math';
+
+  import 'foo.dart';
   ''');
 }
 

--- a/example/format.dart
+++ b/example/format.dart
@@ -19,15 +19,12 @@ void main(List<String> args) {
   debug.traceSolverDequeing = true;
   debug.traceSolverShowCode = true;
 
-  // _formatStmt('''
-  // 1 + 2;
-  // ''');
+  _formatStmt('''
+  1 + 2;
+  ''');
 
   _formatUnit('''
-  import 'dart:io';
-  // import 'dart:math';
-
-  import 'foo.dart';
+  class C {}
   ''');
 }
 

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -100,8 +100,22 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
         directives = directives.skip(1);
       }
 
+      var precedingSection = _DirectiveSection.none;
       for (var directive in directives) {
-        sequence.visit(directive);
+        // Separate sections of different import categories with blank lines.
+        var needsBlank = false;
+        if (style.separateDirectiveSections) {
+          var section = _DirectiveSection.parse(directive);
+          if (section != _DirectiveSection.none &&
+              precedingSection != _DirectiveSection.none &&
+              section != precedingSection) {
+            needsBlank = true;
+          }
+
+          precedingSection = section;
+        }
+
+        sequence.visit(directive, blankBefore: needsBlank);
       }
 
       // Add a blank line between directives and declarations.
@@ -2307,5 +2321,41 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
     }
 
     _parentContext = previousContext;
+  }
+}
+
+/// The sections of imports and exports that should have blank lines between
+/// them.
+///
+/// "Effective Dart" says that "dart:", "package:", and other imports and
+/// exports should be grouped into their own sections with blank lines between
+/// them. The formatter doesn't reorder directives, but it can enforce a blank
+/// line between sections.
+///
+/// See: https://dart.dev/effective-dart/style#ordering
+enum _DirectiveSection {
+  /// A "dart:" URI.
+  dart,
+
+  /// A "package:" URI.
+  package,
+
+  /// A relative or other kind of URI.
+  other,
+
+  /// A directive that doesn't have a URI.
+  none;
+
+  /// Returns the section that [directive] belongs to, for the purpose of
+  /// [separateImportSections].
+  static _DirectiveSection parse(Directive directive) {
+    if (directive is! NamespaceDirective) return _DirectiveSection.none;
+
+    var uri = directive.uri.stringValue;
+    if (uri == null) return _DirectiveSection.none;
+
+    if (uri.startsWith('dart:')) return _DirectiveSection.dart;
+    if (uri.startsWith('package:')) return _DirectiveSection.package;
+    return _DirectiveSection.other;
   }
 }

--- a/lib/src/front_end/formatting_style.dart
+++ b/lib/src/front_end/formatting_style.dart
@@ -75,6 +75,10 @@ final class FormattingStyle {
   /// clause as well.
   bool get blockFormatIfCaseWithGuard => _languageVersion < _version3Dot13;
 
+  /// Whether to force a blank line between imports and exports whose URIs are
+  /// different categories: `dart:`, `package:`, or relative.
+  bool get separateDirectiveSections => _languageVersion >= _version3Dot13;
+
   /// Whether there is a trailing comma at the end of the list delimited by
   /// [rightBracket] which should be preserved by this style.
   bool preserveTrailingCommaBefore(Token rightBracket) =>

--- a/lib/src/front_end/sequence_builder.dart
+++ b/lib/src/front_end/sequence_builder.dart
@@ -99,8 +99,22 @@ final class SequenceBuilder {
 
   /// Visits [node] and adds the resulting [Piece] to this sequence, handling
   /// any comments or blank lines that appear before it.
-  void visit(AstNode node, {Indent? indent, bool allowBlankAfter = true}) {
-    addCommentsBefore(node.firstNonCommentToken, indent: indent);
+  ///
+  /// If [blankBefore] is `true`, then writes a blank line before [node], but
+  /// after any comments that may precede [node].
+  void visit(
+    AstNode node, {
+    Indent? indent,
+    bool blankBefore = false,
+    bool allowBlankAfter = true,
+  }) {
+    var wroteBlank = addCommentsBefore(
+      node.firstNonCommentToken,
+      indent: indent,
+    );
+
+    if (blankBefore && !wroteBlank) addBlank();
+
     add(
       _visitor.nodePiece(node),
       indent: indent,
@@ -122,9 +136,13 @@ final class SequenceBuilder {
   ///
   /// Comments between sequence elements get special handling where comments
   /// on their own line become standalone sequence elements.
-  void addCommentsBefore(Token token, {Indent? indent}) {
+  ///
+  /// Returns `true` if processing the comments ended up writing any blank
+  /// lines.
+  bool addCommentsBefore(Token token, {Indent? indent}) {
     indent ??= Indent.none;
 
+    var wroteBlank = false;
     var comments = _visitor.comments.takeCommentsBefore(token);
     for (var i = 0; i < comments.length; i++) {
       var comment = _visitor.pieces.commentPiece(comments[i]);
@@ -137,6 +155,7 @@ final class SequenceBuilder {
           // Always preserve a blank line above sequence-level comments.
           _allowBlank = true;
           addBlank();
+          wroteBlank = true;
         }
 
         // Write the comment as its own sequence piece.
@@ -151,6 +170,9 @@ final class SequenceBuilder {
       if (comments.isNotEmpty) _allowBlank = true;
 
       addBlank();
+      wroteBlank = true;
     }
+
+    return wroteBlank;
   }
 }

--- a/test/tall/top_level/export_section.unit
+++ b/test/tall/top_level/export_section.unit
@@ -1,0 +1,83 @@
+40 columns                              |
+>>> Don't force a blank line between adjacent "dart:" exports.
+export 'dart:io'; export "dart:math";
+<<< 3.7
+export 'dart:io';
+export "dart:math";
+>>> Preserve one blank line between adjacent "dart:" exports.
+export 'dart:io';
+
+
+
+export "dart:math";
+<<< 3.7
+export 'dart:io';
+
+export "dart:math";
+>>> Don't force a blank line between adjacent "package:" exports.
+export "package:foo/foo.dart"; export 'package:bar/bar.dart';
+<<< 3.7
+export "package:foo/foo.dart";
+export 'package:bar/bar.dart';
+>>> Preserve one blank line between adjacent "package:" exports.
+export "package:foo/foo.dart";
+
+
+
+export 'package:bar/bar.dart';
+<<< 3.7
+export "package:foo/foo.dart";
+
+export 'package:bar/bar.dart';
+>>> Don't force a blank line between adjacent relative exports.
+export 'foo.dart'; export "bar.dart";
+<<< 3.7
+export 'foo.dart';
+export "bar.dart";
+>>> Preserve one blank line between adjacent relative exports.
+export 'foo.dart';
+
+
+
+export "bar.dart";
+<<< 3.7
+export 'foo.dart';
+
+export "bar.dart";
+>>> Force a blank line between exports of different categories.
+export 'dart:io';
+export "dart:math";
+export "package:foo/foo.dart";
+export 'package:bar/bar.dart';
+export 'foo.dart';
+export "bar.dart";
+export "package:foo/foo.dart";
+export 'package:bar/bar.dart';
+export 'dart:io';
+export "dart:math";
+<<< 3.7
+export 'dart:io';
+export "dart:math";
+export "package:foo/foo.dart";
+export 'package:bar/bar.dart';
+export 'foo.dart';
+export "bar.dart";
+export "package:foo/foo.dart";
+export 'package:bar/bar.dart';
+export 'dart:io';
+export "dart:math";
+<<< 3.13
+export 'dart:io';
+export "dart:math";
+
+export "package:foo/foo.dart";
+export 'package:bar/bar.dart';
+
+export 'foo.dart';
+export "bar.dart";
+
+export "package:foo/foo.dart";
+export 'package:bar/bar.dart';
+
+export 'dart:io';
+export "dart:math";

--- a/test/tall/top_level/import_section.unit
+++ b/test/tall/top_level/import_section.unit
@@ -1,0 +1,103 @@
+40 columns                              |
+>>> Don't force a blank line between adjacent "dart:" imports.
+import 'dart:io'; import "dart:math";
+<<< 3.7
+import 'dart:io';
+import "dart:math";
+>>> Preserve one blank line between adjacent "dart:" imports.
+import 'dart:io';
+
+
+
+import "dart:math";
+<<< 3.7
+import 'dart:io';
+
+import "dart:math";
+>>> Don't force a blank line between adjacent "package:" imports.
+import "package:foo/foo.dart"; import 'package:bar/bar.dart';
+<<< 3.7
+import "package:foo/foo.dart";
+import 'package:bar/bar.dart';
+>>> Preserve one blank line between adjacent "package:" imports.
+import "package:foo/foo.dart";
+
+
+
+import 'package:bar/bar.dart';
+<<< 3.7
+import "package:foo/foo.dart";
+
+import 'package:bar/bar.dart';
+>>> Don't force a blank line between adjacent relative imports.
+import 'foo.dart'; import "bar.dart";
+<<< 3.7
+import 'foo.dart';
+import "bar.dart";
+>>> Preserve one blank line between adjacent relative imports.
+import 'foo.dart';
+
+
+
+import "bar.dart";
+<<< 3.7
+import 'foo.dart';
+
+import "bar.dart";
+>>> Force a blank line between imports of different categories.
+import 'dart:io';
+import "dart:math";
+import "package:foo/foo.dart";
+import 'package:bar/bar.dart';
+import 'foo.dart';
+import "bar.dart";
+import "package:foo/foo.dart";
+import 'package:bar/bar.dart';
+import 'dart:io';
+import "dart:math";
+<<< 3.7
+import 'dart:io';
+import "dart:math";
+import "package:foo/foo.dart";
+import 'package:bar/bar.dart';
+import 'foo.dart';
+import "bar.dart";
+import "package:foo/foo.dart";
+import 'package:bar/bar.dart';
+import 'dart:io';
+import "dart:math";
+<<< 3.13
+import 'dart:io';
+import "dart:math";
+
+import "package:foo/foo.dart";
+import 'package:bar/bar.dart';
+
+import 'foo.dart';
+import "bar.dart";
+
+import "package:foo/foo.dart";
+import 'package:bar/bar.dart';
+
+import 'dart:io';
+import "dart:math";
+>>> Don't force blank line before trailing commented out import.
+import 'dart:io';
+// import 'dart:math';
+
+import 'foo.dart';
+<<< 3.7
+import 'dart:io';
+// import 'dart:math';
+
+import 'foo.dart';
+>>> Don't force blank line after leading commented out import.
+import 'dart:io';
+
+// import 'foo.dart';
+import 'bar.dart';
+<<< 3.7
+import 'dart:io';
+
+// import 'foo.dart';
+import 'bar.dart';


### PR DESCRIPTION
"Effective Dart" has long told users to group imports by "dart:", "package:", and relative, with a blank line between each section. The formatter doesn't reorder imports, but it can at least put a blank line between imports that belong in different sections.

Fix #1120.
