### PR TITLE
Bump version to publish 3.1.11.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.11-wip
+## 3.1.11
 
 ### Internal changes
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Do not edit directly. Use tool/bump_version.dart.
-version: 3.1.11-wip
+version: 3.1.11
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/tool/ship.dart
+++ b/tool/ship.dart
@@ -35,7 +35,6 @@ Future<void> main() async {
 
   var shippedVersion = Version(version.major, version.minor, version.patch);
   updateVersion(shippedVersion);
-  print('Updated version to $version.');
 
   // Check and update the CHANGELOG.
   var changelogFile = File('CHANGELOG.md');


### PR DESCRIPTION
The only meaningful change here is widening the version constraint on analyzer to allow 14.0.0 (https://github.com/dart-lang/sdk/issues/63682), so I plan to publish this directly and not bother rolling it into the Dart SDK since there are no formatter changes.

(Also fixed a redundant incorrect print in the ship script.)
