### PR TITLE
Move CHANGELOG entry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,9 @@
 ### Internal changes
 
 * Migrate off grinder.
+* Allow analyzer version 14.
 
 ## 3.1.10
-
-* Allow analyzer version 14.
 
 * Show the supported language versions in `dart format --version --verbose`.
 


### PR DESCRIPTION
I merged #1864, but the author sent the PR before I had published 3.1.10. This moves the CHANGELOG entry up to the new in-progress version.
