### PR TITLE
Move fixing a piece's state by page width to before solving.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@
 
 ### Style changes
 
+* Fix a bug in an eager splitting optimization that would led the formatter to
+  prefer less desirable solutions (#1847).
+
+  Typically, the code affected by this bug is a call chain that contains an
+  argument list with a large collection literal, as in:
+
+  ```dart
+  // Before:
+  await MethodChannelContainer()
+      .onMethodChannelInvoke("reportCrash", <String, dynamic>{
+        "time": nowTime,
+        "errorValue": errorName,
+        "reason": reason,
+        "stacktrace": stacktrace,
+      });
+
+  // After:
+  await MethodChannelContainer().onMethodChannelInvoke(
+    "reportCrash",
+    <String, dynamic>{
+      "time": nowTime,
+      "errorValue": errorName,
+      "reason": reason,
+      "stacktrace": stacktrace,
+    },
+  );
+  ```
+
+  This change is language versioned and only affects code at 3.13 or higher.
+
 * Prefer to split call chains for single-element targets (#1732).
 
   When formatting a method call chain whose target can also split, the formatter

--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -154,7 +154,7 @@ final class CodeWriter {
   /// Increases the indentation by [indent] relative to the current amount of
   /// indentation.
   void pushIndent(Indent indent) {
-    if (_cache.is3Dot7) {
+    if (_cache.style.is3Dot7) {
       _pushIndent3Dot7(indent);
     } else {
       var parent = _indentStack.last;
@@ -191,7 +191,7 @@ final class CodeWriter {
   /// This is only used in a couple of corners of if-case and for-in headers
   /// where the indentation is unusual.
   void pushCollapsibleIndent() {
-    if (_cache.is3Dot7) {
+    if (_cache.style.is3Dot7) {
       _pushIndent3Dot7(Indent.expression, canCollapse: true);
     } else {
       pushIndent(Indent.controlFlowClause);
@@ -362,7 +362,7 @@ final class CodeWriter {
 
     // See if we can immediately bind it based on the page width and the piece's
     // contents.
-    if (isUnsolved) {
+    if (isUnsolved && !_cache.style.pinStateByPageWidthBeforeSolving) {
       // If the solution doesn't bind the piece already, we may be able to
       // eagerly bind it to a state knowing just the page width (minus any
       // leading indentation). If so, do that now. We do that here instead of
@@ -398,7 +398,7 @@ final class CodeWriter {
       );
 
       bool invalid;
-      if (_cache.is3Dot7) {
+      if (_cache.style.is3Dot7) {
         // If the child must be inline, then invalidate because we know it
         // contains some kind of newline.
         // TODO(rnystrom): It would be better if this logic wasn't different for

--- a/lib/src/back_end/solution.dart
+++ b/lib/src/back_end/solution.dart
@@ -146,6 +146,11 @@ final class Solution implements Comparable<Solution> {
   ///
   /// If it can, binds the piece to that state in this solution and returns
   /// `true`. Otherwise returns `false`.
+  ///
+  /// This code has a bug, but is kept for older language versions to avoid
+  /// unexpected formatting changes.
+  ///
+  /// See: https://github.com/dart-lang/dart_style/issues/1847
   bool tryBindByPageWidth(Piece piece, int pageWidth) {
     if (piece.fixedStateForPageWidth(pageWidth) case var state?) {
       _bind(piece, state);

--- a/lib/src/back_end/solution_cache.dart
+++ b/lib/src/back_end/solution_cache.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../front_end/formatting_style.dart';
 import '../piece/piece.dart';
 import 'solution.dart';
 import 'solver.dart';
@@ -23,12 +24,11 @@ import 'solver.dart';
 /// indentation. When that happens, sharing this cache allows us to reuse that
 /// cached subtree Solution.
 final class SolutionCache {
-  /// Whether this cache and all solutions in it use the 3.7 style solver.
-  final bool is3Dot7;
+  final FormattingStyle style;
 
   final _cache = <_Key, Solution>{};
 
-  SolutionCache({required this.is3Dot7});
+  SolutionCache(this.style);
 
   /// Returns a previously cached solution for formatting [root] with leading
   /// [indent] (and [subsequentIndent] for lines after the first) or produces a

--- a/lib/src/back_end/solver.dart
+++ b/lib/src/back_end/solver.dart
@@ -176,8 +176,10 @@ final class Solver {
     if (debug.traceSolver) {
       debug.unindent();
       debug.log(debug.bold('Solved $root to $best'));
-      debug.log(best.code.toDebugString());
-      debug.log('');
+      if (debug.traceSolverShowCode) {
+        debug.log(best.code.toDebugString());
+        debug.log('');
+      }
     }
 
     return best;

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -750,7 +750,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
       this,
       node.metadata,
       [node.extensionKeyword, node.typeKeyword],
-      namePart: node.primaryConstructor,
+      namePart: node.namePart,
       implementsClause: node.implementsClause,
     );
     builder.buildClassBody(node.body);

--- a/lib/src/front_end/formatting_style.dart
+++ b/lib/src/front_end/formatting_style.dart
@@ -85,6 +85,18 @@ final class FormattingStyle {
   /// different categories: `dart:`, `package:`, or relative.
   bool get separateDirectiveSections => _languageVersion >= _version3Dot13;
 
+  /// Whether to try to figure out a piece's state based on the page width
+  /// before running the solver or during.
+  ///
+  /// Initially, this ran during solving but that leads to some subtle bugs in
+  /// the solver. Performing it before solving is less effective for performance
+  /// but avoids those bugs.
+  ///
+  /// We language version this even though the old logic was never correct to
+  /// minimize unexpected churn.
+  bool get pinStateByPageWidthBeforeSolving =>
+      _languageVersion >= _version3Dot13;
+
   /// Whether there is a trailing comma at the end of the list delimited by
   /// [rightBracket] which should be preserved by this style.
   bool preserveTrailingCommaBefore(Token rightBracket) =>

--- a/lib/src/front_end/piece_writer.dart
+++ b/lib/src/front_end/piece_writer.dart
@@ -456,12 +456,16 @@ final class PieceWriter {
 
     Profile.begin('PieceWriter.finish() format piece tree');
 
-    var cache = SolutionCache(is3Dot7: style.is3Dot7);
+    var cache = SolutionCache(style);
     var solver = Solver(
       cache,
       pageWidth: style.pageWidth,
       leadingIndent: style.leadingIndent,
     );
+
+    if (style.pinStateByPageWidthBeforeSolving) {
+      _pinPiecesByPageWidth(rootPiece, style.pageWidth - style.leadingIndent);
+    }
 
     var solution = solver.format(rootPiece);
     var output = solution.code.build(source, style.lineEnding);
@@ -469,6 +473,21 @@ final class PieceWriter {
     Profile.end('PieceWriter.finish() format piece tree');
 
     return output;
+  }
+
+  /// Traverse the piece tree at [rootPiece] and attempt to pin pieces to states
+  /// if the [pageWidth] and the contents of the pieces are enough to
+  /// determine what state the piece will end up in.
+  void _pinPiecesByPageWidth(Piece rootPiece, int pageWidth) {
+    void traverse(Piece piece) {
+      if (piece.fixedStateForPageWidth(pageWidth) case var state?) {
+        piece.pin(state);
+      }
+
+      piece.forEachChild(traverse);
+    }
+
+    traverse(rootPiece);
   }
 
   /// Returns the number of characters past [position] in the source where the

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -1171,7 +1171,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
     space();
     token(node.typeKeyword);
 
-    visit(node.primaryConstructor, before: space);
+    visit(node.namePart, before: space);
 
     builder.startRule(CombinatorRule());
     visit(node.implementsClause);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
-  analyzer: ^13.0.0
+  analyzer: ^13.1.0
   args: ^2.5.0
   collection: ^1.19.0
   package_config: ^2.1.0

--- a/test/tall/regression/1800/1847.unit
+++ b/test/tall/regression/1800/1847.unit
@@ -1,0 +1,333 @@
+>>>
+main() async {
+  {
+    await MethodChannelContainer()
+        .onMethodChannelInvoke("reportCrash", <String, dynamic>{
+          "time": nowTime,
+          "errorValue": errorName,
+          "reason": reason,
+          "stacktrace": stacktrace,
+        });
+  }
+}
+<<< 3.7
+main() async {
+  {
+    await MethodChannelContainer()
+        .onMethodChannelInvoke("reportCrash", <String, dynamic>{
+          "time": nowTime,
+          "errorValue": errorName,
+          "reason": reason,
+          "stacktrace": stacktrace,
+        });
+  }
+}
+<<< 3.13
+main() async {
+  {
+    await MethodChannelContainer().onMethodChannelInvoke(
+      "reportCrash",
+      <String, dynamic>{
+        "time": nowTime,
+        "errorValue": errorName,
+        "reason": reason,
+        "stacktrace": stacktrace,
+      },
+    );
+  }
+}
+>>> (indent 4) abrevva-3.0.4/lib/abrevva_method_channel.dart
+    final result = await _methodChannel
+        .invokeMethod<Map<dynamic, dynamic>?>('read', {
+          'deviceId': deviceId,
+          'service': service,
+          'characteristic': characteristic,
+          'timeout': timeout,
+        });
+<<< 3.7
+    final result = await _methodChannel
+        .invokeMethod<Map<dynamic, dynamic>?>('read', {
+          'deviceId': deviceId,
+          'service': service,
+          'characteristic': characteristic,
+          'timeout': timeout,
+        });
+<<< 3.13
+    final result = await _methodChannel.invokeMethod<Map<dynamic, dynamic>?>(
+      'read',
+      {
+        'deviceId': deviceId,
+        'service': service,
+        'characteristic': characteristic,
+        'timeout': timeout,
+      },
+    );
+>>> amplify_auth_cognito_dart-0.11.20/lib/src/model/hosted_ui/oauth_parameters.g.dart
+final BuiltSet<OAuthErrorCode> _$values =
+    BuiltSet<OAuthErrorCode>(const <OAuthErrorCode>[
+      _$invalidRequest,
+      _$unauthorizedClient,
+      _$accessDenied,
+      _$unsupportedResponseType,
+      _$invalidScope,
+      _$serverError,
+      _$temporarilyUnavailable,
+      _$interactionRequired,
+      _$loginRequired,
+      _$accountSelectionRequired,
+      _$consentRequired,
+      _$invalidRequestUri,
+      _$invalidRequestObject,
+      _$requestNotSupported,
+      _$requestUriNotSupported,
+      _$registrationUriNotSupported,
+    ]);
+<<< 3.7
+final BuiltSet<OAuthErrorCode> _$values =
+    BuiltSet<OAuthErrorCode>(const <OAuthErrorCode>[
+      _$invalidRequest,
+      _$unauthorizedClient,
+      _$accessDenied,
+      _$unsupportedResponseType,
+      _$invalidScope,
+      _$serverError,
+      _$temporarilyUnavailable,
+      _$interactionRequired,
+      _$loginRequired,
+      _$accountSelectionRequired,
+      _$consentRequired,
+      _$invalidRequestUri,
+      _$invalidRequestObject,
+      _$requestNotSupported,
+      _$requestUriNotSupported,
+      _$registrationUriNotSupported,
+    ]);
+<<< 3.13
+final BuiltSet<OAuthErrorCode> _$values = BuiltSet<OAuthErrorCode>(
+  const <OAuthErrorCode>[
+    _$invalidRequest,
+    _$unauthorizedClient,
+    _$accessDenied,
+    _$unsupportedResponseType,
+    _$invalidScope,
+    _$serverError,
+    _$temporarilyUnavailable,
+    _$interactionRequired,
+    _$loginRequired,
+    _$accountSelectionRequired,
+    _$consentRequired,
+    _$invalidRequestUri,
+    _$invalidRequestObject,
+    _$requestNotSupported,
+    _$requestUriNotSupported,
+    _$registrationUriNotSupported,
+  ],
+);
+>>> amplify_datastore-2.11.0/example/integration_test/utils/test_cloud_synced_model_operation.dart
+Future<List<SubscriptionEvent<T>>> createObservedEventsGetter<T extends Model>(
+  ModelType<T> modelType, {
+  required int take,
+  required EventType eventType,
+}) => Amplify.DataStore.observe(modelType)
+    .where((event) => event.eventType == eventType)
+    .distinct(
+      (prev, next) =>
+          prev.eventType == next.eventType &&
+          prev.item.modelIdentifier == next.item.modelIdentifier,
+    )
+    .take(take)
+    .toList();
+<<< 3.7
+Future<List<SubscriptionEvent<T>>> createObservedEventsGetter<T extends Model>(
+  ModelType<T> modelType, {
+  required int take,
+  required EventType eventType,
+}) =>
+    Amplify.DataStore.observe(modelType)
+        .where((event) => event.eventType == eventType)
+        .distinct(
+          (prev, next) =>
+              prev.eventType == next.eventType &&
+              prev.item.modelIdentifier == next.item.modelIdentifier,
+        )
+        .take(take)
+        .toList();
+<<< 3.8
+Future<List<SubscriptionEvent<T>>> createObservedEventsGetter<T extends Model>(
+  ModelType<T> modelType, {
+  required int take,
+  required EventType eventType,
+}) => Amplify.DataStore.observe(modelType)
+    .where((event) => event.eventType == eventType)
+    .distinct(
+      (prev, next) =>
+          prev.eventType == next.eventType &&
+          prev.item.modelIdentifier == next.item.modelIdentifier,
+    )
+    .take(take)
+    .toList();
+<<< 3.13
+### TODO(rnystrom): It shouldn't split after `=>`, but there is some subtle bug
+### around how overflow is used to order solutions. If we don't take overflow
+### into account when comparing solutions, this is fixed, but lots of other
+### things break. An unfortunately load-bearing bug.
+Future<List<SubscriptionEvent<T>>> createObservedEventsGetter<T extends Model>(
+  ModelType<T> modelType, {
+  required int take,
+  required EventType eventType,
+}) =>
+    Amplify.DataStore.observe(modelType)
+        .where((event) => event.eventType == eventType)
+        .distinct(
+          (prev, next) =>
+              prev.eventType == next.eventType &&
+              prev.item.modelIdentifier == next.item.modelIdentifier,
+        )
+        .take(take)
+        .toList();
+>>> analyzer_plugin-0.14.9/test/integration/support/protocol_matchers.dart
+final Matcher isCompletionSuggestionKind =
+    MatchesEnum('CompletionSuggestionKind', [
+      'ARGUMENT_LIST',
+      'IMPORT',
+      'IDENTIFIER',
+      'INVOCATION',
+      'KEYWORD',
+      'NAMED_ARGUMENT',
+      'OPTIONAL_ARGUMENT',
+      'OVERRIDE',
+      'PARAMETER',
+      'PACKAGE_NAME',
+    ]);
+<<< 3.7
+final Matcher isCompletionSuggestionKind =
+    MatchesEnum('CompletionSuggestionKind', [
+      'ARGUMENT_LIST',
+      'IMPORT',
+      'IDENTIFIER',
+      'INVOCATION',
+      'KEYWORD',
+      'NAMED_ARGUMENT',
+      'OPTIONAL_ARGUMENT',
+      'OVERRIDE',
+      'PARAMETER',
+      'PACKAGE_NAME',
+    ]);
+<<< 3.13
+final Matcher isCompletionSuggestionKind = MatchesEnum(
+  'CompletionSuggestionKind',
+  [
+    'ARGUMENT_LIST',
+    'IMPORT',
+    'IDENTIFIER',
+    'INVOCATION',
+    'KEYWORD',
+    'NAMED_ARGUMENT',
+    'OPTIONAL_ARGUMENT',
+    'OVERRIDE',
+    'PARAMETER',
+    'PACKAGE_NAME',
+  ],
+);
+>>> animations-2.2.0/lib/src/fade_through_transition.dart
+class C {
+  static final TweenSequence<double> _fadeOutOpacity =
+      TweenSequence<double>(<TweenSequenceItem<double>>[
+        TweenSequenceItem<double>(
+          tween: Tween<double>(begin: 1.0, end: 0.0).chain(_outCurve),
+          weight: 6 / 20,
+        ),
+        TweenSequenceItem<double>(
+          tween: ConstantTween<double>(0.0),
+          weight: 14 / 20,
+        ),
+      ]);
+}
+<<< 3.7
+class C {
+  static final TweenSequence<double> _fadeOutOpacity =
+      TweenSequence<double>(<TweenSequenceItem<double>>[
+        TweenSequenceItem<double>(
+          tween: Tween<double>(begin: 1.0, end: 0.0).chain(_outCurve),
+          weight: 6 / 20,
+        ),
+        TweenSequenceItem<double>(
+          tween: ConstantTween<double>(0.0),
+          weight: 14 / 20,
+        ),
+      ]);
+}
+<<< 3.13
+class C {
+  static final TweenSequence<double> _fadeOutOpacity = TweenSequence<double>(
+    <TweenSequenceItem<double>>[
+      TweenSequenceItem<double>(
+        tween: Tween<double>(begin: 1.0, end: 0.0).chain(_outCurve),
+        weight: 6 / 20,
+      ),
+      TweenSequenceItem<double>(
+        tween: ConstantTween<double>(0.0),
+        weight: 14 / 20,
+      ),
+    ],
+  );
+}
+>>> (indent 2) dart_desk_client-0.2.1/lib/src/protocol/client.dart
+  _i2.Future<_i8.Document> submitEdit(
+    _i1.UuidValue documentId,
+    String sessionId,
+    String fieldUpdatesJson,
+  ) => caller.callServerEndpoint<_i8.Document>(
+    'documentCollaboration',
+    'submitEdit',
+    {
+      'documentId': documentId,
+      'sessionId': sessionId,
+      'fieldUpdatesJson': fieldUpdatesJson,
+    },
+  );
+<<< 3.7
+  _i2.Future<_i8.Document> submitEdit(
+    _i1.UuidValue documentId,
+    String sessionId,
+    String fieldUpdatesJson,
+  ) => caller
+      .callServerEndpoint<_i8.Document>('documentCollaboration', 'submitEdit', {
+        'documentId': documentId,
+        'sessionId': sessionId,
+        'fieldUpdatesJson': fieldUpdatesJson,
+      });
+<<< 3.13
+  _i2.Future<_i8.Document> submitEdit(
+    _i1.UuidValue documentId,
+    String sessionId,
+    String fieldUpdatesJson,
+  ) => caller.callServerEndpoint<_i8.Document>(
+    'documentCollaboration',
+    'submitEdit',
+    {
+      'documentId': documentId,
+      'sessionId': sessionId,
+      'fieldUpdatesJson': fieldUpdatesJson,
+    },
+  );
+>>> (indent 6) ffastdb-0.2.6/example_flutter/lib/stress_test_page.dart
+      final updated = await widget.db
+          .updateWhere((q) => q.where('type').equals('post').findIds(), {
+            'massivelyUpdated': true,
+            'lastUpdateTs': DateTime.now().millisecondsSinceEpoch,
+          });
+<<< 3.7
+      final updated = await widget.db
+          .updateWhere((q) => q.where('type').equals('post').findIds(), {
+            'massivelyUpdated': true,
+            'lastUpdateTs': DateTime.now().millisecondsSinceEpoch,
+          });
+<<< 3.13
+      final updated = await widget.db.updateWhere(
+        (q) => q.where('type').equals('post').findIds(),
+        {
+          'massivelyUpdated': true,
+          'lastUpdateTs': DateTime.now().millisecondsSinceEpoch,
+        },
+      );


### PR DESCRIPTION
A key optimization the formatter performs is that if it can tell that the contents of a Piece are so large that the Piece will be forced to split regardless of any surrounding context, then it binds the Piece to the split state eagerly before solving gets involved. This radically speeds up solving because the solver doesn't have to explore a large number of *combinations* of piece states before finding the state for one piece.

Before this PR, that optimization was applied in the middle of building and formatting a solution. When writing an piece inline to a solution, we'd try to see if it had a fixed state based on its contents and the remaining page width at that point. Doing this optimization in the middle of writing the piece was good for performance because it gave us more information about the surrounding indentation. That in turn effectively reduced the page width which made it more likely the optimization would apply and successfully pick a state for the piece.

However, the process of exploring the solution tree is pretty complex and having some pieces get bound in the solution right in the middle of that process is brittle. In particular, it turns out there was at least one bug. When formatting a solution, we might eagerly bind some piece deep in the middle of the piece tree to a state based on its contents (the optimization). At that point, we would also increment the solution's cost to pay for that state.

Later, we might derive a new solution from that solution that formats part of its subtree separately. Separate formatting is another optimization where we can reuse formatted subtrees across multiple solutions. When we separately format, we add in the entire formatted output of a subtree. We also need to include the cost of any pieces split in that subtree.

These two optimizations didn't play nice together. In some cases, the eager piece binding would bind a piece to some state and pay its cost. Later, that piece would be part of a subtree that was separately formatted. When the subtree was merged, we would pay its cost again. The result is that when the eager piece binding optimization applied, sometimes a piece's state cost would be double counted.

That in turn would cause that solution to be not as desirable as it should be and sometimes other worse solutions would win. Looking through the diff, it mostly seems to manifest in code where you have a `.` method call whose argument list contains a large collection literal. The split list literal's cost would be double counted and instead some other solution that doesn't push the collection far enough to the right to trigger the optimization would win.

For example, currently the formatter produces:

```dart
main() async {
  {
    await MethodChannelContainer()
        .onMethodChannelInvoke("reportCrash", <String, dynamic>{
          "time": nowTime,
          "errorValue": errorName,
          "reason": reason,
          "stacktrace": stacktrace,
        });
  }
}
```

There is no reason to split before `.onMethodChannelInvoke`. It's just double-counting the cost of the split list literal which incorrectly bumps the cost of the solution that should win:

```dart
main() async {
  {
    await MethodChannelContainer().onMethodChannelInvoke(
      "reportCrash",
      <String, dynamic>{
        "time": nowTime,
        "errorValue": errorName,
        "reason": reason,
        "stacktrace": stacktrace,
      },
    );
  }
}
```

This PR fixes that by moving the "eagerly bind pieces based on contents" optimization out of the solver. Instead, we do one big traversal of the piece tree first and bind what we can. When we do, since the piece will now be bound to that state for all possible solutions, there's no need to count its cost. And thus we never double-count it (or even single-count it for that matter).

You can see the diff applied to a large corpus [here](https://gist.github.com/munificent/db66c4c2573d99cb9d25dbd0c1cb7b13). That's the entire diff from a very large corpus, so the amount of code affected is relatively small. Interestingly, it seems to be very often in method channel calls. I'm guessing because those often combine a call chain with a large collection literal.

This does regress performance. :( Doing the optimization earlier is beneficial in some ways because we'll only try to apply it to a given piece once instead of once per solution that happens to reach it. But it's also worse because the effective page width is always the full width of the file without taking any indentation for where the piece appears into account. Thus the optimization kicks in less frequently. Overall, it's a regression but not catastrophic:

Here's the benchmarks on my Macbook (higher percentages = faster):

```
Benchmark (tall)                fastest   median  slowest  average  baseline
-----------------------------  --------  -------  -------  -------  --------
block                             0.080    0.088    0.174    0.091     82.7%
chain                             0.704    0.721    0.759    0.724     95.5%
collection                        0.408    0.420    0.447    0.422     64.1%
collection_large                  1.759    1.797    1.936    1.806    101.2%
conditional                       0.084    0.085    0.105    0.087     80.0%
curry                             0.173    0.175    0.203    0.178     99.4%
curry_2                           0.346    0.356    0.398    0.360     99.5%
ffi                               0.159    0.162    0.185    0.166     99.2%
flutter_popup_menu_test           0.542    0.559    0.595    0.559     93.1%
flutter_scrollbar_test            1.996    2.017    2.055    2.019     48.8%
function_call                     1.781    1.822    1.904    1.821     99.6%
infix_large                       0.714    0.737    0.775    0.740    101.4%
infix_small                       0.182    0.185    0.222    0.189    107.5%
interpolation                     0.142    0.146    0.175    0.148     96.3%
interpolation_1516                0.125    0.126    0.141    0.128     95.5%
large                             4.046    4.145    4.362    4.149     93.3%
top_level                         0.149    0.155    0.181    0.157     97.3%
```

And here's the time formatting a giant corpus of pub code:

```
Before this PR: 233.91s user 30.02s system 109% cpu 4:01.20 total
After:          261.15s user 30.66s system 108% cpu 4:27.88 total
```

Fix #1847.
