### PR TITLE
Fix version_test to handle being run from within the Dart SDK.

### DIFF
--- a/test/cli/version_test.dart
+++ b/test/cli/version_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:dart_style/src/cli/formatter_options.dart';
+import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
@@ -13,7 +14,20 @@ import 'package:yaml/yaml.dart';
 /// matches the actual version currently in the pubspec.
 void main() {
   test('dartStyleVersion matches pubspec.yaml', () {
-    var pubspec = loadYaml(File('pubspec.yaml').readAsStringSync()) as YamlMap;
+    // Assume we're running this test from the root of the dart_style package.
+    var pubspecPath = 'pubspec.yaml';
+
+    // If it looks like we're running the test through the Dart SDK's test
+    // runner, then the working directory will be the root of the Dart SDK, and
+    // not the root of the dart_style package. In that case, we need to get a
+    // path from the Dart SDK root to dart_style's own package root.
+    var testPath = Platform.script.path;
+    var dartStylePathInSdk = p.join('third_party', 'pkg', 'dart_style');
+    if (testPath.contains(dartStylePathInSdk)) {
+      pubspecPath = p.join(dartStylePathInSdk, pubspecPath);
+    }
+
+    var pubspec = loadYaml(File(pubspecPath).readAsStringSync()) as YamlMap;
     var version = Version.parse(pubspec['version'] as String);
 
     // The version printed by `--version` strips off the `-wip` part.


### PR DESCRIPTION
Normally, when you run a package's tests, the current working directory is the root directory of the package. Without using mirrors, tests don't have a way to locate a file relative to the test file itself. Instead, most just assume the CWD is the package root and find files relative to that.

However, when the Dart SDK's test runner runs tests, the CWD is usually the root of the SDK itself and not the package's root. I put some time into having the test runner set the working directory to the package root when it runs a package's tests, but that breaks a lot of other stuff: Currently in the test runner, the executable and arguments are all relative to the SDK root. I don't think it's a good idea to change all of those.

Instead, in version_test, I just do a little hack to try to detect if it looks like the test is being run by the test runner and tweak the path if so.
