### PR TITLE
Fix missing trailing comma in enums with primary constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 3.1.13-wip
 
+### Bug fixes
+
+* Add a trailing comma after the last value of an enum with a primary
+  constructor and no members. Previously, the trailing comma was dropped, which
+  was inconsistent with how enums without primary constructors are formatted
+  (#1888).
+
 ### API changes
 
 * `DartFormatter.lineEnding` is no longer mutable. If no line ending is

--- a/lib/src/front_end/type_builder.dart
+++ b/lib/src/front_end/type_builder.dart
@@ -94,9 +94,11 @@ final class TypeBuilder {
       // So always force the body to split if there is a primary constructor.
       switch (node.body) {
         case BlockEnumBody body:
-          if (body.members.isEmpty &&
-              node.namePart is! PrimaryConstructorDeclaration) {
-            return _buildNormalBlockEnumBody(body);
+          if (body.members.isEmpty) {
+            return _buildNormalBlockEnumBody(
+              body,
+              forceSplit: node.namePart is PrimaryConstructorDeclaration,
+            );
           } else {
             return _buildEnhancedBlockEnumBody(body);
           }
@@ -211,8 +213,11 @@ final class TypeBuilder {
   /// members.
   ///
   /// Formats the constants like a list. This keeps the enum declaration on one
-  /// line if it fits.
-  Piece _buildNormalBlockEnumBody(BlockEnumBody body) {
+  /// line if it fits, unless [forceSplit] is `true`.
+  Piece _buildNormalBlockEnumBody(
+    BlockEnumBody body, {
+    bool forceSplit = false,
+  }) {
     var builder = DelimitedListBuilder(
       _visitor,
       const ListStyle(spaceWhenUnsplit: true),
@@ -222,9 +227,11 @@ final class TypeBuilder {
     body.constants.forEach(builder.visit);
     builder.rightBracket(semicolon: body.semicolon, body.rightBracket);
     return builder.build(
-      forceSplit: _visitor.style.preserveTrailingCommaBefore(
-        body.semicolon ?? body.rightBracket,
-      ),
+      forceSplit:
+          forceSplit ||
+          _visitor.style.preserveTrailingCommaBefore(
+            body.semicolon ?? body.rightBracket,
+          ),
     );
   }
 

--- a/test/tall/declaration/constructor_primary.unit
+++ b/test/tall/declaration/constructor_primary.unit
@@ -83,7 +83,23 @@ enum const C(int x) { a, b, c }
 enum const C(int x) {
   a,
   b,
-  c
+  c,
+}
+>>> Preserve trailing comma after the last value.
+enum const C(int x) { a, b, c, }
+<<< 3.13
+enum const C(int x) {
+  a,
+  b,
+  c,
+}
+>>> Remove semicolon after the last value if there are no members.
+enum const C(int x) { a, b, c; }
+<<< 3.13
+enum const C(int x) {
+  a,
+  b,
+  c,
 }
 >>> With optional parameters.
 class Foo(int a, int b, [int? c, int? d]);


### PR DESCRIPTION
When an enum has a primary constructor, the formatter forces the enum to split. Before, it would simply treat the enum as an enhanced enum, even when it has no members. This PR uses the "normal" formatting path and sets `forceSplit` for primary constructors.

As a "bonus" (not mentioned in the original issue), the semicolon is now also replaced with a trailing comma, just like enums without primary constructors.

Closes #1888

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
