### PR TITLE
[dart stable] Don't crash on a missing analysis_options.yaml include.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unpublished
+
+This change is landing in a branch of dart_style that isn't the main dev line
+and won't be published. It exists only to be rolled into the Dart SDK as a
+cherry-pick.
+
+### Bug fixes
+
+* Don't crash if an `analysis_options.yaml` file has an `include` that points to
+  a non-existent or unreadable file (#1840).
+
 ## 3.1.8-wip
 
 ### Style changes

--- a/lib/src/analysis_options/analysis_options_file.dart
+++ b/lib/src/analysis_options/analysis_options_file.dart
@@ -69,8 +69,6 @@ Future<AnalysisOptions> findAnalysisOptions(
 /// If there any "package:" includes, then they are resolved to file paths
 /// using [resolvePackageUri]. If [resolvePackageUri] is omitted, an exception
 /// is thrown if any "package:" includes are found.
-///
-/// If reading the file fails, an [AnalysisOptionsReadException] is thrown.
 Future<AnalysisOptions> readAnalysisOptions(
   FileSystem fileSystem,
   FileSystemPath optionsPath, {

--- a/lib/src/analysis_options/analysis_options_file.dart
+++ b/lib/src/analysis_options/analysis_options_file.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:io';
+
 import 'package:yaml/yaml.dart';
 
 import 'file_system.dart';
@@ -29,12 +31,17 @@ typedef ResolvePackageUri = Future<String?> Function(Uri packageUri);
 /// reads any of the other referenced YAML files and merges them into this one.
 /// Returns the resulting map with the `include` key removed.
 ///
+/// If an [IOException] occurs when reading a file, then [reportFailedRead] is
+/// called with the file path, an empty YAML file is used instead, and the
+/// process continues.
+///
 /// If there any "package:" includes, then they are resolved to file paths
 /// using [resolvePackageUri]. If [resolvePackageUri] is omitted, an exception
 /// is thrown if any "package:" includes are found.
 Future<AnalysisOptions> findAnalysisOptions(
   FileSystem fileSystem,
   FileSystemPath directory, {
+  required void Function(String path) reportFailedRead,
   ResolvePackageUri? resolvePackageUri,
 }) async {
   while (true) {
@@ -43,6 +50,7 @@ Future<AnalysisOptions> findAnalysisOptions(
       return readAnalysisOptions(
         fileSystem,
         optionsPath,
+        reportFailedRead: reportFailedRead,
         resolvePackageUri: resolvePackageUri,
       );
     }
@@ -61,12 +69,23 @@ Future<AnalysisOptions> findAnalysisOptions(
 /// If there any "package:" includes, then they are resolved to file paths
 /// using [resolvePackageUri]. If [resolvePackageUri] is omitted, an exception
 /// is thrown if any "package:" includes are found.
+///
+/// If reading the file fails, an [AnalysisOptionsReadException] is thrown.
 Future<AnalysisOptions> readAnalysisOptions(
   FileSystem fileSystem,
   FileSystemPath optionsPath, {
+  required void Function(String path) reportFailedRead,
   ResolvePackageUri? resolvePackageUri,
 }) async {
-  var yaml = loadYamlNode(await fileSystem.readFile(optionsPath));
+  YamlNode yaml;
+  try {
+    yaml = loadYamlNode(await fileSystem.readFile(optionsPath));
+  } on IOException {
+    // Don't crash on failed reads, just report and continue as if the file was
+    // empty.
+    reportFailedRead(optionsPath.toString());
+    yaml = YamlMap();
+  }
 
   // If for some reason the YAML isn't a map, consider it malformed and yield
   // a default empty map.
@@ -103,9 +122,11 @@ Future<AnalysisOptions> readAnalysisOptions(
       (await fileSystem.parentDirectory(optionsPath))!,
       include,
     );
-    return await readAnalysisOptions(
+
+    return readAnalysisOptions(
       fileSystem,
       includePath,
+      reportFailedRead: reportFailedRead,
       resolvePackageUri: resolvePackageUri,
     );
   }

--- a/lib/src/analysis_options/io_file_system.dart
+++ b/lib/src/analysis_options/io_file_system.dart
@@ -27,7 +27,7 @@ final class IOFileSystem implements FileSystem {
   ) async {
     // Make [path] absolute (if not already) so that we can walk outside of the
     // literal path string passed.
-    var result = p.dirname(p.absolute(path.path));
+    var result = p.dirname(p.normalize(p.absolute(path.path)));
 
     // If the parent directory is the same as [path], we must be at the root.
     if (result == path.path) return null;
@@ -48,4 +48,7 @@ final class IOFileSystemPath implements FileSystemPath {
   final String path;
 
   IOFileSystemPath._(this.path);
+
+  @override
+  String toString() => path;
 }

--- a/lib/src/config_cache.dart
+++ b/lib/src/config_cache.dart
@@ -47,6 +47,11 @@ final class ConfigCache {
 
   final IOFileSystem _fileSystem = IOFileSystem();
 
+  /// Paths to files that we have failed to read.
+  ///
+  /// These are cached so that the warning is only printed once per file.
+  final Set<String> _failedReadPaths = {};
+
   /// Looks for a package surrounding [file] and, if found, returns the default
   /// language version specified by that package.
   Future<Version?> findLanguageVersion(File file, String displayPath) async {
@@ -122,6 +127,7 @@ final class ConfigCache {
       var optionsFile = await findAnalysisOptions(
         _fileSystem,
         await _fileSystem.makePath(file.path),
+        reportFailedRead: _reportFailedRead,
         resolvePackageUri: (uri) => _resolvePackageUri(file, uri),
       );
 
@@ -213,6 +219,12 @@ final class ConfigCache {
     if (config == null) return null;
 
     return config.resolve(packageUri)?.toFilePath();
+  }
+
+  void _reportFailedRead(String path) {
+    if (_failedReadPaths.add(path)) {
+      stderr.writeln('Warning: Couldn\'t read file "$path".');
+    }
   }
 }
 

--- a/lib/src/testing/test_file_system.dart
+++ b/lib/src/testing/test_file_system.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import '../analysis_options/file_system.dart';
 
 /// A simulated file system for tests.
@@ -44,7 +46,7 @@ final class TestFileSystem implements FileSystem {
   @override
   Future<String> readFile(covariant TestFileSystemPath path) async {
     if (_files[path._path] case var contents?) return contents;
-    throw Exception('No file at "$path".');
+    throw TestIOException(path._path);
   }
 }
 
@@ -52,6 +54,15 @@ final class TestFileSystemPath implements FileSystemPath {
   final String _path;
 
   TestFileSystemPath(this._path);
+
+  @override
+  String toString() => _path;
+}
+
+final class TestIOException implements IOException {
+  final String _path;
+
+  TestIOException(this._path);
 
   @override
   String toString() => _path;

--- a/test/analysis_options/analysis_options_file_test.dart
+++ b/test/analysis_options/analysis_options_file_test.dart
@@ -15,6 +15,7 @@ void main() {
       var options = await findAnalysisOptions(
         testFS,
         TestFileSystemPath('dir|sub'),
+        reportFailedRead: _unexpectedReadFailure,
       );
       expect(options, isEmpty);
     });
@@ -27,6 +28,7 @@ void main() {
       var options = await findAnalysisOptions(
         testFS,
         TestFileSystemPath('dir'),
+        reportFailedRead: _unexpectedReadFailure,
       );
       expect(_pageWidth(options), equals(100));
     });
@@ -40,6 +42,7 @@ void main() {
       var options = await findAnalysisOptions(
         testFS,
         TestFileSystemPath('dir|sub'),
+        reportFailedRead: _unexpectedReadFailure,
       );
       expect(_pageWidth(options), equals(100));
     });
@@ -56,12 +59,13 @@ void main() {
       var options = await findAnalysisOptions(
         testFS,
         TestFileSystemPath('dir|sub'),
+        reportFailedRead: _unexpectedReadFailure,
       );
       expect(_pageWidth(options), isNull);
     });
   });
 
-  group('readAnalysisOptionsOptions()', () {
+  group('readAnalysisOptions()', () {
     test('reads an analysis options file', () async {
       var testFS = TestFileSystem({
         'file.yaml': analysisOptions(pageWidth: 120),
@@ -70,6 +74,7 @@ void main() {
       var options = await readAnalysisOptions(
         testFS,
         TestFileSystemPath('file.yaml'),
+        reportFailedRead: _unexpectedReadFailure,
       );
       expect(_pageWidth(options), 120);
     });
@@ -79,6 +84,7 @@ void main() {
       var options = await readAnalysisOptions(
         testFS,
         TestFileSystemPath('file.yaml'),
+        reportFailedRead: _unexpectedReadFailure,
       );
       expect(options, isA<Map>());
       expect(options, isEmpty);
@@ -123,6 +129,7 @@ void main() {
       var options = await readAnalysisOptions(
         testFS,
         TestFileSystemPath('dir|a.yaml'),
+        reportFailedRead: _unexpectedReadFailure,
       );
       expect(options['a'], 'from a');
       expect(options['ab'], 'from a');
@@ -145,6 +152,7 @@ void main() {
       var options = await readAnalysisOptions(
         testFS,
         TestFileSystemPath('dir|main.yaml'),
+        reportFailedRead: _unexpectedReadFailure,
       );
       expect(options['include'], isNull);
     });
@@ -165,6 +173,7 @@ void main() {
       var options = await readAnalysisOptions(
         testFS,
         TestFileSystemPath('dir|a.yaml'),
+        reportFailedRead: _unexpectedReadFailure,
       );
       expect(options['a'], 'from a');
       expect(options['b'], 'from b');
@@ -191,6 +200,7 @@ void main() {
       var options = await readAnalysisOptions(
         testFS,
         TestFileSystemPath('dir|a.yaml'),
+        reportFailedRead: _unexpectedReadFailure,
         resolvePackageUri: resolve,
       );
       expect(options['a'], 'from a');
@@ -204,7 +214,11 @@ void main() {
       });
 
       expect(
-        readAnalysisOptions(testFS, TestFileSystemPath('options.yaml')),
+        readAnalysisOptions(
+          testFS,
+          TestFileSystemPath('options.yaml'),
+          reportFailedRead: _unexpectedReadFailure,
+        ),
         throwsA(isA<PackageResolutionException>()),
       );
     });
@@ -221,6 +235,7 @@ void main() {
         readAnalysisOptions(
           testFS,
           TestFileSystemPath('options.yaml'),
+          reportFailedRead: _unexpectedReadFailure,
           resolvePackageUri: failingResolver,
         ),
         throwsA(
@@ -235,6 +250,45 @@ void main() {
         ),
       );
     });
+
+    test('returns an empty map if reading the file fails', () async {
+      var testFS = TestFileSystem();
+
+      var gotFailedRead = false;
+      var options = await readAnalysisOptions(
+        testFS,
+        TestFileSystemPath('unknown_options.yaml'),
+        reportFailedRead: (path) {
+          expect(path, 'unknown_options.yaml');
+          gotFailedRead = true;
+        },
+      );
+      expect(gotFailedRead, isTrue);
+      expect(options, isA<Map>());
+      expect(options, isEmpty);
+    });
+
+    test('ignores missing includes', () async {
+      var testFS = TestFileSystem({
+        'dir|analysis_options.yaml': analysisOptions(
+          include: ['unknown1.yaml', 'known.yaml', 'unknown2.yaml'],
+        ),
+        'dir|known.yaml': analysisOptions(pageWidth: 100),
+      });
+
+      var failedReads = <String>[];
+      var options = await readAnalysisOptions(
+        testFS,
+        TestFileSystemPath('dir|analysis_options.yaml'),
+        reportFailedRead: failedReads.add,
+      );
+
+      expect(
+        failedReads,
+        orderedEquals(['dir|unknown1.yaml', 'dir|unknown2.yaml']),
+      );
+      expect(_pageWidth(options), equals(100));
+    });
   });
 }
 
@@ -242,3 +296,7 @@ void main() {
 /// it or `null` if not found.
 Object? _pageWidth(AnalysisOptions options) =>
     (options['formatter'] as Map<Object?, Object?>?)?['page_width'];
+
+void _unexpectedReadFailure(String path) {
+  fail('Unexpected read failure.');
+}

--- a/test/cli/page_width_test.dart
+++ b/test/cli/page_width_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
@@ -140,6 +141,57 @@ void main() {
     await d.dir('dir', [
       d.dir('foo', [d.file('main.dart', _formatted80)]),
     ]).validate();
+  });
+
+  test('ignore missing includes', () async {
+    await d.dir('dir', [
+      analysisOptionsFile(
+        include: ['unknown1.yaml', 'known.yaml', 'unknown2.yaml'],
+      ),
+      analysisOptionsFile(name: 'known.yaml', pageWidth: 30),
+      d.file('main.dart', _unformatted),
+    ]).create();
+
+    var process = await runFormatterOnDir();
+
+    var unknown1Path = p.join(d.sandbox, 'dir', 'unknown1.yaml');
+    expect(
+      await process.stderr.next,
+      'Warning: Couldn\'t read file "$unknown1Path".',
+    );
+
+    var unknown2Path = p.join(d.sandbox, 'dir', 'unknown2.yaml');
+    expect(
+      await process.stderr.next,
+      'Warning: Couldn\'t read file "$unknown2Path".',
+    );
+
+    await process.shouldExit(0);
+
+    // Should format the file at 30 from the successful include.
+    await d.dir('dir', [d.file('main.dart', _formatted30)]).validate();
+  });
+  test('only warn on a missing include once', () async {
+    await d.dir('dir', [
+      analysisOptionsFile(
+        include: ['unknown.yaml', 'unknown.yaml', 'unknown.yaml'],
+      ),
+      d.file('main.dart', _unformatted),
+    ]).create();
+
+    var process = await runFormatterOnDir();
+
+    var unknownPath = p.join(d.sandbox, 'dir', 'unknown.yaml');
+    expect(
+      await process.stderr.next,
+      'Warning: Couldn\'t read file "$unknownPath".',
+    );
+
+    expect(await process.stderr.hasNext, isFalse);
+    await process.shouldExit(0);
+
+    // Should format the file at the default width.
+    await d.dir('dir', [d.file('main.dart', _formatted80)]).validate();
   });
 
   group('stdin', () {

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -403,7 +403,7 @@ d.FileDescriptor analysisOptionsFile({
   String name = 'analysis_options.yaml',
   int? pageWidth,
   TrailingCommas? trailingCommas,
-  String? include,
+  Object? include,
 }) {
   var yaml = analysisOptions(
     pageWidth: pageWidth,


### PR DESCRIPTION
If an analysis_options.yaml file has an include that points to another relative path and reading that other file fails, print a warning and continue as if the file was found and empty.

Fix #1840.

This is sort of a short-term fix for the root cause of that issue which is that the formatter is trying to format code in `build/` directories that contain packages that aren't fully resolved with all of their dependencies and shouldn't be formatted anyway.

I think the right long-term solution for that is to support file exclusion (#864). I plan to work on that soon, but it will take a while because it's part of revising the overall library API and how configuration data is plumbed from hosts to the formatter.

Even when that long-term solution is done, I think this change is good too. It's still possible for users to get into this situation, as simply as having a typo in an analysis_options.yaml file. When that happens, the formatter should degrade more gracefully. Warning and continuing as in this PR is consistent with how we handle other configuration failures.

---

Note: This PR is identical to #1851 except:

* Its parent commit is 9b302dd, which is the commit that Dart SDK stable currently has for dart_style.

* It includes [the changes to `io_file_system.dart`](https://github.com/dart-lang/dart_style/commit/5ed5aadd8cfb0228668e286ab45977f989352b48#diff-cd6508e68de5dc72aa1bb51352d5258b9d1dd228d66fae6b1b0831b25b507726) from #1818 which this fix relies on.

* It has a slightly different CHANGELOG entry.