### PR TITLE
Add a benchmark script to measure time spending reading configuration.

### DIFF
--- a/benchmark/config_io.dart
+++ b/benchmark/config_io.dart
@@ -1,0 +1,196 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:dart_style/src/cli/formatter_options.dart';
+import 'package:dart_style/src/cli/output.dart';
+import 'package:dart_style/src/cli/show.dart';
+import 'package:dart_style/src/io.dart';
+import 'package:dart_style/src/profile.dart';
+import 'package:path/path.dart' as p;
+
+/// Use a fixed seed to make the data deterministic.
+final _random = Random(12345);
+
+/// The stack of [_inDirectory()] calls that haven't completed yet.
+final _directoryStack = <Directory>[];
+
+/// Benchmarks the IO performed to read package configurations and
+/// `analysis_options.yaml` files.
+///
+/// Generates a collection of synthetic packages that have package configs and
+/// `analysis_options.yaml` files and then repeatedly formats them.
+///
+/// Does not measure the time to write the resulting formatted output back to
+/// disk.
+void main() async {
+  var allPackages = [
+    for (var adjective in _adjectives)
+      for (var animal in _animals) '${adjective}_$animal',
+  ];
+
+  print('Creating synthetic packages...');
+  var tempDir = await Directory.systemTemp.createTemp('dart_style_benchmark_');
+  _directoryStack.add(tempDir);
+
+  _inDirectory('lints', () {
+    _buildFile('pubspec.yaml', (buffer) {
+      buffer.writeln('name: lints');
+    });
+
+    _inDirectory('lib', () {
+      _buildFile('analysis_options.yaml', (buffer) {
+        buffer.writeln('formatter:');
+        buffer.writeln('  page_width: 100');
+      });
+    });
+  });
+
+  try {
+    for (var package in allPackages) {
+      _inDirectory(package, () {
+        _buildFile('pubspec.yaml', (buffer) {
+          buffer.writeln('name: $package');
+        });
+
+        // Depend on 10-20 other packages so there is some content in the
+        // package config.
+        var otherPackages = allPackages
+            .where((other) => other != package)
+            .toList();
+        otherPackages.shuffle(_random);
+        var dependencies = [
+          'lints',
+          ...otherPackages.take(10 + _random.nextInt(11)),
+        ];
+
+        _buildFile('analysis_options.yaml', (buffer) {
+          // Sometimes include another options file.
+          if (_random.nextBool()) {
+            buffer.writeln('include: package:lints/analysis_options.yaml');
+          }
+          buffer.writeln('formatter:');
+          buffer.writeln('  page_width: ${50 + _random.nextInt(50)}');
+        });
+
+        _inDirectory('.dart_tool', () {
+          _buildFile('package_config.json', (buffer) {
+            var config = {
+              'configVersion': 2,
+              'packages': [
+                {
+                  'name': package,
+                  'rootUri': '../',
+                  'packageUri': 'lib/',
+                  'languageVersion': '3.13',
+                },
+                for (var dependency in dependencies)
+                  {
+                    'name': dependency,
+                    'rootUri': '../../$dependency',
+                    'packageUri': 'lib/',
+                    'languageVersion': '3.13',
+                  },
+              ],
+            };
+
+            buffer.writeln(const JsonEncoder.withIndent('  ').convert(config));
+          });
+        });
+
+        _inDirectory('bin', () {
+          for (var i = 0; i < 20; i++) {
+            _buildFile('main_$i.dart', (buffer) {
+              buffer.writeln('void main() {');
+              buffer.write('  print(');
+              _writeCallTree(buffer);
+              buffer.writeln(');');
+              buffer.writeln('}');
+            });
+          }
+        });
+      });
+    }
+
+    print('Warming up JIT...');
+    var options = FormatterOptions(output: Output.none, show: Show.none);
+    for (var i = 0; i < 20; i++) {
+      await formatPaths(options, [tempDir.path]);
+    }
+
+    Profile.reset();
+
+    print('Running trials...');
+    for (var i = 0; i < 20; i++) {
+      Profile.begin('Benchmark trial');
+      var stopwatch = Stopwatch()..start();
+      await formatPaths(options, [tempDir.path]);
+      print('Run #$i: ${stopwatch.elapsedMilliseconds}ms');
+      Profile.end('Benchmark trial');
+    }
+
+    Profile.report();
+  } finally {
+    await tempDir.delete(recursive: true);
+  }
+}
+
+/// Creates a new directory at [path], relative to the current directory and
+/// invokes [callback] with it as the current directory.
+void _inDirectory(String path, void Function() callback) {
+  var directory = Directory(p.join(_directoryStack.last.path, path));
+  directory.createSync();
+  _directoryStack.add(directory);
+  callback();
+  _directoryStack.removeLast();
+}
+
+/// Writes the StringBuffer populated by [builder] to [path] which is relative
+/// to the surrounding directory from [_inDirectory()].
+void _buildFile(String path, void Function(StringBuffer) builder) {
+  var buffer = StringBuffer();
+  builder(buffer);
+  File(
+    p.join(_directoryStack.last.path, path),
+  ).writeAsStringSync(buffer.toString());
+}
+
+/// Writes a random nested function call to [buffer].
+void _writeCallTree(StringBuffer buffer, [int depth = 0]) {
+  buffer.write(_animals[_random.nextInt(_animals.length)]);
+  if (depth < _random.nextInt(5) + 1) {
+    buffer.write('(');
+    var arguments = _random.nextInt(5);
+    for (var i = 0; i < arguments; i++) {
+      if (i > 0) buffer.write(',');
+      _writeCallTree(buffer, depth + 1);
+    }
+    buffer.write(')');
+  }
+}
+
+const _adjectives = [
+  'cuddly',
+  'fiesty',
+  'grumpy',
+  'happy',
+  'hungry',
+  'lazy',
+  'noisy',
+  'silly',
+  'sleepy',
+  'spunky',
+];
+
+const _animals = [
+  'bat',
+  'cat',
+  'dog',
+  'fox',
+  'goat',
+  'llama',
+  'mouse',
+  'owl',
+  'pig',
+  'wolf',
+];

--- a/lib/src/cli/formatter_options.dart
+++ b/lib/src/cli/formatter_options.dart
@@ -13,7 +13,7 @@ import 'show.dart';
 import 'summary.dart';
 
 // Do not edit directly. Use tool/bump_version.dart.
-const dartStyleVersion = '3.1.13';
+const dartStyleVersion = '3.1.14';
 
 /// Global options parsed from the command line that affect how the formatter
 /// produces and uses its outputs.

--- a/lib/src/config_cache.dart
+++ b/lib/src/config_cache.dart
@@ -55,30 +55,36 @@ final class ConfigCache {
   /// Looks for a package surrounding [file] and, if found, returns the default
   /// language version specified by that package.
   Future<Version?> findLanguageVersion(File file, String displayPath) async {
-    // Use the cached version (which may be `null`) if present.
-    var directory = file.parent.path;
-    if (_directoryVersions.containsKey(directory)) {
-      return _directoryVersions[directory];
+    try {
+      Profile.begin('ConfigCache.findLanguageVersion()');
+
+      // Use the cached version (which may be `null`) if present.
+      var directory = file.parent.path;
+      if (_directoryVersions.containsKey(directory)) {
+        return _directoryVersions[directory];
+      }
+
+      // Otherwise, walk the file system and look for it.
+      var config = await _findPackageConfig(
+        file,
+        displayPath,
+        forLanguageVersion: true,
+      );
+
+      if (config?.packageOf(file.absolute.uri)?.languageVersion
+          case var languageVersion?) {
+        // Store the version as pub_semver's [Version] type because that's
+        // what the analyzer parser uses, which is where the version
+        // ultimately gets used.
+        var version = Version(languageVersion.major, languageVersion.minor, 0);
+        return _directoryVersions[directory] = version;
+      }
+
+      // We weren't able to resolve this file's version, so don't try again.
+      return _directoryVersions[directory] = null;
+    } finally {
+      Profile.end('ConfigCache.findLanguageVersion()');
     }
-
-    // Otherwise, walk the file system and look for it.
-    var config = await _findPackageConfig(
-      file,
-      displayPath,
-      forLanguageVersion: true,
-    );
-
-    if (config?.packageOf(file.absolute.uri)?.languageVersion
-        case var languageVersion?) {
-      // Store the version as pub_semver's [Version] type because that's
-      // what the analyzer parser uses, which is where the version
-      // ultimately gets used.
-      var version = Version(languageVersion.major, languageVersion.minor, 0);
-      return _directoryVersions[directory] = version;
-    }
-
-    // We weren't able to resolve this file's version, so don't try again.
-    return _directoryVersions[directory] = null;
   }
 
   /// Looks for an "analysis_options.yaml" file surrounding [file] and, if
@@ -91,7 +97,12 @@ final class ConfigCache {
   ///     formatter:
   ///       page_width: 123
   Future<int?> findPageWidth(File file) async {
-    return (await _findFormatterOptions(file)).pageWidth;
+    try {
+      Profile.begin('ConfigCache.findPageWidth()');
+      return (await _findFormatterOptions(file)).pageWidth;
+    } finally {
+      Profile.end('ConfigCache.findPageWidth()');
+    }
   }
 
   /// Looks for an "analysis_options.yaml" file surrounding [file] and, if
@@ -105,7 +116,12 @@ final class ConfigCache {
   ///     formatter:
   ///       trailing_commas: preserve # Or "automate".
   Future<TrailingCommas?> findTrailingCommas(File file) async {
-    return (await _findFormatterOptions(file)).trailingCommas;
+    try {
+      Profile.begin('ConfigCache.findTrailingCommas()');
+      return (await _findFormatterOptions(file)).trailingCommas;
+    } finally {
+      Profile.end('ConfigCache.findTrailingCommas()');
+    }
   }
 
   /// Looks for an "analysis_options.yaml" file surrounding [file] and, if
@@ -171,7 +187,6 @@ final class ConfigCache {
     String displayPath, {
     required bool forLanguageVersion,
   }) async {
-    Profile.begin('look up package config');
     try {
       // Use the cached one (which might be `null`) if we have it.
       var directory = file.parent.path;
@@ -181,9 +196,14 @@ final class ConfigCache {
 
       // Otherwise, walk the file system and look for it. If we fail to find it,
       // store `null` so that we don't look again in that same directory.
-      return _directoryConfigs[directory] = await findPackageConfig(
-        file.parent,
-      );
+      Profile.begin('package_config.findPackageConfig()');
+      try {
+        return _directoryConfigs[directory] = await findPackageConfig(
+          file.parent,
+        );
+      } finally {
+        Profile.end('package_config.findPackageConfig()');
+      }
     } catch (error) {
       // We need a language version, so report an error if we can't find one.
       // We don't need a page width because we happily use the default, so say
@@ -199,8 +219,6 @@ final class ConfigCache {
         );
       }
       return null;
-    } finally {
-      Profile.end('look up package config');
     }
   }
 

--- a/lib/src/dart_formatter.dart
+++ b/lib/src/dart_formatter.dart
@@ -4,6 +4,7 @@
 import 'dart:math' as math;
 
 import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
@@ -19,6 +20,7 @@ import 'dart_version_history.dart';
 import 'exceptions.dart';
 import 'front_end/ast_node_visitor.dart';
 import 'front_end/formatting_style.dart';
+import 'profile.dart';
 import 'short/source_visitor.dart';
 import 'source_code.dart';
 import 'string_compare.dart' as string_compare;
@@ -163,12 +165,18 @@ final class DartFormatter {
     );
 
     // Parse it.
-    var parseResult = parseString(
-      content: text,
-      featureSet: featureSet,
-      path: source.uri,
-      throwIfDiagnostics: false,
-    );
+    Profile.begin('parseString()');
+    ParseStringResult parseResult;
+    try {
+      parseResult = parseString(
+        content: text,
+        featureSet: featureSet,
+        path: source.uri,
+        throwIfDiagnostics: false,
+      );
+    } finally {
+      Profile.end('parseString()');
+    }
 
     // Infer the line ending if not given one. Do it here since now we know
     // where the lines start.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_style
 # Do not edit directly. Use tool/bump_version.dart.
-version: 3.1.13
+version: 3.1.14-wip
 description: >-
   Opinionated, automatic Dart source code formatter.
   Provides an API and a CLI tool.


### PR DESCRIPTION
I'm investing moving the formatter to use the analyzer API for inferring the language version of each formatted file and reading the analysis_options.yaml files. Before I do that, I want some kind of benchmark so I can measure performance and detect regressions.

I've done local testing using a small corpus of real packages, but I wanted something repeatable but hopefully somewhat realistic. This script creates a collection of synthetic packages that have package configs and analysis_options.yaml files, then repeatedly formats them.

Also added some more profiler instrumentation for the code that reads config files.
