### PR TITLE
Fix version_test on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.14-wip
+
+No user-visible changes.
+
 ## 3.1.13
 
 ### Bug fixes

--- a/test/cli/version_test.dart
+++ b/test/cli/version_test.dart
@@ -21,7 +21,7 @@ void main() {
     // runner, then the working directory will be the root of the Dart SDK, and
     // not the root of the dart_style package. In that case, we need to get a
     // path from the Dart SDK root to dart_style's own package root.
-    var testPath = Platform.script.path;
+    var testPath = p.fromUri(Platform.script);
     var dartStylePathInSdk = p.join('third_party', 'pkg', 'dart_style');
     if (testPath.contains(dartStylePathInSdk)) {
       pubspecPath = p.join(dartStylePathInSdk, pubspecPath);


### PR DESCRIPTION
This test has some annoying special sauce to work when being run within the Dart SDK test runner which uses a different working directory. That special sauce had a bug on Windows because it accidentally used a URI as a file system path.

This fixes that bug (I hope, I haven't been able to test locally).

Fix https://github.com/dart-lang/sdk/issues/64107.
