### PR TITLE
Fix io_file_system_test.dart.

### DIFF
--- a/test/analysis_options/io_file_system_test.dart
+++ b/test/analysis_options/io_file_system_test.dart
@@ -162,7 +162,12 @@ void main() {
       Future<String?> failingResolver(Uri uri) async => null;
 
       expect(
-        readAnalysisOptions(fs, path, resolvePackageUri: failingResolver),
+        readAnalysisOptions(
+          fs,
+          path,
+          reportFailedRead: (path) => fail('Unexpected read failure.'),
+          resolvePackageUri: failingResolver,
+        ),
         throwsA(
           isA<PackageResolutionException>().having(
             (error) => error.toString(),


### PR DESCRIPTION
I added a new mandatory named parameter to `readAnalysisOptions()` and somehow I missed one callsite in a test.

For this test, no file reads should fail, so we just provide it with a closure that fails the test if invoked.

