### PR TITLE
Support a trailing comma in extension type representation clauses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,9 @@
   Note how a blank line was added above `// Comment 2.` but not `// Comment 1.`.
   Now, it won't add a blank line before the last comment.
 
+* Write a trailing comma in split extension type representation clauses when in
+  a library whose language version allows it (#1845).
+
 ### Internal changes
 
 * Require `analyzer: ^13.1.0`.

--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -811,9 +811,11 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
       return;
     }
 
-    // If all parameters are optional, put the `[` or `{` right after `(`.
+    // Extension type representation clauses prior to Dart 3.13 don't allow a
+    // trailing comma.
     var listStyle = const ListStyle();
-    if (node.parent?.parent is ExtensionTypeDeclaration) {
+    if (!style.allowTrailingCommaInRepresentationClause &&
+        node.parent?.parent is ExtensionTypeDeclaration) {
       listStyle = const ListStyle(commas: Commas.nonTrailing);
     }
 
@@ -822,6 +824,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
     builder.addLeftBracket(
       pieces.build(() {
         pieces.token(node.leftParenthesis);
+        // If all parameters are optional, put the `[` or `{` right after `(`.
         if (node.parameters.isNotEmpty && firstOptional == 0) {
           pieces.token(node.leftDelimiter);
         }

--- a/lib/src/front_end/formatting_style.dart
+++ b/lib/src/front_end/formatting_style.dart
@@ -97,6 +97,15 @@ final class FormattingStyle {
   bool get pinStateByPageWidthBeforeSolving =>
       _languageVersion >= _version3Dot13;
 
+  /// Whether an extension type's representation clause allows a trailing
+  /// comma.
+  ///
+  /// When primary constructors were added in Dart 3.13, the grammar was
+  /// adjusted to define extension types in terms of them which also means that
+  /// a trailing comma is now permitted.
+  bool get allowTrailingCommaInRepresentationClause =>
+      _languageVersion >= _version3Dot13;
+
   /// Whether there is a trailing comma at the end of the list delimited by
   /// [rightBracket] which should be preserved by this style.
   bool preserveTrailingCommaBefore(Token rightBracket) =>

--- a/test/tall/declaration/extension_type.unit
+++ b/test/tall/declaration/extension_type.unit
@@ -18,6 +18,10 @@ extension type A<T extends int, R>(int a) {}
 extension type A<T extends int, R>(
   int a
 ) {}
+<<< 3.13
+extension type A<T extends int, R>(
+  int a,
+) {}
 >>> Indentation in body.
 extension type A(int a) {
 inc(int x) => ++x;
@@ -45,6 +49,10 @@ extension type LongExtensionType(LongTypeName a) {}
 extension type LongExtensionType(
   LongTypeName a
 ) {}
+<<< 3.13
+extension type LongExtensionType(
+  LongTypeName a,
+) {}
 >>> Split in representation with implements clause.
 extension type LongExtensionType(LongTypeName a) implements Something {
   method() {;}
@@ -68,7 +76,7 @@ extension type LongExtensionType(
 }
 <<< 3.13
 extension type LongExtensionType(
-  LongTypeName a
+  LongTypeName a,
 ) implements Something {
   method() {
     ;

--- a/test/tall/declaration/extension_type_comment.unit
+++ b/test/tall/declaration/extension_type_comment.unit
@@ -26,6 +26,18 @@ extension /*b*/ type /*c*/ A
         I2 /*n*/ {
   /*o*/
 } /*p*/
+<<< 3.13
+/*a*/
+extension /*b*/ type /*c*/ A
+/*d*/ (
+  /*e*/ @ /*f*/ override /*g*/
+  int /*h*/ a /*i*/,
+) /*j*/
+    implements /*k*/
+        I1 /*l*/, /*m*/
+        I2 /*n*/ {
+  /*o*/
+} /*p*/
 >>> Line comments everywhere.
 // 0
 @patch // a
@@ -92,6 +104,31 @@ name // j
   required // m
   int // n
   a // o
+) // p
+    implements // q
+        I // r
+        {
+  // s
+} // t
+<<< 3.13
+// 0
+@patch // a
+extension // b
+type // c
+const // d
+A // e
+<
+  // f
+  T // g
+> // h
+. // i
+name // j
+(
+  // k
+  @ // l
+  required // m
+  int // n
+  a, // o
 ) // p
     implements // q
         I // r

--- a/test/tall/preserve_trailing_commas/extension_type.unit
+++ b/test/tall/preserve_trailing_commas/extension_type.unit
@@ -1,0 +1,24 @@
+40 columns                              |
+(trailing_commas preserve)
+>>> Representation clause splits with trailing comma.
+extension type Foo(int x,) {}
+<<< 3.13
+### Trailing commas aren't allowed prior to 3.13.
+extension type Foo(
+  int x,
+) {}
+>>> Doesn't force split representation clause without trailing comma.
+extension type Foo(int x) {}
+<<< 3.7
+extension type Foo(int x) {}
+>>> May still split without trailing comma if doesn't fit.
+extension type Foo(LongType parameter) {}
+<<< 3.7
+### Trailing commas aren't allowed prior to 3.13.
+extension type Foo(
+  LongType parameter
+) {}
+<<< 3.13
+extension type Foo(
+  LongType parameter,
+) {}

--- a/test/tall/regression/1500/1505.unit
+++ b/test/tall/regression/1500/1505.unit
@@ -13,5 +13,5 @@ extension type JSExportedDartFunction._(
     implements JSFunction {}
 <<< 3.13
 extension type JSExportedDartFunction._(
-  JSExportedDartFunctionRepType _jsExportedDartFunction
+  JSExportedDartFunctionRepType _jsExportedDartFunction,
 ) implements JSFunction {}


### PR DESCRIPTION
In Dart 3.13, we changed the grammar for extension types to match primary constructors (with restrictions). A side effect of that is that where the old grammar (inadvertently) didn't allow a trailing comma in a split representation clause, the new grammar does (because it's just a formal parameter list now).

So in Dart 3.13 and later libraries, the formatter will write a trailing comma there, to be consistent with most other places in the language were we write a trailing comma.

Fix #1845.
