### PR TITLE
Make DartFormatter.lineEnding immutable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@
   `lineEnding` always returns the value you passed in the constructor.
 
   This means you can use the same `DartFormatter` instance to format code with
-  different line endings and the first `format()` call won't affect the results
-  of later calls (#1337).
+  different line endings by not providing an explicit line ending. Each call
+  to `format()` will infer a separate line ending for only that call's code
+  (#1337).
 
   The setter for `lineEnding` is still available but is marked deprecated and
   does nothing. This is technically a **breaking change**, but I believe no code
-  in the wild actually reads the `lineEnding` field so it is harmless. In a
-  future major version release, the setter will be removed.
+  in the wild is affected by it. To be affected by the setter doing nothing,
+  code would have to call the setter and then call `format()`, or call the
+  `lineEnding` getter. I haven't found any code on pub that sets or gets
+  `lineEnding`, so I suspect this change is harmless. In a future major version
+  release, the setter will be removed.
 
 ## 3.1.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 3.1.13-wip
+
+### API changes
+
+* `DartFormatter.lineEnding` is no longer mutable. If no line ending is
+  provided, then a line ending is inferred from the source as usual, but the
+  result is not stored back in the `lineEnding` field. Instead, accessing
+  `lineEnding` always returns the value you passed in the constructor.
+
+  This means you can use the same `DartFormatter` instance to format code with
+  different line endings and the first `format()` call won't affect the results
+  of later calls (#1337).
+
+  The setter for `lineEnding` is still available but is marked deprecated and
+  does nothing. This is technically a **breaking change**, but I believe no code
+  in the wild actually reads the `lineEnding` field so it is harmless. In a
+  future major version release, the setter will be removed.
+
 ## 3.1.12
 
 ### Internal changes

--- a/benchmark/run.dart
+++ b/benchmark/run.dart
@@ -10,6 +10,7 @@ import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:args/args.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:dart_style/src/dart_formatter.dart';
 import 'package:dart_style/src/debug.dart' as debug;
 import 'package:dart_style/src/front_end/ast_node_visitor.dart';
 import 'package:dart_style/src/front_end/formatting_style.dart';
@@ -163,6 +164,10 @@ double _runTrial(
   SourceCode source,
   String expected,
 ) {
+  var lineEnding =
+      formatter.lineEnding ??
+      inferLineEnding(parseResult.lineInfo, source.text);
+
   var stopwatch = Stopwatch()..start();
 
   // For a single benchmark, format the source multiple times.
@@ -170,10 +175,10 @@ double _runTrial(
   for (var j = 0; j < _formatsPerTrial; j++) {
     if (_isShort) {
       var visitor = SourceVisitor(formatter, parseResult.lineInfo, source);
-      result = visitor.run(parseResult.unit).text;
+      result = visitor.run(parseResult.unit, lineEnding).text;
     } else {
       var visitor = AstNodeVisitor(
-        FormattingStyle(formatter),
+        FormattingStyle(formatter, lineEnding: lineEnding),
         parseResult.lineInfo,
         source,
       );

--- a/lib/dart_style.dart
+++ b/lib/dart_style.dart
@@ -1,6 +1,6 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-export 'src/dart_formatter.dart';
+export 'src/dart_formatter.dart' hide inferLineEnding;
 export 'src/exceptions.dart';
 export 'src/source_code.dart';

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Do not edit directly. Use tool/bump_version.dart.
-const dartStyleVersion = '3.1.12';
+const dartStyleVersion = '3.1.13';
 
 /// Global options parsed from the command line that affect how the formatter
 /// produces and uses its outputs.

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/diagnostic/diagnostic.dart';
 import 'package:analyzer/error/error.dart';
+import 'package:analyzer/source/line_info.dart' show LineInfo;
 import 'package:analyzer/source/source.dart';
 import 'package:analyzer/source/timestamped_data.dart';
 import 'package:path/path.dart' as p;
@@ -60,7 +61,14 @@ final class DartFormatter {
   /// If not explicitly provided, this is inferred from the source text. If the
   /// first newline is `\r\n` (Windows), it will use that. Otherwise, it uses
   /// Unix-style line endings (`\n`).
-  String? lineEnding;
+  String? get lineEnding => _lineEnding;
+  final String? _lineEnding;
+
+  /// Setting after creating a [DartFormatter] is no longer supported and does
+  /// nothing.
+  // TODO(rnystrom): Remove this when we're ready to move to 4.0.0.
+  @Deprecated('To change the line ending, create a new DartFormatter.')
+  set lineEnding(String? value) {}
 
   /// The number of characters allowed in a single line.
   final int pageWidth;
@@ -83,19 +91,20 @@ final class DartFormatter {
   /// Creates a new formatter for Dart code at [languageVersion].
   ///
   /// If [lineEnding] is given, that will be used for any newlines in the
-  /// output. Otherwise, the line separator will be inferred from the line
-  /// endings in the source file.
+  /// output. Otherwise, the line separator is inferred from the first line
+  /// ending in the source code on each format.
   ///
   /// If [indent] is given, that many levels of indentation will be prefixed
   /// before each resulting line in the output.
   DartFormatter({
     required this.languageVersion,
-    this.lineEnding,
+    String? lineEnding,
     int? pageWidth,
     int? indent,
     TrailingCommas? trailingCommas,
     List<String>? experimentFlags,
-  }) : pageWidth = pageWidth ?? defaultPageWidth,
+  }) : _lineEnding = lineEnding,
+       pageWidth = pageWidth ?? defaultPageWidth,
        indent = indent ?? 0,
        trailingCommas = trailingCommas ?? TrailingCommas.automate,
        experimentFlags = [...?experimentFlags];
@@ -163,17 +172,8 @@ final class DartFormatter {
 
     // Infer the line ending if not given one. Do it here since now we know
     // where the lines start.
-    if (lineEnding == null) {
-      // If the first newline is "\r\n", use that. Otherwise, use "\n".
-      var lineStarts = parseResult.lineInfo.lineStarts;
-      if (lineStarts.length > 1 &&
-          lineStarts[1] >= 2 &&
-          text[lineStarts[1] - 2] == '\r') {
-        lineEnding = '\r\n';
-      } else {
-        lineEnding = '\n';
-      }
-    }
+    var inferredLineEnding =
+        _lineEnding ?? inferLineEnding(parseResult.lineInfo, text);
 
     // Throw if there are syntactic errors.
     var syntacticErrors = parseResult.errors.where((error) {
@@ -239,6 +239,7 @@ final class DartFormatter {
       var visitor = AstNodeVisitor(
         FormattingStyle(
           this,
+          lineEnding: inferredLineEnding,
           languageVersion: sourceLanguageVersion,
           pageWidth: pageWidthFromComment,
         ),
@@ -249,7 +250,7 @@ final class DartFormatter {
     } else {
       // Use the old style.
       var visitor = SourceVisitor(this, lineInfo, unitSourceCode);
-      output = visitor.run(node);
+      output = visitor.run(node, inferredLineEnding);
     }
 
     // Sanity check that only whitespace was changed if that's all we expect.
@@ -259,6 +260,19 @@ final class DartFormatter {
 
     return output;
   }
+}
+
+/// Infers the line endings in [source] from the ending of the first newline.
+String inferLineEnding(LineInfo lineInfo, String source) {
+  // If the first newline is "\r\n", use that. Otherwise, use "\n".
+  var lineStarts = lineInfo.lineStarts;
+  if (lineStarts.length > 1 &&
+      lineStarts[1] >= 2 &&
+      source[lineStarts[1] - 2] == '\r') {
+    return '\r\n';
+  }
+
+  return '\n';
 }
 
 /// Configuration for how trailing commas should be handled by the formatter.

--- a/lib/src/front_end/formatting_style.dart
+++ b/lib/src/front_end/formatting_style.dart
@@ -34,11 +34,15 @@ final class FormattingStyle {
   /// formatted has a `// dart format width = ` comment.
   final int pageWidth;
 
-  FormattingStyle(this._formatter, {Version? languageVersion, int? pageWidth})
-    : _languageVersion = languageVersion ?? _formatter.languageVersion,
-      pageWidth = pageWidth ?? _formatter.pageWidth;
+  FormattingStyle(
+    this._formatter, {
+    required this.lineEnding,
+    Version? languageVersion,
+    int? pageWidth,
+  }) : _languageVersion = languageVersion ?? _formatter.languageVersion,
+       pageWidth = pageWidth ?? _formatter.pageWidth;
 
-  String? get lineEnding => _formatter.lineEnding;
+  final String? lineEnding;
 
   /// The number of characters of indentation to prefix the output lines with.
   int get leadingIndent => _formatter.indent;

--- a/lib/src/short/chunk_builder.dart
+++ b/lib/src/short/chunk_builder.dart
@@ -567,7 +567,7 @@ final class ChunkBuilder {
 
   /// Finishes writing and returns a [SourceCode] containing the final output
   /// and updated selection, if any.
-  SourceCode end() {
+  SourceCode end(String lineEnding) {
     assert(_rules.isEmpty);
 
     _divideChunks();
@@ -580,7 +580,7 @@ final class ChunkBuilder {
 
     Profile.begin('ChunkBuilder run line splitter');
 
-    var writer = LineWriter(_formatter, _chunks);
+    var writer = LineWriter(_formatter, lineEnding, _chunks);
     var result = writer.writeLines(
       isCompilationUnit: _source.isCompilationUnit,
     );

--- a/lib/src/short/line_writer.dart
+++ b/lib/src/short/line_writer.dart
@@ -42,9 +42,8 @@ final class LineWriter {
   /// The number of characters that have been written to the output.
   int get length => _buffer.length;
 
-  LineWriter(DartFormatter formatter, this._chunks)
-    : _lineEnding = formatter.lineEnding!,
-      pageWidth = formatter.pageWidth,
+  LineWriter(DartFormatter formatter, this._lineEnding, this._chunks)
+    : pageWidth = formatter.pageWidth,
       _blockIndentation = 0,
       _blockCache = {};
 

--- a/lib/src/short/source_visitor.dart
+++ b/lib/src/short/source_visitor.dart
@@ -103,7 +103,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
   ///
   /// This is the only method that should be called externally. Everything else
   /// is effectively private.
-  SourceCode run(AstNode node) {
+  SourceCode run(AstNode node, String lineEnding) {
     Profile.begin('SourceVisitor create Chunks');
 
     visit(node);
@@ -114,7 +114,7 @@ final class SourceVisitor extends ThrowingAstVisitor {
     Profile.end('SourceVisitor create Chunks');
 
     // Finish writing and return the complete result.
-    return builder.end();
+    return builder.end(lineEnding);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Do not edit directly. Use tool/bump_version.dart.
-version: 3.1.12
+version: 3.1.13-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.

--- a/test/dart_formatter_test.dart
+++ b/test/dart_formatter_test.dart
@@ -309,6 +309,25 @@ var variable =
         ),
       );
     });
+
+    test('DartFormat.lineEnding getter is not mutated by inferred ending', () {
+      var formatter = makeFormatter();
+      expect(formatter.lineEnding, isNull);
+
+      formatter.format('var\r\ni\n=\n1;\n');
+      expect(formatter.lineEnding, isNull);
+
+      formatter.format('var\ni\n=\n1;\n');
+      expect(formatter.lineEnding, isNull);
+    });
+
+    test('DartFormat.lineEnding setter does nothing', () {
+      var formatter = makeFormatter(lineEnding: 'before');
+      expect(formatter.lineEnding, 'before');
+
+      formatter.lineEnding = 'after';
+      expect(formatter.lineEnding, 'before');
+    });
   });
 
   test('throws an UnexpectedOutputException on non-whitespace changes', () {


### PR DESCRIPTION
This property was always intended to be semantically immutable but since the early days, it was exposed as a public writable field.

This retains the setter to avoid a compile-time breaking change in the off chance there is some code calling the setter, but invoking it does nothing.

This also fixes the weird behavior where if you omit a line ending (which I'm guessing all users do), it infers the line ending from the first format() call and then persists that to later calls. This is a weird subtle kind of mutability. In practice, it's harmless because users rarely reuse a DartFormatter instance to format code with different line endings. But it never felt like a good design.

This is technically a breaking change, but in a corpus of 2,000 pub packages, I couldn't find a single reference to an identifier named "lineEnding", so I suspect no code in the wild will actually break, which is why I only bumped the patch version.

Fix #1337.
