### PR TITLE
Optimize code writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.1.14-wip
 
-No user-visible changes.
+### Performance
+
+* Optimize code writing.
 
 ## 3.1.13
 

--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -162,7 +162,7 @@ final class CodeWriter {
 
     // If we haven't found an overflowing line yet, then this line might be one
     // so keep track of the unsolved pieces we've encountered on it.
-    if (!_foundExpandLine) {
+    if (!_foundExpandLine && _currentUnsolvedPieces.isNotEmpty) {
       _currentLinePieces.addAll(_currentUnsolvedPieces);
     }
   }
@@ -374,7 +374,7 @@ final class CodeWriter {
   /// Format [piece] writing directly into this [CodeWriter].
   void _formatInline(Piece piece) {
     var isUnsolved =
-        !_solution.isBound(piece) && piece.additionalStates.isNotEmpty;
+        piece.additionalStates.isNotEmpty && !_solution.isBound(piece);
 
     // See if we can immediately bind it based on the page width and the piece's
     // contents.

--- a/lib/src/back_end/code_writer.dart
+++ b/lib/src/back_end/code_writer.dart
@@ -162,6 +162,8 @@ final class CodeWriter {
 
     // If we haven't found an overflowing line yet, then this line might be one
     // so keep track of the unsolved pieces we've encountered on it.
+    // Note: The `isNotEmpty` check is redundant since `addAll()` will do
+    // nothing in that case, but checking it is measurably faster.
     if (!_foundExpandLine && _currentUnsolvedPieces.isNotEmpty) {
       _currentLinePieces.addAll(_currentUnsolvedPieces);
     }


### PR DESCRIPTION
Simply swapping the order of some `&&` operands to put the faster operation first and avoiding a pointless `addAll()` call saves a few percent overall:

```
Benchmark (tall)                fastest   median  slowest  average  baseline
-----------------------------  --------  -------  -------  -------  --------
block                             0.088    0.104    0.182    0.113    102.3%
chain                             0.708    0.733    0.770    0.735     99.9%
collection                        0.419    0.436    0.481    0.438    102.1%
collection_large                  1.816    1.863    2.258    1.885    102.4%
conditional                       0.088    0.092    0.112    0.094    100.6%
curry                             0.182    0.188    0.215    0.191    102.0%
curry_2                           0.360    0.367    0.402    0.371    102.7%
ffi                               0.162    0.166    0.189    0.168    102.1%
flutter_popup_menu_test           0.580    0.599    0.627    0.599    102.4%
flutter_scrollbar_test            2.025    2.061    2.166    2.064    102.5%
function_call                     1.836    1.880    1.995    1.880    101.9%
infix_large                       0.750    0.773    0.819    0.774    101.5%
infix_small                       0.189    0.196    0.215    0.197    101.8%
interpolation                     0.148    0.150    0.172    0.152    104.9%
interpolation_1516                0.130    0.132    0.152    0.134    104.8%
large                             4.530    4.629    5.122    4.622    100.7%
top_level                         0.165    0.169    0.193    0.172    102.1%
```
