### PR TITLE
Fix regression that incorrectly moved a blank line around a comment.

### DIFF
--- a/lib/src/front_end/ast_node_visitor.dart
+++ b/lib/src/front_end/ast_node_visitor.dart
@@ -138,10 +138,7 @@ final class AstNodeVisitor extends ThrowingAstVisitor<void> with PieceFactory {
           _ => false,
         };
 
-        // Add a blank line before and after types with bodies.
-        if (needsBlank || addBlankLines) sequence.addBlank();
-
-        sequence.visit(declaration);
+        sequence.visit(declaration, blankBefore: needsBlank || addBlankLines);
 
         // Add a blank line after type or function declarations with bodies.
         needsBlank = addBlankLines || declaration.hasNonEmptyBody;

--- a/lib/src/front_end/comment_writer.dart
+++ b/lib/src/front_end/comment_writer.dart
@@ -275,6 +275,16 @@ final class CommentSequence extends ListBase<SourceComment> {
   /// token and the preceding one.
   int get linesBeforeNextToken => _linesBetween.last;
 
+  /// Whether there are any blank lines before or after any of the comments in
+  /// this sequence in the original source code.
+  bool get containsBlankLine {
+    for (var i = 0; i < length; i++) {
+      if (linesBefore(i) > 1) return true;
+    }
+
+    return linesBeforeNextToken > 1;
+  }
+
   /// The number of comments in the sequence.
   @override
   int get length => _comments.length;

--- a/lib/src/front_end/delimited_list_builder.dart
+++ b/lib/src/front_end/delimited_list_builder.dart
@@ -290,9 +290,13 @@ final class DelimitedListBuilder {
       }
     }
 
-    // Preserve one blank line between successive elements.
-    if (_elements.isNotEmpty && comments.linesBeforeNextToken > 1) {
+    // Preserve one blank line between the last element and a trailing comment.
+    var wroteBlank = false;
+    if (!hasElementAfter &&
+        _elements.isNotEmpty &&
+        comments.linesBeforeNextToken > 1) {
       _blanksAfter.add(_elements.last);
+      wroteBlank = true;
     }
 
     // Comments that are neither hanging nor leading are treated like their own
@@ -301,10 +305,19 @@ final class DelimitedListBuilder {
       var comment = separateComments[i];
       if (separateComments.linesBefore(i) > 1 && _elements.isNotEmpty) {
         _blanksAfter.add(_elements.last);
+        wroteBlank = true;
       }
 
       var commentPiece = _visitor.pieces.commentPiece(comment);
       _elements.add(ListElementPiece.comment(commentPiece));
+    }
+
+    // Preserve a blank line after the last comment before the next element,
+    // unless we've already written one before one of the comments.
+    if (!wroteBlank &&
+        _elements.isNotEmpty &&
+        comments.linesBeforeNextToken > 1) {
+      _blanksAfter.add(_elements.last);
     }
 
     // Leading comments are written before the next element.

--- a/lib/src/front_end/piece_factory.dart
+++ b/lib/src/front_end/piece_factory.dart
@@ -222,9 +222,7 @@ mixin PieceFactory {
 
     var needsBlank = false;
     for (var node in contents) {
-      if (needsBlank) sequence.addBlank();
-
-      sequence.visit(node);
+      sequence.visit(node, blankBefore: needsBlank);
 
       // If the node has a non-empty braced body, then require a blank line
       // between it and the next node.

--- a/lib/src/front_end/sequence_builder.dart
+++ b/lib/src/front_end/sequence_builder.dart
@@ -100,26 +100,22 @@ final class SequenceBuilder {
   /// Visits [node] and adds the resulting [Piece] to this sequence, handling
   /// any comments or blank lines that appear before it.
   ///
-  /// If [blankBefore] is `true`, then writes a blank line before [node], but
-  /// after any comments that may precede [node].
-  void visit(
-    AstNode node, {
-    Indent? indent,
-    bool blankBefore = false,
-    bool allowBlankAfter = true,
-  }) {
+  /// If [blankBefore] is `true`, then ensures there is a blank line before
+  /// [token]. If there any blank lines around the comments, then the first one
+  /// will be preserved. Otherwise, writes a blank line before the first
+  /// comment.
+  void visit(AstNode node, {Indent? indent, bool blankBefore = false}) {
+    var token = node.firstNonCommentToken;
+
     var wroteBlank = addCommentsBefore(
-      node.firstNonCommentToken,
+      token,
       indent: indent,
+      blankBefore: blankBefore,
     );
 
     if (blankBefore && !wroteBlank) addBlank();
 
-    add(
-      _visitor.nodePiece(node),
-      indent: indent,
-      allowBlankAfter: allowBlankAfter,
-    );
+    add(_visitor.nodePiece(node), indent: indent);
   }
 
   /// Appends a blank line before the next piece in the sequence.
@@ -137,13 +133,30 @@ final class SequenceBuilder {
   /// Comments between sequence elements get special handling where comments
   /// on their own line become standalone sequence elements.
   ///
+  /// If [blankBefore] is `true`, then ensures there is a blank line before
+  /// [token]. If there any blank lines around the comments, then the first one
+  /// will be preserved. Otherwise, writes a blank line before the first
+  /// comment.
+  ///
   /// Returns `true` if processing the comments ended up writing any blank
   /// lines.
-  bool addCommentsBefore(Token token, {Indent? indent}) {
+  bool addCommentsBefore(
+    Token token, {
+    Indent? indent,
+    bool blankBefore = false,
+  }) {
     indent ??= Indent.none;
 
     var wroteBlank = false;
     var comments = _visitor.comments.takeCommentsBefore(token);
+
+    // Default to putting the blank line before all comments unless there are
+    // blank lines inside or after them.
+    if (blankBefore && !comments.containsBlankLine) {
+      addBlank();
+      wroteBlank = true;
+    }
+
     for (var i = 0; i < comments.length; i++) {
       var comment = _visitor.pieces.commentPiece(comments[i]);
 

--- a/test/tall/declaration/class_comment.unit
+++ b/test/tall/declaration/class_comment.unit
@@ -105,3 +105,22 @@ class C {
   }
   // comment
 }
+>>> Ensure blank line between declarations with comment between.
+class C {}
+// comment
+class D {}
+<<< 3.7
+class C {}
+
+// comment
+class D {}
+>>> Allow line after comment as the blank line.
+class C {}
+// comment
+
+class D {}
+<<< 3.7
+class C {}
+// comment
+
+class D {}

--- a/test/tall/declaration/enum_comment.unit
+++ b/test/tall/declaration/enum_comment.unit
@@ -206,3 +206,22 @@ enum E {
   // 2
   // 3
 }
+>>> Ensure blank line between declarations with comment between.
+enum C { a }
+// comment
+enum D { b }
+<<< 3.7
+enum C { a }
+
+// comment
+enum D { b }
+>>> Allow line after comment as the blank line.
+enum C { a }
+// comment
+
+enum D { b}
+<<< 3.7
+enum C { a }
+// comment
+
+enum D { b }

--- a/test/tall/declaration/extension_comment.unit
+++ b/test/tall/declaration/extension_comment.unit
@@ -1,0 +1,20 @@
+40 columns                              |
+>>> Ensure blank line between declarations with comment between.
+extension on int {}
+// comment
+extension on bool {}
+<<< 3.7
+extension on int {}
+
+// comment
+extension on bool {}
+>>> Allow line after comment as the blank line.
+extension on int {}
+// comment
+
+extension on bool {}
+<<< 3.7
+extension on int {}
+// comment
+
+extension on bool {}

--- a/test/tall/declaration/extension_type_comment.unit
+++ b/test/tall/declaration/extension_type_comment.unit
@@ -141,3 +141,26 @@ extension type I(int i) // Comment.
 <<< 3.13
 extension type I(int i) // Comment.
 ;
+>>> Ensure blank line between declarations with comment between.
+extension type C(int i) {}
+// comment
+extension type D(int i) {}
+<<< 3.7
+extension type C(int i) {}
+// comment
+extension type D(int i) {}
+<<< 3.13
+extension type C(int i) {}
+
+// comment
+extension type D(int i) {}
+>>> Allow line after comment as the blank line.
+extension type C(int i) {}
+// comment
+
+extension type D(int i) {}
+<<< 3.7
+extension type C(int i) {}
+// comment
+
+extension type D(int i) {}

--- a/test/tall/declaration/member_comment.unit
+++ b/test/tall/declaration/member_comment.unit
@@ -52,3 +52,17 @@ class C {
 class C {
   static /* c */ int method() {}
 }
+>>> Don't move blank line around comment.
+class C {
+  m() {}
+  // comment
+
+  n() {}
+}
+<<< 3.7
+class C {
+  m() {}
+  // comment
+
+  n() {}
+}

--- a/test/tall/declaration/mixin_comment.unit
+++ b/test/tall/declaration/mixin_comment.unit
@@ -1,0 +1,24 @@
+40 columns                              |
+>>> Ensure blank line between declarations with comment between.
+mixin M {}
+// comment
+mixin N {}
+<<< 3.7
+mixin M {}
+// comment
+mixin N {}
+<<< 3.13
+mixin M {}
+
+// comment
+mixin N {}
+>>> Allow line after comment as the blank line.
+mixin M {}
+// comment
+
+mixin N {}
+<<< 3.7
+mixin M {}
+// comment
+
+mixin N {}

--- a/test/tall/expression/list_comment.stmt
+++ b/test/tall/expression/list_comment.stmt
@@ -166,3 +166,23 @@ var x = [
   1, // Comment 1.
   // Comment 2.
 ];
+>>> Don't move blank line around comment.
+var x = [
+  first,
+  // comment
+
+  second,
+
+  // comment
+  third,
+];
+<<< 3.7
+var x = [
+  first,
+  // comment
+
+  second,
+
+  // comment
+  third,
+];

--- a/test/tall/expression/map_comment.stmt
+++ b/test/tall/expression/map_comment.stmt
@@ -78,3 +78,23 @@ value});
   key: // comment
       value,
 });
+>>> Don't move blank line around comment.
+({
+  a: first,
+  // comment
+
+  b: second,
+
+  // comment
+  c: third,
+});
+<<< 3.7
+({
+  a: first,
+  // comment
+
+  b: second,
+
+  // comment
+  c: third,
+});

--- a/test/tall/expression/record_comment.stmt
+++ b/test/tall/expression/record_comment.stmt
@@ -103,3 +103,23 @@ var record = (
 
   element,
 );
+>>> Don't move blank line around comment.
+(
+  first,
+  // comment
+
+  second,
+
+  // comment
+  third,
+);
+<<< 3.7
+(
+  first,
+  // comment
+
+  second,
+
+  // comment
+  third,
+);

--- a/test/tall/expression/set_comment.stmt
+++ b/test/tall/expression/set_comment.stmt
@@ -20,3 +20,23 @@ var set = {/* comment */};
 ({
   element, // comment
 });
+>>> Don't move blank line around comment.
+({
+  first,
+  // comment
+
+  second,
+
+  // comment
+  third,
+});
+<<< 3.7
+({
+  first,
+  // comment
+
+  second,
+
+  // comment
+  third,
+});

--- a/test/tall/expression/switch_comment.stmt
+++ b/test/tall/expression/switch_comment.stmt
@@ -19,8 +19,8 @@ e = switch (n) {
 e = switch (n) {
   // comment
   0 => a,
-
   // comment
+
   1 => b,
 
   // comment

--- a/test/tall/invocation/comment.stmt
+++ b/test/tall/invocation/comment.stmt
@@ -26,6 +26,19 @@ function(
 line
 comment */
 );
+>>> Don't force blank lines around comments.
+function(argument,
+  // comment
+another,
+// comment
+);
+<<< 3.7
+function(
+  argument,
+  // comment
+  another,
+  // comment
+);
 >>> Remove extra leading and all trailing empty lines.
 function(argument,
 
@@ -70,6 +83,20 @@ function(
   // five
   another,
 );
+>>> Preserve one blank line before trailing comment.
+function(argument,
+
+
+// comment
+
+
+);
+<<< 3.7
+function(
+  argument,
+
+  // comment
+);
 >>> Don't preserve newlines in argument lists with line comment.
 ### For collection literals, a line comment is a signal to preserve the user's
 ### original newlines. This test is just to validate that we *don't* do that
@@ -87,4 +114,24 @@ function(
   fourth,
   fifth,
   sixth,
+);
+>>> Don't move blank line around comment.
+function(
+  first,
+  // comment
+
+  second,
+
+  // comment
+  third,
+);
+<<< 3.7
+function(
+  first,
+  // comment
+
+  second,
+
+  // comment
+  third,
 );

--- a/test/tall/statement/block_comment.stmt
+++ b/test/tall/statement/block_comment.stmt
@@ -116,3 +116,23 @@ a;
 
   a;
 }
+>>> Don't move blank line around comment.
+{
+  first;
+  // comment
+
+  second;
+
+  // comment
+  third;
+}
+<<< 3.7
+{
+  first;
+  // comment
+
+  second;
+
+  // comment
+  third;
+}


### PR DESCRIPTION
In #1831, I tweaked how comments and blank lines at the ends of blocks are handled. An unintended consequence of that change (that surprisingly was not caught by any tests) was that it sometimes moves a blank line around a comment. If you have code like:

```dart
class C {}
// Comment.

class D {}
```

It would change it to:

```dart
class C {}

// Comment.
class D {}
```

That actually does look nice most of the time. However, it can be less nice in code like:

```dart
import 'package:foo/foo.dart';
//import 'package:bar/bar.dart';

import 'something/relative.dart';
```

And it's *really* problematic inside the Dart SDK where static error tests use line comments directly below code to determine error locations:

```dart
String v2 = await fi;
//          ^^^^^^^^
// [analyzer] COMPILE_TIME_ERROR.INVALID_ASSIGNMENT
// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
```

Here, that `//          ^^^^^^^^` comment stops working if the formatter puts a blank line above it.

Now, granted, the formatter's job isn't to support a bespoke test format used inside the SDK. But it's a real pain to break all the static error tests. And in real world code, there are sometimes cases where the user *does* want the blank line below the comment and not above.

This PR fixes that unintended regression. This change (as with the previous comment change) is not language-versioned. I ran this PR on a corpus of already-formatted code, and it produced no changes. The output of the previous format run leaves a set of blank lines that this change doesn't interfere with. I also ran this PR on a corpus of unformatted code and generated a diff relative to that same corpus formatted before this PR. The diff is [here](https://gist.github.com/munificent/051274a8e76154520a31b234eb364c80). As expected, the difference is that it keeps blank lines where they were in some places where the previous formatter would delete or move the blank line.

I've tested this change on the SDK and it correctly doesn't break static error test marker comments.
