### PR TITLE
Store the result of version tests instead of comparing each time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.1.14-wip
 
-No user-visible changes.
+### Performance
+
+* Optimize version checks.
 
 ## 3.1.13
 

--- a/lib/src/front_end/formatting_style.dart
+++ b/lib/src/front_end/formatting_style.dart
@@ -22,25 +22,48 @@ final class FormattingStyle {
   /// The [DartFormatter] the style was created from.
   final DartFormatter _formatter;
 
-  /// The language version of the style.
-  ///
-  /// Usually the same version as [formatter], but may be different if the file
-  /// being formatted has an `@dart=` comment.
-  final Version _languageVersion;
-
   /// The number of characters allowed in a single line.
   ///
   /// Usually the same as [formatter]'s but may be different if the file being
   /// formatted has a `// dart format width = ` comment.
   final int pageWidth;
 
-  FormattingStyle(
-    this._formatter, {
-    required this.lineEnding,
+  /// Whether the language version is at least 3.10.
+  ///
+  /// We cache this instead of storing the version directly for performance.
+  final bool _isVersion3Dot10OrHigher;
+
+  /// Whether the language version is at least 3.13.
+  ///
+  /// We cache this instead of storing the version directly for performance.
+  final bool _isVersion3Dot13OrHigher;
+
+  factory FormattingStyle(
+    DartFormatter formatter, {
+    required String lineEnding,
     Version? languageVersion,
     int? pageWidth,
-  }) : _languageVersion = languageVersion ?? _formatter.languageVersion,
-       pageWidth = pageWidth ?? _formatter.pageWidth;
+  }) {
+    languageVersion ??= formatter.languageVersion;
+    return FormattingStyle._(
+      formatter,
+      pageWidth: pageWidth ?? formatter.pageWidth,
+      lineEnding: lineEnding,
+      is3Dot7: languageVersion == _version3Dot7,
+      isVersion3Dot10OrHigher: languageVersion >= _version3Dot10,
+      isVersion3Dot13OrHigher: languageVersion >= _version3Dot13,
+    );
+  }
+
+  FormattingStyle._(
+    this._formatter, {
+    required this.pageWidth,
+    required this.lineEnding,
+    required this.is3Dot7,
+    required bool isVersion3Dot10OrHigher,
+    required bool isVersion3Dot13OrHigher,
+  }) : _isVersion3Dot10OrHigher = isVersion3Dot10OrHigher,
+       _isVersion3Dot13OrHigher = isVersion3Dot13OrHigher;
 
   final String? lineEnding;
 
@@ -49,7 +72,7 @@ final class FormattingStyle {
 
   /// Whether the code being formatted is at language version 3.7 and doesn't
   /// include the sweeping style changes in 3.8.
-  bool get is3Dot7 => _languageVersion == _version3Dot7;
+  final bool is3Dot7;
 
   /// Whether a trailing comma should be preserved after for-loop updaters.
   bool get preserveTrailingCommaAfterForUpdaters =>
@@ -57,33 +80,32 @@ final class FormattingStyle {
 
   /// Whether a trailing comma should be preserved after enum values.
   bool get preserveTrailingCommaAfterEnumValues =>
-      _formatter.trailingCommas == TrailingCommas.preserve &&
-      _languageVersion >= _version3Dot10;
+      _isVersion3Dot10OrHigher &&
+      _formatter.trailingCommas == TrailingCommas.preserve;
 
   /// Whether the formatter should penalize splitting in the target of a call
   /// chain if the target is an argument list with only one argument or a
   /// collection literal with only one element.
   bool get avoidSplittingSingleElementCallChainTargets =>
-      _languageVersion >= _version3Dot13;
+      _isVersion3Dot13OrHigher;
 
   /// Whether mixin declarations and extension types with brace bodies should
   /// always get a blank line above and below them.
   ///
   /// They always should have, but they were overlooked. We already do this for
   /// classes, enums, and extensions.
-  bool get blankLineAroundMixinAndExtensionTypes =>
-      _languageVersion >= _version3Dot13;
+  bool get blankLineAroundMixinAndExtensionTypes => _isVersion3Dot13OrHigher;
 
   /// Whether parameter lists should be block formatted in things like typedefs.
-  bool get blockFormatParameterLists => _languageVersion >= _version3Dot13;
+  bool get blockFormatParameterLists => _isVersion3Dot13OrHigher;
 
   /// Whether the LHS of an `as`, `is`, or `is!` expression can be block
   /// formatted.
-  bool get blockFormatTypeTest => _languageVersion >= _version3Dot13;
+  bool get blockFormatTypeTest => _isVersion3Dot13OrHigher;
 
   /// Whether an if-case pattern can be block-formatted when there is a guard
   /// clause as well.
-  bool get blockFormatIfCaseWithGuard => _languageVersion < _version3Dot13;
+  bool get blockFormatIfCaseWithGuard => !_isVersion3Dot13OrHigher;
 
   /// Whether the formatter should prefer overflow from "soft" characters versus
   /// others when no solution fits the page width and an overflowing solution
@@ -122,11 +144,11 @@ final class FormattingStyle {
   /// common cases.
   ///
   /// This feature has no effect on code that does fit in the page width.
-  bool get useSoftOverflow => _languageVersion >= _version3Dot13;
+  bool get useSoftOverflow => _isVersion3Dot13OrHigher;
 
   /// Whether to force a blank line between imports and exports whose URIs are
   /// different categories: `dart:`, `package:`, or relative.
-  bool get separateDirectiveSections => _languageVersion >= _version3Dot13;
+  bool get separateDirectiveSections => _isVersion3Dot13OrHigher;
 
   /// Whether to try to figure out a piece's state based on the page width
   /// before running the solver or during.
@@ -137,8 +159,7 @@ final class FormattingStyle {
   ///
   /// We language version this even though the old logic was never correct to
   /// minimize unexpected churn.
-  bool get pinStateByPageWidthBeforeSolving =>
-      _languageVersion >= _version3Dot13;
+  bool get pinStateByPageWidthBeforeSolving => _isVersion3Dot13OrHigher;
 
   /// Whether an extension type's representation clause allows a trailing
   /// comma.
@@ -146,8 +167,7 @@ final class FormattingStyle {
   /// When primary constructors were added in Dart 3.13, the grammar was
   /// adjusted to define extension types in terms of them which also means that
   /// a trailing comma is now permitted.
-  bool get allowTrailingCommaInRepresentationClause =>
-      _languageVersion >= _version3Dot13;
+  bool get allowTrailingCommaInRepresentationClause => _isVersion3Dot13OrHigher;
 
   /// Whether there is a trailing comma at the end of the list delimited by
   /// [rightBracket] which should be preserved by this style.


### PR DESCRIPTION
Because style is language versioned, the formatter very often checks to see if the language version is above some threshold where a style change was shipped.

Prior to this PR, we did that by invoking the comparison operator on the Version object each time. It turns out those tests are often enough that doing the check each time is slow. Instead, this calculates the predicates we need ahead of time and stores those directly.

```
Benchmark (tall)                fastest   median  slowest  average  baseline
-----------------------------  --------  -------  -------  -------  --------
block                             0.083    0.099    0.182    0.107    108.4%
chain                             0.703    0.727    0.755    0.726    100.6%
collection                        0.413    0.422    0.454    0.425    103.5%
collection_large                  1.778    1.813    2.045    1.819    104.6%
conditional                       0.084    0.085    0.102    0.087    105.6%
curry                             0.175    0.176    0.207    0.180    106.6%
curry_2                           0.348    0.354    0.393    0.359    106.0%
ffi                               0.161    0.163    0.183    0.166    103.1%
flutter_popup_menu_test           0.567    0.586    0.607    0.585    104.7%
flutter_scrollbar_test            2.003    2.026    2.075    2.030    103.5%
function_call                     1.793    1.837    1.952    1.837    104.4%
infix_large                       0.739    0.757    0.787    0.760    103.0%
infix_small                       0.186    0.191    0.234    0.194    103.5%
interpolation                     0.145    0.149    0.174    0.151    107.0%
interpolation_1516                0.128    0.131    0.151    0.133    106.7%
large                             4.366    4.433    4.687    4.425    104.5%
top_level                         0.161    0.164    0.193    0.166    104.9%
```
