### PR TITLE
Allow package_config 3.x.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.12
+
+### Internal changes
+
+* Allow package_config version 3 (#1876).
+
 ## 3.1.11
 
 ### Internal changes

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Do not edit directly. Use tool/bump_version.dart.
-const dartStyleVersion = '3.1.11';
+const dartStyleVersion = '3.1.12';
 
 /// Global options parsed from the command line that affect how the formatter
 /// produces and uses its outputs.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Do not edit directly. Use tool/bump_version.dart.
-version: 3.1.11
+version: 3.1.12
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.
@@ -12,7 +12,7 @@ dependencies:
   analyzer: '>=13.1.0 <15.0.0'
   args: ^2.5.0
   collection: ^1.19.0
-  package_config: ^2.1.0
+  package_config: '>=2.1.0 <4.0.0'
   path: ^1.9.0
   pub_semver: ^2.1.4
   source_span: ^1.8.0


### PR DESCRIPTION
No changes were needed in dart_style to work with the new version since dart_style doesn't call any of the changed functions, so I just widened the constraint range.

The version bumps here are not "-wip" because I intend to immediately publish this to unblock users that need to get onto analyzer 14.0.0.

Fix #1876.
