### PR TITLE
Fix enums with primary constructors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 ## 3.1.13-wip
 
+### Bug fixes
+
+* Don't crash when formatting an enum with a primary constructor when preserve
+  trailing commas is enabled (#1885).
+
+### Style changes
+
+* Insert a trailing comma after the last enum value when an enum has a primary
+  constructor (#1888). When enum values are split, they should always have a
+  trailing comma after the last value (unless there is a semicolon instead):
+
+  ```dart
+  enum Color {
+    red,
+    yellow,
+    blue,
+  }
+  ```
+
+  The formatter would erroneously *not* add one if the enum had a primary
+  constructor:
+
+  ```dart
+  enum Color() {
+    red,
+    yellow,
+    blue,
+  }
+  ```
+
+  This is now fixed. This change is *not* language versioned. (The previous
+  style was wrong, primary constructors are new and not yet common in the wild,
+  and we want to ship the style fix in a patch release of the Dart SDK instead
+  of waiting until 3.14.)
+
 ### API changes
 
 * `DartFormatter.lineEnding` is no longer mutable. If no line ending is

--- a/lib/src/front_end/type_builder.dart
+++ b/lib/src/front_end/type_builder.dart
@@ -94,9 +94,11 @@ final class TypeBuilder {
       // So always force the body to split if there is a primary constructor.
       switch (node.body) {
         case BlockEnumBody body:
-          if (body.members.isEmpty &&
-              node.namePart is! PrimaryConstructorDeclaration) {
-            return _buildNormalBlockEnumBody(body);
+          if (body.members.isEmpty) {
+            return _buildNormalBlockEnumBody(
+              body,
+              forceSplit: node.namePart is PrimaryConstructorDeclaration,
+            );
           } else {
             return _buildEnhancedBlockEnumBody(body);
           }
@@ -211,8 +213,12 @@ final class TypeBuilder {
   /// members.
   ///
   /// Formats the constants like a list. This keeps the enum declaration on one
-  /// line if it fits.
-  Piece _buildNormalBlockEnumBody(BlockEnumBody body) {
+  /// line if it fits (unless [forceSplit] is `true` in which case it always
+  /// splits).
+  Piece _buildNormalBlockEnumBody(
+    BlockEnumBody body, {
+    bool forceSplit = false,
+  }) {
     var builder = DelimitedListBuilder(
       _visitor,
       const ListStyle(spaceWhenUnsplit: true),
@@ -222,9 +228,11 @@ final class TypeBuilder {
     body.constants.forEach(builder.visit);
     builder.rightBracket(semicolon: body.semicolon, body.rightBracket);
     return builder.build(
-      forceSplit: _visitor.style.preserveTrailingCommaBefore(
-        body.semicolon ?? body.rightBracket,
-      ),
+      forceSplit:
+          forceSplit ||
+          _visitor.style.preserveTrailingCommaBefore(
+            body.semicolon ?? body.rightBracket,
+          ),
     );
   }
 

--- a/test/tall/declaration/class.unit
+++ b/test/tall/declaration/class.unit
@@ -6,7 +6,7 @@ class   A   {
 }
 <<< 3.7
 class A {}
->>> (experiment primary-constructors) Empty semicolon body.
+>>> Empty semicolon body.
 class   A   ;
 <<< 3.13
 class A;
@@ -78,7 +78,7 @@ class SomeClass native "Zapp" {
 }
 <<< 3.7
 class SomeClass native "Zapp" {}
->>> (experiment primary-constructors) Don't force blank lines around `;` bodies.
+>>> Don't force blank lines around `;` bodies.
 class   A   ;
 class   B(int x)   ;
 class   C   ;

--- a/test/tall/declaration/class_comment.unit
+++ b/test/tall/declaration/class_comment.unit
@@ -87,7 +87,7 @@ class Foo {}
 /**
 */
 class Bar {}
->>> (experiment primary-constructors) Comment before empty body.
+>>> Comment before empty body.
 class C // Comment.
 ;
 <<< 3.13

--- a/test/tall/declaration/constructor_factory.unit
+++ b/test/tall/declaration/constructor_factory.unit
@@ -1,5 +1,4 @@
 40 columns                              |
-(experiment primary-constructors)
 ### Tests for using `factory` to define a constructor.
 >>> Factory.
 class C {

--- a/test/tall/declaration/constructor_new.unit
+++ b/test/tall/declaration/constructor_new.unit
@@ -1,5 +1,4 @@
 40 columns                              |
-(experiment primary-constructors)
 ### Tests for using `new` to define a constructor.
 >>> Generative.
 class C {

--- a/test/tall/declaration/constructor_parameter.unit
+++ b/test/tall/declaration/constructor_parameter.unit
@@ -149,7 +149,7 @@ class A {
   int? _y;
   int? _z;
 }
->>> (experiment primary-constructors) Declaring normal parameters.
+>>> Declaring normal parameters.
 class C(var int x, final String y, var untyped, final another);
 <<< 3.13
 class C(
@@ -158,7 +158,7 @@ class C(
   var untyped,
   final another,
 );
->>> (experiment primary-constructors) Declaring optional positional parameters.
+>>> Declaring optional positional parameters.
 class C([var int? x, final String? y, var untyped, final another]);
 <<< 3.13
 class C([
@@ -167,7 +167,7 @@ class C([
   var untyped,
   final another,
 ]);
->>> (experiment primary-constructors) Declaring optional named parameters.
+>>> Declaring optional named parameters.
 class C({var int? x, final String? y, var untyped, final another});
 <<< 3.13
 class C({
@@ -176,7 +176,7 @@ class C({
   var untyped,
   final another,
 });
->>> (experiment primary-constructors) Declaring required named parameters.
+>>> Declaring required named parameters.
 class C({required var int? x, required final String? y, required var untyped, required final another});
 <<< 3.13
 class C({
@@ -185,7 +185,7 @@ class C({
   required var untyped,
   required final another,
 });
->>> (experiment primary-constructors) Declaring coviariant parameters.
+>>> Declaring coviariant parameters.
 class C(covariant var int? x, {required covariant var int z, covariant var String? a});
 <<< 3.13
 class C(
@@ -193,7 +193,7 @@ class C(
   required covariant var int z,
   covariant var String? a,
 });
->>> (experiment primary-constructors) Declaring parameter with default values.
+>>> Declaring parameter with default values.
 class C1([var int x = 1, final String y = 's']);
 class C2({var int x = 1, final String y = 's'});
 <<< 3.13
@@ -205,7 +205,7 @@ class C2({
   var int x = 1,
   final String y = 's',
 });
->>> (experiment primary-constructors) Declaring function-typed parameters.
+>>> Declaring function-typed parameters.
 class C(var int fn(), final callback(String s));
 <<< 3.13
 class C(

--- a/test/tall/declaration/constructor_primary.unit
+++ b/test/tall/declaration/constructor_primary.unit
@@ -1,5 +1,4 @@
 40 columns                              |
-(experiment primary-constructors)
 ### Tests for primary constructors in the class header.
 >>> Unsplit.
 class  const  C  <  T  >  .  named  (  int  x  ,  int  y  )  {  }
@@ -19,11 +18,11 @@ class B(int x) with M1, M2;
 class C(int x) implements I1, I2;
 >>> Don't split after const.
 class const ExtremelyLongClassNameHere();
-<<< 3.7
+<<< 3.13
 class const ExtremelyLongClassNameHere();
 >>> Don't split on class name.
 class LongClassName.longConstructorName();
-<<< 3.7
+<<< 3.13
 class LongClassName.longConstructorName();
 >>> With everything split.
 class const C<T1 extends TypeBound, T2 extends TypeBound>.named

--- a/test/tall/declaration/constructor_primary.unit
+++ b/test/tall/declaration/constructor_primary.unit
@@ -83,7 +83,7 @@ enum const C(int x) { a, b, c }
 enum const C(int x) {
   a,
   b,
-  c
+  c,
 }
 >>> With optional parameters.
 class Foo(int a, int b, [int? c, int? d]);

--- a/test/tall/declaration/enum.unit
+++ b/test/tall/declaration/enum.unit
@@ -51,6 +51,14 @@ enum E { a, b }
 enum E {a,b,c,;}
 <<< 3.7
 enum E { a, b, c }
+>>> Remove semicolon but split if a primary constructor.
+enum E() {a,b,c,;}
+<<< 3.13
+enum E() {
+  a,
+  b,
+  c,
+}
 >>> Split values and add trailing comma but remove semicolon if no members.
 enum Primate{bonobo,chimp,gorilla,organutan;}
 <<< 3.7

--- a/test/tall/declaration/enum.unit
+++ b/test/tall/declaration/enum.unit
@@ -190,25 +190,25 @@ enum E {
 }
 <<< 3.7
 enum E { a, b, c }
->>> (experiment primary-constructors) Empty body with semicolon.
+>>> Empty body with semicolon.
 enum E;
-<<< 3.7
+<<< 3.13
 enum E;
->>> (experiment primary-constructors) Don't force blank lines around `;` bodies.
+>>> Don't force blank lines around `;` bodies.
 var x = 1;
 enum A ;
 var y = 2;
-<<< 3.7
+<<< 3.13
 var x = 1;
 enum A;
 var y = 2;
->>> (experiment primary-constructors) Generic enum type with empty body.
+>>> Generic enum type with empty body.
 enum MagicNumbers< T    extends num   ,   S> ;
-<<< 3.7
+<<< 3.13
 enum MagicNumbers<T extends num, S>;
->>> (experiment primary-constructors) Split in type parameters with empty body.
+>>> Split in type parameters with empty body.
 enum SomeEnumType<LongTypeParameterName, Another> ;
-<<< 3.7
+<<< 3.13
 enum SomeEnumType<
   LongTypeParameterName,
   Another

--- a/test/tall/declaration/enum_clause.unit
+++ b/test/tall/declaration/enum_clause.unit
@@ -41,31 +41,31 @@ enum SomeEnum
         AnotherInterface {
   a,
 }
->>> (experiment primary-constructors) Unsplit with clause with empty body.
+>>> Unsplit with clause with empty body.
 enum E with M ;
-<<< 3.7
+<<< 3.13
 enum E with M;
->>> (experiment primary-constructors) Unsplit implements clause with empty body.
+>>> Unsplit implements clause with empty body.
 enum E implements I ;
-<<< 3.7
+<<< 3.13
 enum E implements I;
->>> (experiment primary-constructors) Unsplit both clauses with empty body.
+>>> Unsplit both clauses with empty body.
 enum E with M implements I ;
-<<< 3.7
+<<< 3.13
 enum E with M implements I;
->>> (experiment primary-constructors) Split with clause with empty body.
+>>> Split with clause with empty body.
 enum VeryLongEnumTypeName with LongMixin ;
-<<< 3.7
+<<< 3.13
 enum VeryLongEnumTypeName
     with LongMixin;
->>> (experiment primary-constructors) Split implements clause with empty body.
+>>> Split implements clause with empty body.
 enum VeryLongEnumTypeName implements LongInterface ;
-<<< 3.7
+<<< 3.13
 enum VeryLongEnumTypeName
     implements LongInterface;
->>> (experiment primary-constructors) Both clauses split with empty body.
+>>> Both clauses split with empty body.
 enum SomeEnum with SomeLongMixin, AnotherMixin<int> implements SomeInterface<String, bool>, AnotherInterface ;
-<<< 3.7
+<<< 3.13
 enum SomeEnum
     with
         SomeLongMixin,

--- a/test/tall/declaration/extension.unit
+++ b/test/tall/declaration/extension.unit
@@ -68,55 +68,55 @@ extension SomeExtension
           VeryLongType,
           AnotherLongType
         > {}
->>> (experiment primary-constructors) Empty body with semicolon.
+>>> Empty body with semicolon.
 extension A on B;
-<<< 3.7
+<<< 3.13
 extension A on B;
->>> (experiment primary-constructors) Don't force blank lines around `;` bodies.
+>>> Don't force blank lines around `;` bodies.
 var x = 1;
 extension A on B;
 var y = 2;
-<<< 3.7
+<<< 3.13
 var x = 1;
 extension A on B;
 var y = 2;
->>> (experiment primary-constructors) Unsplit type parameters with empty body.
+>>> Unsplit type parameters with empty body.
 extension  A  <  T  ,  S  >  on  B  ;
-<<< 3.7
+<<< 3.13
 extension A<T, S> on B;
->>> (experiment primary-constructors) Split type parameters with empty body.
+>>> Split type parameters with empty body.
 extension Extension<LongTypeParameter, Another> on BaseClass ;
-<<< 3.7
+<<< 3.13
 extension Extension<
   LongTypeParameter,
   Another
 >
     on BaseClass;
->>> (experiment primary-constructors) Unnamed with empty body.
+>>> Unnamed with empty body.
 extension on String ;
-<<< 3.7
+<<< 3.13
 extension on String;
->>> (experiment primary-constructors) Unnamed with type parameters with empty body.
+>>> Unnamed with type parameters with empty body.
 extension  <  T  ,  S  >  on  B ;
-<<< 3.7
+<<< 3.13
 extension<T, S> on B;
->>> (experiment primary-constructors) Split at `on` with empty body.
+>>> Split at `on` with empty body.
 extension SomeExtension on VeryLongClass ;
-<<< 3.7
+<<< 3.13
 extension SomeExtension
     on VeryLongClass;
->>> (experiment primary-constructors) Unsplit generic on type with empty body.
+>>> Unsplit generic on type with empty body.
 extension SomeExtension on C<int> ;
-<<< 3.7
+<<< 3.13
 extension SomeExtension on C<int>;
->>> (experiment primary-constructors) Split before `on` on generic on type with empty body.
+>>> Split before `on` on generic on type with empty body.
 extension SomeExtension on C<SomeLongClass> ;
-<<< 3.7
+<<< 3.13
 extension SomeExtension
     on C<SomeLongClass>;
->>> (experiment primary-constructors) Split in generic on type with empty body.
+>>> Split in generic on type with empty body.
 extension SomeExtension on C<ExtremelyLongType, AnotherLongType> ;
-<<< 3.7
+<<< 3.13
 extension SomeExtension
     on
         C<

--- a/test/tall/declaration/extension_type.unit
+++ b/test/tall/declaration/extension_type.unit
@@ -4,7 +4,7 @@ extension type A(int a) {
   }
 <<< 3.7
 extension type A(int a) {}
->>> (experiment primary-constructors) Empty semicolon body.
+>>> Empty semicolon body.
 extension type   A(int a)   ;
 <<< 3.13
 extension type A(int a);
@@ -183,7 +183,7 @@ var y = 2;
 extension type B(int x) {}
 
 var z = 3;
->>> (experiment primary-constructors) Don't force blank lines around `;` bodies.
+>>> Don't force blank lines around `;` bodies.
 extension type   A(int x)   ;
 extension type   B(int x)   ;
 extension type   C(int x)   ;

--- a/test/tall/declaration/extension_type_comment.unit
+++ b/test/tall/declaration/extension_type_comment.unit
@@ -135,7 +135,7 @@ name // j
         {
   // s
 } // t
->>> (experiment primary-constructors) Comment before empty body.
+>>> Comment before empty body.
 extension type I(int i) // Comment.
 ;
 <<< 3.13

--- a/test/tall/declaration/mixin.unit
+++ b/test/tall/declaration/mixin.unit
@@ -79,15 +79,15 @@ var y = 2;
 mixin M2 {}
 
 var z = 3;
->>> (experiment primary-constructors) Empty body with semicolon.
+>>> Empty body with semicolon.
 mixin A;
-<<< 3.7
+<<< 3.13
 mixin A;
->>> (experiment primary-constructors) Empty body with semicolon and on clause.
+>>> Empty body with semicolon and on clause.
 mixin B on C;
-<<< 3.7
+<<< 3.13
 mixin B on C;
->>> (experiment primary-constructors) Don't force blank lines around `;` bodies.
+>>> Don't force blank lines around `;` bodies.
 var x = 1;
 mixin A;
 mixin B on C;
@@ -97,13 +97,13 @@ var x = 1;
 mixin A;
 mixin B on C;
 var y = 2;
->>> (experiment primary-constructors) Modifiers with empty body.
+>>> Modifiers with empty body.
 mixin  class  M1  ;
 base  mixin  class  M2  ;
 abstract  mixin  class  M3  ;
 abstract  base  mixin  class  M4  ;
 base  mixin  M5  ;
-<<< 3.7
+<<< 3.13
 mixin class M1;
 base mixin class M2;
 abstract mixin class M3;

--- a/test/tall/declaration/mixin_clause.unit
+++ b/test/tall/declaration/mixin_clause.unit
@@ -122,123 +122,123 @@ mixin C on A
           LongTypeArgument,
           AnotherLongType
         > {}
->>> (experiment primary-constructors) Unsplit on clause with empty body.
+>>> Unsplit on clause with empty body.
 mixin A on B ;
-<<< 3.7
+<<< 3.13
 mixin A on B;
->>> (experiment primary-constructors) Multiple unsplit types in on clause with empty body.
+>>> Multiple unsplit types in on clause with empty body.
 mixin  M2  on  A  ,  B  ,  C  ;
-<<< 3.7
+<<< 3.13
 mixin M2 on A, B, C;
->>> (experiment primary-constructors) Split at `on` with empty body.
+>>> Split at `on` with empty body.
 mixin SomeLongMixin on VeryLongBaseMixin ;
-<<< 3.7
+<<< 3.13
 mixin SomeLongMixin
     on VeryLongBaseMixin;
->>> (experiment primary-constructors) Split multiple at `on` with empty body.
+>>> Split multiple at `on` with empty body.
 mixin  LongMixin  on  SupertypeA  ,  SupertypeB  ;
-<<< 3.7
+<<< 3.13
 mixin LongMixin
     on SupertypeA, SupertypeB;
->>> (experiment primary-constructors) Split multiple on clause with empty body.
+>>> Split multiple on clause with empty body.
 mixin  M2  on  SupertypeA  ,  SupertypeB  ,  SupertypeC  ;
-<<< 3.7
+<<< 3.13
 mixin M2
     on
         SupertypeA,
         SupertypeB,
         SupertypeC;
->>> (experiment primary-constructors) Unsplit implements clause with empty body.
+>>> Unsplit implements clause with empty body.
 mixin A implements B ;
-<<< 3.7
+<<< 3.13
 mixin A implements B;
->>> (experiment primary-constructors) Unsplit multiple clauses with empty body.
+>>> Unsplit multiple clauses with empty body.
 mixin A on B implements D ;
-<<< 3.7
+<<< 3.13
 mixin A on B implements D;
->>> (experiment primary-constructors) Split at `implements` with empty body.
+>>> Split at `implements` with empty body.
 mixin SomeMixin implements VeryLongBaseMixin ;
-<<< 3.7
+<<< 3.13
 mixin SomeMixin
     implements VeryLongBaseMixin;
->>> (experiment primary-constructors) Split at `implements` but not between interfaces with empty body.
+>>> Split at `implements` but not between interfaces with empty body.
 mixin SomeMixin implements Interface, AnotherOne ;
-<<< 3.7
+<<< 3.13
 mixin SomeMixin
     implements Interface, AnotherOne;
->>> (experiment primary-constructors) Split at `implements` and interfaces with empty body.
+>>> Split at `implements` and interfaces with empty body.
 mixin SomeMixin implements Interface, Another, Third ;
-<<< 3.7
+<<< 3.13
 mixin SomeMixin
     implements
         Interface,
         Another,
         Third;
->>> (experiment primary-constructors) Split at `on` splits `implements` too with empty body.
+>>> Split at `on` splits `implements` too with empty body.
 mixin AVeryLongSomeMixin on LongBaseMixin implements I ;
-<<< 3.7
+<<< 3.13
 mixin AVeryLongSomeMixin
     on LongBaseMixin
     implements I;
->>> (experiment primary-constructors)
+>>> With empty body.
 mixin AVeryLongSomeMixin on LongBaseMixin implements Interface ;
-<<< 3.7
+<<< 3.13
 mixin AVeryLongSomeMixin
     on LongBaseMixin
     implements Interface;
->>> (experiment primary-constructors) Can split `implements` clause without splitting `on` with empty body.
+>>> Can split `implements` clause without splitting `on` with empty body.
 mixin SomeMixin on A implements Type, Another ;
-<<< 3.7
+<<< 3.13
 mixin SomeMixin on A
     implements Type, Another;
->>> (experiment primary-constructors)
+>>> With empty body.
 mixin SomeMixin on A implements Type, Another, Third, Fourth ;
-<<< 3.7
+<<< 3.13
 mixin SomeMixin on A
     implements
         Type,
         Another,
         Third,
         Fourth;
->>> (experiment primary-constructors) Unsplit generic supermixin with empty body.
+>>> Unsplit generic supermixin with empty body.
 mixin SomeMixin on C<int> ;
-<<< 3.7
+<<< 3.13
 mixin SomeMixin on C<int>;
->>> (experiment primary-constructors) Split before `on` on generic supermixin with empty body.
+>>> Split before `on` on generic supermixin with empty body.
 mixin SomeMixin on Superclass<SomeLongmixin> ;
-<<< 3.7
+<<< 3.13
 mixin SomeMixin
     on Superclass<SomeLongmixin>;
->>> (experiment primary-constructors) Split in generic supermixin with empty body.
+>>> Split in generic supermixin with empty body.
 mixin SomeMixin on C<ExtremelyLongType, AnotherLongType> ;
-<<< 3.7
+<<< 3.13
 mixin SomeMixin
     on
         C<
           ExtremelyLongType,
           AnotherLongType
         >;
->>> (experiment primary-constructors) Unsplit generic superinterface with empty body.
+>>> Unsplit generic superinterface with empty body.
 mixin SomeMixin implements C<int> ;
-<<< 3.7
+<<< 3.13
 mixin SomeMixin implements C<int>;
->>> (experiment primary-constructors) Split before `implements` on generic superinterface with empty body.
+>>> Split before `implements` on generic superinterface with empty body.
 mixin SomeMixin implements C<SomeLongmixin> ;
-<<< 3.7
+<<< 3.13
 mixin SomeMixin
     implements C<SomeLongmixin>;
->>> (experiment primary-constructors) Split in generic superinterface with empty body.
+>>> Split in generic superinterface with empty body.
 mixin SomeMixin implements C<ExtremelyLongType, AnotherLongType> ;
-<<< 3.7
+<<< 3.13
 mixin SomeMixin
     implements
         C<
           ExtremelyLongType,
           AnotherLongType
         >;
->>> (experiment primary-constructors) Split in generic `implements` clause does not force `on` clause to split with empty body.
+>>> Split in generic `implements` clause does not force `on` clause to split with empty body.
 mixin C on A implements B<LongTypeArgument, AnotherLongType> ;
-<<< 3.7
+<<< 3.13
 mixin C on A
     implements
         B<

--- a/test/tall/declaration/this_block.unit
+++ b/test/tall/declaration/this_block.unit
@@ -1,5 +1,4 @@
 40 columns                              |
-(experiment primary-constructors)
 ### Tests for a primary constructor `this` block in the class body.
 >>> Unsplit.
 class C(int x) {

--- a/test/tall/preserve_trailing_commas/constructor.unit
+++ b/test/tall/preserve_trailing_commas/constructor.unit
@@ -78,19 +78,19 @@ class A {
   A(int x) : this.named(x);
   A.named(int x) : this(x);
 }
->>> (experiment primary-constructors) Primary constructor parameter list splits with trailing comma.
+>>> Primary constructor parameter list splits with trailing comma.
 class A(int x,);
-<<< 3.7
+<<< 3.13
 class A(
   int x,
 );
->>> (experiment primary-constructors) Doesn't force split primary constructor parameter list without trailing comma.
+>>> Doesn't force split primary constructor parameter list without trailing comma.
 class A(int x, int y);
-<<< 3.11
+<<< 3.13
 class A(int x, int y);
->>> (experiment primary-constructors) May still split primary constructor without trailing comma if doesn't fit.
+>>> May still split primary constructor without trailing comma if doesn't fit.
 class A(int parameter1, int parameter2, int parameter3);
-<<< 3.11
+<<< 3.13
 class A(
   int parameter1,
   int parameter2,

--- a/test/tall/preserve_trailing_commas/enum.unit
+++ b/test/tall/preserve_trailing_commas/enum.unit
@@ -69,3 +69,38 @@ enum Args {
     named: 1,
   ),
 }
+>>> Splits even without trailing comma because of the primary constructor.
+enum E() {e,f,g}
+<<< 3.13
+enum E() {
+  e,
+  f,
+  g,
+}
+>>> Preserve trailing comma but remove semicolon if primary constructor and no members.
+enum E() {e,;}
+<<< 3.13
+enum E() {
+  e,
+}
+>>> No trailing comma with primary constructor and members keeps semicolon on same line.
+enum E() { a, b, c; int x; }
+<<< 3.13
+enum E() {
+  a,
+  b,
+  c;
+
+  int x;
+}
+>>> Trailing comma with primary constructor and members.
+enum E() { a, b, c,; int x; }
+<<< 3.13
+enum E() {
+  a,
+  b,
+  c,
+  ;
+
+  int x;
+}

--- a/test/tall/regression/1800/1885.unit
+++ b/test/tall/regression/1800/1885.unit
@@ -1,0 +1,34 @@
+>>>
+enum MyEnum() { foo, bar }
+<<< 3.13
+enum MyEnum() {
+  foo,
+  bar,
+}
+>>>
+enum MyEnum() {
+  foo,
+  bar;
+}
+<<< 3.13
+enum MyEnum() {
+  foo,
+  bar,
+}
+>>> (trailing_commas preserve)
+enum MyEnum() { foo, bar }
+<<< 3.13
+enum MyEnum() {
+  foo,
+  bar,
+}
+>>> (trailing_commas preserve)
+enum MyEnum() {
+  foo,
+  bar;
+}
+<<< 3.13
+enum MyEnum() {
+  foo,
+  bar,
+}

--- a/test/tall/regression/1800/1888.unit
+++ b/test/tall/regression/1800/1888.unit
@@ -1,0 +1,34 @@
+>>>
+enum A() {one,two,three,four,five,six,seven,eight,nine,ten,eleven,twelve}
+
+enum B {one,two,three,four,five,six,seven,eight,nine,ten,eleven,twelve}
+<<< 3.13
+enum A() {
+  one,
+  two,
+  three,
+  four,
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+  eleven,
+  twelve,
+}
+
+enum B {
+  one,
+  two,
+  three,
+  four,
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+  eleven,
+  twelve,
+}


### PR DESCRIPTION
Fix two related issues with primary constructors in enums:

- If the user has preserve trailing commas enabled and the enum does not
  have any members, then the formatter would crash.

- An enum with split values should always have a trailing comma after
  the last value. This is true if the enum doesn't have a primary
  constructor, but a bug in the implementation omitted the trailing
  comma when there was a primary constructor.

A difficult question is whether this style change should be language
versioned. I am moving towards a model where practically every single
style change is language versioned because it's painful for users to
have spontaneous style changes.

But I think this fix should get rolled into the SDK and shipped in a
patch release well before 3.14 comes out. So there is no good language
version to pin it too. Also, the current style is just wrong. There's
no reason for an enum with a primary constructor to lack the trailing
comma.

So I lean towards not language versioning this fix, but I am very open
to feedback one way or the other.

Fix #1885.
Fix #1888.