### PR TITLE
Allow analyzer version 14.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.1.10-wip
 
+* Allow analyzer version 14.
+
 * Show the supported language versions in `dart format --version --verbose`.
 
 ### Bug fixes

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
-  analyzer: ^13.1.0
+  analyzer: '>=13.1.0 <15.0.0'
   args: ^2.5.0
   collection: ^1.19.0
   package_config: ^2.1.0


### PR DESCRIPTION
Widens the `analyzer` dependency constraint from `^13.1.0` to
`>=13.1.0 <15.0.0` so dart_style can be used in projects that depend on
analyzer 14 (published recently).

### Why
dart_style is currently pinned to analyzer 13, which blocks downstream
packages from upgrading to analyzer 14.

### Compatibility
No source changes were required. Verified locally by forcing analyzer
14.0.0 via a temporary `dependency_overrides`:

- `dart analyze lib bin` — no issues found
- `dart test` — all 8983 tests pass

### Note on CI
The `test` dev-dependency (latest 1.31.1) still caps analyzer at
`<14.0.0`, so `dart pub get` in this repo continues to resolve analyzer
13.x until a newer `test` release allows 14.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
