### PR TITLE
Optimize writing multi-line text in TextPiece.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.1.14-wip
 
-No user-visible changes.
+### Performance
+
+* Optimize writing multi-line text.
 
 ## 3.1.13
 

--- a/lib/src/piece/text.dart
+++ b/lib/src/piece/text.dart
@@ -59,12 +59,25 @@ sealed class TextPiece extends Piece {
       _selectionEnd = _adjustSelection(selectionEnd);
     }
 
+    // Note: This code is performance sensitive. When editing, use the
+    // benchmarks to avoid regressing performance.
+
     if (multiline) {
       var lines = text.split(_lineTerminatorPattern);
-      for (var i = 0; i < lines.length; i++) {
-        if (i > 0) _lines.add('');
-        _lines.last += lines[i];
+
+      // Append the first line to the end of the previous line, if any.
+      if (_lines.last.isEmpty) {
+        _lines.last = lines[0];
+      } else {
+        _lines.last += lines[0];
       }
+
+      // Add the remaining lines.
+      for (var i = 1; i < lines.length; i++) {
+        _lines.add(lines[i]);
+      }
+    } else if (_lines.last.isEmpty) {
+      _lines.last = text;
     } else {
       _lines.last += text;
     }


### PR DESCRIPTION
When a TextPiece is first created, its `_lines` field contains a single empty string. When the first token is written, that token's lexeme is concatenated to that empty string.

Since most TextPieces only ever contain a single token, that's a lot of pointless string concatenation. Instead, check to see if the line being written to is empty first. If so, just replace it with the new token directly.

```
Benchmark (tall)                fastest   median  slowest  average  baseline
-----------------------------  --------  -------  -------  -------  --------
block                             0.081    0.105    0.173    0.108    111.3%
chain                             0.706    0.726    0.766    0.728    100.1%
collection                        0.415    0.428    0.451    0.429    102.9%
collection_large                  1.790    1.823    2.060    1.827    103.9%
conditional                       0.083    0.085    0.108    0.087    106.1%
curry                             0.179    0.183    0.213    0.186    104.0%
curry_2                           0.358    0.365    0.398    0.370    103.1%
ffi                               0.161    0.165    0.199    0.168    103.1%
flutter_popup_menu_test           0.581    0.600    0.645    0.603    102.2%
flutter_scrollbar_test            2.060    2.081    2.133    2.084    100.7%
function_call                     1.764    1.820    1.925    1.823    106.2%
infix_large                       0.724    0.750    0.809    0.754    105.2%
infix_small                       0.182    0.184    0.207    0.187    105.9%
interpolation                     0.143    0.147    0.170    0.149    108.3%
interpolation_1516                0.126    0.129    0.146    0.131    107.8%
large                             4.386    4.483    4.598    4.466    104.0%
top_level                         0.158    0.163    0.190    0.165    106.6%
```
