### PR TITLE
Optimize writing indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.1.14-wip
 
-No user-visible changes.
+### Performance
+
+* Optimize writing indentation.
 
 ## 3.1.13
 

--- a/lib/src/back_end/code.dart
+++ b/lib/src/back_end/code.dart
@@ -194,38 +194,7 @@ final class _StringBuilder {
   ///
   /// Generating these ahead of time is faster than concatenating multiple
   /// spaces at runtime.
-  static const _indents = {
-    2: '  ',
-    4: '    ',
-    6: '      ',
-    8: '        ',
-    10: '          ',
-    12: '            ',
-    14: '              ',
-    16: '                ',
-    18: '                  ',
-    20: '                    ',
-    22: '                      ',
-    24: '                        ',
-    26: '                          ',
-    28: '                            ',
-    30: '                              ',
-    32: '                                ',
-    34: '                                  ',
-    36: '                                    ',
-    38: '                                      ',
-    40: '                                        ',
-    42: '                                          ',
-    44: '                                            ',
-    46: '                                              ',
-    48: '                                                ',
-    50: '                                                  ',
-    52: '                                                    ',
-    54: '                                                      ',
-    56: '                                                        ',
-    58: '                                                          ',
-    60: '                                                            ',
-  };
+  static final _indents = List.generate(128, (i) => ' ' * i);
 
   final SourceCode _source;
   final String _lineEnding;
@@ -268,7 +237,11 @@ final class _StringBuilder {
         // re-enabled.
         if (_disableFormattingStart == -1) {
           // Write any pending indentation.
-          _buffer.write(_indents[_indent] ?? (' ' * _indent));
+          if (_indent > _indents.length) {
+            _buffer.write(' ' * _indent);
+          } else if (_indent > 0) {
+            _buffer.write(_indents[_indent]);
+          }
           _indent = 0;
 
           _buffer.write(code._text);


### PR DESCRIPTION
This has a slight performance benefit that is just above the noise:

```
Benchmark (tall)                fastest   median  slowest  average  baseline
-----------------------------  --------  -------  -------  -------  --------
block                             0.087    0.103    0.204    0.108    103.9%
chain                             0.713    0.736    0.776    0.737     99.2%
collection                        0.425    0.437    0.476    0.439    100.6%
collection_large                  1.829    1.860    2.151    1.866    101.7%
conditional                       0.087    0.091    0.106    0.092    101.5%
curry                             0.181    0.185    0.211    0.187    102.6%
curry_2                           0.364    0.370    0.409    0.375    101.4%
ffi                               0.164    0.167    0.187    0.170    101.0%
flutter_popup_menu_test           0.587    0.605    0.633    0.607    101.2%
flutter_scrollbar_test            2.073    2.087    2.145    2.091    100.1%
function_call                     1.832    1.873    1.950    1.872    102.2%
infix_large                       0.750    0.777    0.829    0.779    101.4%
infix_small                       0.190    0.195    0.233    0.198    101.4%
interpolation                     0.151    0.154    0.175    0.156    102.3%
interpolation_1516                0.133    0.134    0.159    0.137    102.7%
large                             4.508    4.578    4.748    4.573    101.2%
top_level                         0.166    0.173    0.195    0.174    101.3%
```

I might skip it because it's kind of marginal, but the resulting code is actually cleaner too, so there's no reason not to.
